### PR TITLE
feat: paginated agent history (tail + getMessages)

### DIFF
--- a/packages/client/dist/index.d.ts
+++ b/packages/client/dist/index.d.ts
@@ -1145,24 +1145,66 @@ declare class AgentApi {
      * @param opts - Subscription options.
      * @param opts.since - Start from this event cursor. `0` = from the beginning.
      * @param opts.includeHistory - If `true`, replay DB-persisted history as events.
-     * @returns The current cursor position.
+     * @param opts.tail - If set to N, replay only the last N persisted messages
+     *   before live-streaming. Lets clients open a session without paying for
+     *   full history; pair with {@link getMessages} to load older messages on
+     *   demand. Mutually exclusive with `since` / `includeHistory`.
+     * @returns Current cursor, plus `oldestCursor` and `hasMore` (when `tail`
+     *   was used) so callers can drive reverse pagination via {@link getMessages}.
      *
      * @example
      * ```ts
-     * // Subscribe to all events from the beginning
+     * // Subscribe with only the last 20 messages, then load older on scroll-up
      * sna.agent.onEvent(({ event }) => console.log(event));
-     * const { cursor } = await sna.agent.subscribe("default", {
-     *   since: 0,
-     *   includeHistory: true,
-     * });
-     * console.log(`Subscribed, cursor at ${cursor}`);
+     * const { cursor, oldestCursor, hasMore } = await sna.agent.subscribe("default", { tail: 20 });
+     * if (hasMore && oldestCursor !== undefined) {
+     *   const older = await sna.agent.getMessages("default", { before: oldestCursor, limit: 20 });
+     * }
      * ```
      */
     subscribe(session: string, opts?: {
         since?: number;
         includeHistory?: boolean;
+        tail?: number;
     }): Promise<{
         cursor: number;
+        oldestCursor?: number;
+        hasMore: boolean;
+    }>;
+    /**
+     * Fetch a paginated batch of older persisted messages for a session, in
+     * ascending cursor order. Stateless — does not affect the live subscription.
+     *
+     * Cursors returned here share the same numbering as {@link subscribe}, so
+     * deduplication against live events works without translation.
+     *
+     * @param session - Target session ID.
+     * @param opts - Pagination options.
+     * @param opts.before - Smallest cursor the client currently holds. Returns
+     *   the `limit` events immediately preceding it. Omit to fetch the tail.
+     * @param opts.limit - Max events to return (default 50, capped at 200).
+     * @returns Events with their cursors, plus `oldestCursor` and `hasMore`.
+     *
+     * @example
+     * ```ts
+     * // Load older messages when user scrolls to the top
+     * const { events, oldestCursor, hasMore } = await sna.agent.getMessages("default", {
+     *   before: currentOldestCursor,
+     *   limit: 20,
+     * });
+     * for (const { cursor, event } of events) prependToUi(cursor, event);
+     * ```
+     */
+    getMessages(session: string, opts?: {
+        before?: number;
+        limit?: number;
+    }): Promise<{
+        events: Array<{
+            cursor: number;
+            event: Record<string, unknown>;
+        }>;
+        oldestCursor?: number;
+        hasMore: boolean;
     }>;
     /**
      * Unsubscribe from agent events for a session.

--- a/packages/client/dist/index.js
+++ b/packages/client/dist/index.js
@@ -820,22 +820,53 @@ var AgentApi = class {
    * @param opts - Subscription options.
    * @param opts.since - Start from this event cursor. `0` = from the beginning.
    * @param opts.includeHistory - If `true`, replay DB-persisted history as events.
-   * @returns The current cursor position.
+   * @param opts.tail - If set to N, replay only the last N persisted messages
+   *   before live-streaming. Lets clients open a session without paying for
+   *   full history; pair with {@link getMessages} to load older messages on
+   *   demand. Mutually exclusive with `since` / `includeHistory`.
+   * @returns Current cursor, plus `oldestCursor` and `hasMore` (when `tail`
+   *   was used) so callers can drive reverse pagination via {@link getMessages}.
    *
    * @example
    * ```ts
-   * // Subscribe to all events from the beginning
+   * // Subscribe with only the last 20 messages, then load older on scroll-up
    * sna.agent.onEvent(({ event }) => console.log(event));
-   * const { cursor } = await sna.agent.subscribe("default", {
-   *   since: 0,
-   *   includeHistory: true,
-   * });
-   * console.log(`Subscribed, cursor at ${cursor}`);
+   * const { cursor, oldestCursor, hasMore } = await sna.agent.subscribe("default", { tail: 20 });
+   * if (hasMore && oldestCursor !== undefined) {
+   *   const older = await sna.agent.getMessages("default", { before: oldestCursor, limit: 20 });
+   * }
    * ```
    */
   async subscribe(session, opts) {
     this.subscribedSessions.add(session);
     return this.client.request("agent.subscribe", { session, ...opts });
+  }
+  /**
+   * Fetch a paginated batch of older persisted messages for a session, in
+   * ascending cursor order. Stateless — does not affect the live subscription.
+   *
+   * Cursors returned here share the same numbering as {@link subscribe}, so
+   * deduplication against live events works without translation.
+   *
+   * @param session - Target session ID.
+   * @param opts - Pagination options.
+   * @param opts.before - Smallest cursor the client currently holds. Returns
+   *   the `limit` events immediately preceding it. Omit to fetch the tail.
+   * @param opts.limit - Max events to return (default 50, capped at 200).
+   * @returns Events with their cursors, plus `oldestCursor` and `hasMore`.
+   *
+   * @example
+   * ```ts
+   * // Load older messages when user scrolls to the top
+   * const { events, oldestCursor, hasMore } = await sna.agent.getMessages("default", {
+   *   before: currentOldestCursor,
+   *   limit: 20,
+   * });
+   * for (const { cursor, event } of events) prependToUi(cursor, event);
+   * ```
+   */
+  async getMessages(session, opts) {
+    return this.client.request("agent.getMessages", { session, ...opts });
   }
   /**
    * Unsubscribe from agent events for a session.

--- a/packages/client/src/sna-client.ts
+++ b/packages/client/src/sna-client.ts
@@ -1460,22 +1460,64 @@ class AgentApi {
    * @param opts - Subscription options.
    * @param opts.since - Start from this event cursor. `0` = from the beginning.
    * @param opts.includeHistory - If `true`, replay DB-persisted history as events.
-   * @returns The current cursor position.
+   * @param opts.tail - If set to N, replay only the last N persisted messages
+   *   before live-streaming. Lets clients open a session without paying for
+   *   full history; pair with {@link getMessages} to load older messages on
+   *   demand. Mutually exclusive with `since` / `includeHistory`.
+   * @returns Current cursor, plus `oldestCursor` and `hasMore` (when `tail`
+   *   was used) so callers can drive reverse pagination via {@link getMessages}.
    *
    * @example
    * ```ts
-   * // Subscribe to all events from the beginning
+   * // Subscribe with only the last 20 messages, then load older on scroll-up
    * sna.agent.onEvent(({ event }) => console.log(event));
-   * const { cursor } = await sna.agent.subscribe("default", {
-   *   since: 0,
-   *   includeHistory: true,
-   * });
-   * console.log(`Subscribed, cursor at ${cursor}`);
+   * const { cursor, oldestCursor, hasMore } = await sna.agent.subscribe("default", { tail: 20 });
+   * if (hasMore && oldestCursor !== undefined) {
+   *   const older = await sna.agent.getMessages("default", { before: oldestCursor, limit: 20 });
+   * }
    * ```
    */
-  async subscribe(session: string, opts?: { since?: number; includeHistory?: boolean }): Promise<{ cursor: number }> {
+  async subscribe(
+    session: string,
+    opts?: { since?: number; includeHistory?: boolean; tail?: number },
+  ): Promise<{ cursor: number; oldestCursor?: number; hasMore: boolean }> {
     this.subscribedSessions.add(session);
     return this.client.request("agent.subscribe", { session, ...opts });
+  }
+
+  /**
+   * Fetch a paginated batch of older persisted messages for a session, in
+   * ascending cursor order. Stateless — does not affect the live subscription.
+   *
+   * Cursors returned here share the same numbering as {@link subscribe}, so
+   * deduplication against live events works without translation.
+   *
+   * @param session - Target session ID.
+   * @param opts - Pagination options.
+   * @param opts.before - Smallest cursor the client currently holds. Returns
+   *   the `limit` events immediately preceding it. Omit to fetch the tail.
+   * @param opts.limit - Max events to return (default 50, capped at 200).
+   * @returns Events with their cursors, plus `oldestCursor` and `hasMore`.
+   *
+   * @example
+   * ```ts
+   * // Load older messages when user scrolls to the top
+   * const { events, oldestCursor, hasMore } = await sna.agent.getMessages("default", {
+   *   before: currentOldestCursor,
+   *   limit: 20,
+   * });
+   * for (const { cursor, event } of events) prependToUi(cursor, event);
+   * ```
+   */
+  async getMessages(
+    session: string,
+    opts?: { before?: number; limit?: number },
+  ): Promise<{
+    events: Array<{ cursor: number; event: Record<string, unknown> }>;
+    oldestCursor?: number;
+    hasMore: boolean;
+  }> {
+    return this.client.request("agent.getMessages", { session, ...opts });
   }
 
   /**

--- a/packages/core/dist/electron/index.cjs
+++ b/packages/core/dist/electron/index.cjs
@@ -4454,6 +4454,8 @@ function handleMessage(ws, msg, sm2, state) {
       return handleAgentSubscribe(ws, msg, sm2, state);
     case "agent.unsubscribe":
       return handleAgentUnsubscribe(ws, msg, state);
+    case "agent.getMessages":
+      return handleAgentGetMessages(ws, msg);
     // ── Skill events ──────────────────────────────────
     // ── Permission ────────────────────────────────────
     case "permission.respond":
@@ -4806,13 +4808,68 @@ async function handleAgentCompletion(ws, msg) {
     replyError(ws, msg, e.message);
   }
 }
+function mapChatRowToEvent(row) {
+  const eventType = row.actor === "user" ? "user_message" : row.actor === "assistant" && row.kind === "text" ? "assistant" : row.actor === "assistant" && row.kind === "thinking" ? "thinking" : row.actor === "assistant" && row.kind === "tool_use" ? "tool_use" : row.actor === "system" && row.kind === "tool_result" ? "tool_result" : row.actor === "system" && row.kind === "error" ? "error" : null;
+  if (!eventType) return null;
+  const meta = row.meta ? JSON.parse(row.meta) : void 0;
+  return {
+    type: eventType,
+    message: row.content,
+    data: meta,
+    timestamp: new Date(row.created_at).getTime()
+  };
+}
+function countChatMessages(sessionId) {
+  const db = getDb();
+  const row = db.prepare(
+    `SELECT COUNT(*) as c FROM chat_messages WHERE session_id = ?`
+  ).get(sessionId);
+  return row?.c ?? 0;
+}
 function handleAgentSubscribe(ws, msg, sm2, state) {
   const sessionId = msg.session ?? "default";
   const session = sm2.getOrCreateSession(sessionId);
   state.agentUnsubs.get(sessionId)?.();
-  const includeHistory = msg.since === 0 || msg.includeHistory === true;
+  const tail = typeof msg.tail === "number" && msg.tail > 0 ? Math.floor(msg.tail) : null;
+  const includeHistory = tail === null && (msg.since === 0 || msg.includeHistory === true);
   let cursor = 0;
-  if (includeHistory) {
+  let oldestCursor;
+  let hasMore = false;
+  if (tail !== null) {
+    try {
+      const db = getDb();
+      const total = countChatMessages(sessionId);
+      const offset = Math.max(0, total - tail);
+      hasMore = offset > 0;
+      const rows = db.prepare(
+        `SELECT actor, kind, content, meta, created_at FROM chat_messages
+         WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?`
+      ).all(sessionId, tail, offset);
+      cursor = offset;
+      if (rows.length > 0) oldestCursor = offset + 1;
+      for (const row of rows) {
+        cursor++;
+        const event = mapChatRowToEvent(row);
+        if (!event) continue;
+        send(ws, {
+          type: "agent.event",
+          session: sessionId,
+          cursor,
+          isHistory: true,
+          event
+        });
+      }
+    } catch {
+    }
+    if (cursor < session.eventCounter) {
+      const unpersisted = session.eventCounter - cursor;
+      const bufferSlice = session.eventBuffer.slice(-unpersisted);
+      for (const event of bufferSlice) {
+        cursor++;
+        send(ws, { type: "agent.event", session: sessionId, cursor, event });
+      }
+    }
+  } else if (includeHistory) {
     try {
       const db = getDb();
       const rows = db.prepare(
@@ -4821,20 +4878,14 @@ function handleAgentSubscribe(ws, msg, sm2, state) {
       ).all(sessionId);
       for (const row of rows) {
         cursor++;
-        const eventType = row.actor === "user" ? "user_message" : row.actor === "assistant" && row.kind === "text" ? "assistant" : row.actor === "assistant" && row.kind === "thinking" ? "thinking" : row.actor === "assistant" && row.kind === "tool_use" ? "tool_use" : row.actor === "system" && row.kind === "tool_result" ? "tool_result" : row.actor === "system" && row.kind === "error" ? "error" : null;
-        if (!eventType) continue;
-        const meta = row.meta ? JSON.parse(row.meta) : void 0;
+        const event = mapChatRowToEvent(row);
+        if (!event) continue;
         send(ws, {
           type: "agent.event",
           session: sessionId,
           cursor,
           isHistory: true,
-          event: {
-            type: eventType,
-            message: row.content,
-            data: meta,
-            timestamp: new Date(row.created_at).getTime()
-          }
+          event
         });
       }
     } catch {
@@ -4868,7 +4919,57 @@ function handleAgentSubscribe(ws, msg, sm2, state) {
     }
   });
   state.agentUnsubs.set(sessionId, unsub);
-  reply(ws, msg, { cursor });
+  reply(ws, msg, {
+    cursor,
+    hasMore,
+    ...oldestCursor !== void 0 ? { oldestCursor } : {}
+  });
+}
+function handleAgentGetMessages(ws, msg) {
+  const sessionId = msg.session;
+  if (!sessionId) return replyError(ws, msg, "session is required");
+  const before = typeof msg.before === "number" && msg.before > 0 ? Math.floor(msg.before) : null;
+  const requestedLimit = typeof msg.limit === "number" && msg.limit > 0 ? Math.floor(msg.limit) : 50;
+  const limit = Math.min(requestedLimit, 200);
+  try {
+    const db = getDb();
+    const total = countChatMessages(sessionId);
+    let offset;
+    let take;
+    if (before === null) {
+      offset = Math.max(0, total - limit);
+      take = Math.min(limit, total);
+    } else {
+      const upperOrdinalExclusive = before;
+      const available = upperOrdinalExclusive - 1;
+      take = Math.max(0, Math.min(limit, available));
+      offset = available - take;
+    }
+    if (take <= 0) {
+      return reply(ws, msg, { events: [], hasMore: false });
+    }
+    const rows = db.prepare(
+      `SELECT actor, kind, content, meta, created_at FROM chat_messages
+       WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?`
+    ).all(sessionId, take, offset);
+    const events = [];
+    for (let i = 0; i < rows.length; i++) {
+      const cursor = offset + i + 1;
+      const event = mapChatRowToEvent(rows[i]);
+      if (!event) continue;
+      events.push({ cursor, event });
+    }
+    const hasMore = offset > 0;
+    const oldestCursor = rows.length > 0 ? offset + 1 : void 0;
+    reply(ws, msg, {
+      events,
+      hasMore,
+      ...oldestCursor !== void 0 ? { oldestCursor } : {}
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "DB error";
+    replyError(ws, msg, message);
+  }
 }
 function handleAgentUnsubscribe(ws, msg, state) {
   const sessionId = msg.session ?? "default";

--- a/packages/core/dist/server/standalone.js
+++ b/packages/core/dist/server/standalone.js
@@ -3872,6 +3872,8 @@ function handleMessage(ws, msg, sm, state) {
       return handleAgentSubscribe(ws, msg, sm, state);
     case "agent.unsubscribe":
       return handleAgentUnsubscribe(ws, msg, state);
+    case "agent.getMessages":
+      return handleAgentGetMessages(ws, msg);
     // ── Skill events ──────────────────────────────────
     // ── Permission ────────────────────────────────────
     case "permission.respond":
@@ -4224,13 +4226,68 @@ async function handleAgentCompletion(ws, msg) {
     replyError(ws, msg, e.message);
   }
 }
+function mapChatRowToEvent(row) {
+  const eventType = row.actor === "user" ? "user_message" : row.actor === "assistant" && row.kind === "text" ? "assistant" : row.actor === "assistant" && row.kind === "thinking" ? "thinking" : row.actor === "assistant" && row.kind === "tool_use" ? "tool_use" : row.actor === "system" && row.kind === "tool_result" ? "tool_result" : row.actor === "system" && row.kind === "error" ? "error" : null;
+  if (!eventType) return null;
+  const meta = row.meta ? JSON.parse(row.meta) : void 0;
+  return {
+    type: eventType,
+    message: row.content,
+    data: meta,
+    timestamp: new Date(row.created_at).getTime()
+  };
+}
+function countChatMessages(sessionId) {
+  const db = getDb();
+  const row = db.prepare(
+    `SELECT COUNT(*) as c FROM chat_messages WHERE session_id = ?`
+  ).get(sessionId);
+  return row?.c ?? 0;
+}
 function handleAgentSubscribe(ws, msg, sm, state) {
   const sessionId = msg.session ?? "default";
   const session = sm.getOrCreateSession(sessionId);
   state.agentUnsubs.get(sessionId)?.();
-  const includeHistory = msg.since === 0 || msg.includeHistory === true;
+  const tail = typeof msg.tail === "number" && msg.tail > 0 ? Math.floor(msg.tail) : null;
+  const includeHistory = tail === null && (msg.since === 0 || msg.includeHistory === true);
   let cursor = 0;
-  if (includeHistory) {
+  let oldestCursor;
+  let hasMore = false;
+  if (tail !== null) {
+    try {
+      const db = getDb();
+      const total = countChatMessages(sessionId);
+      const offset = Math.max(0, total - tail);
+      hasMore = offset > 0;
+      const rows = db.prepare(
+        `SELECT actor, kind, content, meta, created_at FROM chat_messages
+         WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?`
+      ).all(sessionId, tail, offset);
+      cursor = offset;
+      if (rows.length > 0) oldestCursor = offset + 1;
+      for (const row of rows) {
+        cursor++;
+        const event = mapChatRowToEvent(row);
+        if (!event) continue;
+        send(ws, {
+          type: "agent.event",
+          session: sessionId,
+          cursor,
+          isHistory: true,
+          event
+        });
+      }
+    } catch {
+    }
+    if (cursor < session.eventCounter) {
+      const unpersisted = session.eventCounter - cursor;
+      const bufferSlice = session.eventBuffer.slice(-unpersisted);
+      for (const event of bufferSlice) {
+        cursor++;
+        send(ws, { type: "agent.event", session: sessionId, cursor, event });
+      }
+    }
+  } else if (includeHistory) {
     try {
       const db = getDb();
       const rows = db.prepare(
@@ -4239,20 +4296,14 @@ function handleAgentSubscribe(ws, msg, sm, state) {
       ).all(sessionId);
       for (const row of rows) {
         cursor++;
-        const eventType = row.actor === "user" ? "user_message" : row.actor === "assistant" && row.kind === "text" ? "assistant" : row.actor === "assistant" && row.kind === "thinking" ? "thinking" : row.actor === "assistant" && row.kind === "tool_use" ? "tool_use" : row.actor === "system" && row.kind === "tool_result" ? "tool_result" : row.actor === "system" && row.kind === "error" ? "error" : null;
-        if (!eventType) continue;
-        const meta = row.meta ? JSON.parse(row.meta) : void 0;
+        const event = mapChatRowToEvent(row);
+        if (!event) continue;
         send(ws, {
           type: "agent.event",
           session: sessionId,
           cursor,
           isHistory: true,
-          event: {
-            type: eventType,
-            message: row.content,
-            data: meta,
-            timestamp: new Date(row.created_at).getTime()
-          }
+          event
         });
       }
     } catch {
@@ -4286,7 +4337,57 @@ function handleAgentSubscribe(ws, msg, sm, state) {
     }
   });
   state.agentUnsubs.set(sessionId, unsub);
-  reply(ws, msg, { cursor });
+  reply(ws, msg, {
+    cursor,
+    hasMore,
+    ...oldestCursor !== void 0 ? { oldestCursor } : {}
+  });
+}
+function handleAgentGetMessages(ws, msg) {
+  const sessionId = msg.session;
+  if (!sessionId) return replyError(ws, msg, "session is required");
+  const before = typeof msg.before === "number" && msg.before > 0 ? Math.floor(msg.before) : null;
+  const requestedLimit = typeof msg.limit === "number" && msg.limit > 0 ? Math.floor(msg.limit) : 50;
+  const limit = Math.min(requestedLimit, 200);
+  try {
+    const db = getDb();
+    const total = countChatMessages(sessionId);
+    let offset;
+    let take;
+    if (before === null) {
+      offset = Math.max(0, total - limit);
+      take = Math.min(limit, total);
+    } else {
+      const upperOrdinalExclusive = before;
+      const available = upperOrdinalExclusive - 1;
+      take = Math.max(0, Math.min(limit, available));
+      offset = available - take;
+    }
+    if (take <= 0) {
+      return reply(ws, msg, { events: [], hasMore: false });
+    }
+    const rows = db.prepare(
+      `SELECT actor, kind, content, meta, created_at FROM chat_messages
+       WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?`
+    ).all(sessionId, take, offset);
+    const events = [];
+    for (let i = 0; i < rows.length; i++) {
+      const cursor = offset + i + 1;
+      const event = mapChatRowToEvent(rows[i]);
+      if (!event) continue;
+      events.push({ cursor, event });
+    }
+    const hasMore = offset > 0;
+    const oldestCursor = rows.length > 0 ? offset + 1 : void 0;
+    reply(ws, msg, {
+      events,
+      hasMore,
+      ...oldestCursor !== void 0 ? { oldestCursor } : {}
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "DB error";
+    replyError(ws, msg, message);
+  }
 }
 function handleAgentUnsubscribe(ws, msg, state) {
   const sessionId = msg.session ?? "default";

--- a/packages/core/dist/server/ws.d.ts
+++ b/packages/core/dist/server/ws.d.ts
@@ -28,8 +28,17 @@ import 'better-sqlite3';
  *   agent.send        { session?, message, meta? }
  *   agent.kill        { session? }
  *   agent.status      { session? }
- *   agent.subscribe   { session?, since? }
+ *   agent.subscribe   { session?, since?, includeHistory?, tail? }
+ *                     Reply: { cursor, oldestCursor?, hasMore }
+ *                     - tail=N replays only the last N persisted messages then live-streams.
+ *                     - oldestCursor / hasMore let clients page older messages via agent.getMessages.
+ *                     - since / includeHistory keep the legacy "all-history" behavior.
  *   agent.unsubscribe { session? }
+ *   agent.getMessages { session, before?, limit? }
+ *                     Reply: { events: [{ cursor, event }], oldestCursor?, hasMore }
+ *                     Stateless reverse-paginated history fetch. `before` is the smallest
+ *                     cursor the client currently holds; returns the `limit` events
+ *                     immediately preceding it, in ascending cursor order.
  *   agent.run-once    { message, model?, systemPrompt?, appendSystemPrompt?, permissionMode?, cwd?, timeout?, provider?, extraArgs? }
  *   agent.completion  { prompt, model?, label?, systemPrompt?, appendSystemPrompt?, timeout?, extraArgs?, env? }
  *

--- a/packages/core/dist/server/ws.js
+++ b/packages/core/dist/server/ws.js
@@ -125,6 +125,8 @@ function handleMessage(ws, msg, sm, state) {
       return handleAgentSubscribe(ws, msg, sm, state);
     case "agent.unsubscribe":
       return handleAgentUnsubscribe(ws, msg, state);
+    case "agent.getMessages":
+      return handleAgentGetMessages(ws, msg);
     // ── Skill events ──────────────────────────────────
     // ── Permission ────────────────────────────────────
     case "permission.respond":
@@ -477,13 +479,68 @@ async function handleAgentCompletion(ws, msg) {
     replyError(ws, msg, e.message);
   }
 }
+function mapChatRowToEvent(row) {
+  const eventType = row.actor === "user" ? "user_message" : row.actor === "assistant" && row.kind === "text" ? "assistant" : row.actor === "assistant" && row.kind === "thinking" ? "thinking" : row.actor === "assistant" && row.kind === "tool_use" ? "tool_use" : row.actor === "system" && row.kind === "tool_result" ? "tool_result" : row.actor === "system" && row.kind === "error" ? "error" : null;
+  if (!eventType) return null;
+  const meta = row.meta ? JSON.parse(row.meta) : void 0;
+  return {
+    type: eventType,
+    message: row.content,
+    data: meta,
+    timestamp: new Date(row.created_at).getTime()
+  };
+}
+function countChatMessages(sessionId) {
+  const db = getDb();
+  const row = db.prepare(
+    `SELECT COUNT(*) as c FROM chat_messages WHERE session_id = ?`
+  ).get(sessionId);
+  return row?.c ?? 0;
+}
 function handleAgentSubscribe(ws, msg, sm, state) {
   const sessionId = msg.session ?? "default";
   const session = sm.getOrCreateSession(sessionId);
   state.agentUnsubs.get(sessionId)?.();
-  const includeHistory = msg.since === 0 || msg.includeHistory === true;
+  const tail = typeof msg.tail === "number" && msg.tail > 0 ? Math.floor(msg.tail) : null;
+  const includeHistory = tail === null && (msg.since === 0 || msg.includeHistory === true);
   let cursor = 0;
-  if (includeHistory) {
+  let oldestCursor;
+  let hasMore = false;
+  if (tail !== null) {
+    try {
+      const db = getDb();
+      const total = countChatMessages(sessionId);
+      const offset = Math.max(0, total - tail);
+      hasMore = offset > 0;
+      const rows = db.prepare(
+        `SELECT actor, kind, content, meta, created_at FROM chat_messages
+         WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?`
+      ).all(sessionId, tail, offset);
+      cursor = offset;
+      if (rows.length > 0) oldestCursor = offset + 1;
+      for (const row of rows) {
+        cursor++;
+        const event = mapChatRowToEvent(row);
+        if (!event) continue;
+        send(ws, {
+          type: "agent.event",
+          session: sessionId,
+          cursor,
+          isHistory: true,
+          event
+        });
+      }
+    } catch {
+    }
+    if (cursor < session.eventCounter) {
+      const unpersisted = session.eventCounter - cursor;
+      const bufferSlice = session.eventBuffer.slice(-unpersisted);
+      for (const event of bufferSlice) {
+        cursor++;
+        send(ws, { type: "agent.event", session: sessionId, cursor, event });
+      }
+    }
+  } else if (includeHistory) {
     try {
       const db = getDb();
       const rows = db.prepare(
@@ -492,20 +549,14 @@ function handleAgentSubscribe(ws, msg, sm, state) {
       ).all(sessionId);
       for (const row of rows) {
         cursor++;
-        const eventType = row.actor === "user" ? "user_message" : row.actor === "assistant" && row.kind === "text" ? "assistant" : row.actor === "assistant" && row.kind === "thinking" ? "thinking" : row.actor === "assistant" && row.kind === "tool_use" ? "tool_use" : row.actor === "system" && row.kind === "tool_result" ? "tool_result" : row.actor === "system" && row.kind === "error" ? "error" : null;
-        if (!eventType) continue;
-        const meta = row.meta ? JSON.parse(row.meta) : void 0;
+        const event = mapChatRowToEvent(row);
+        if (!event) continue;
         send(ws, {
           type: "agent.event",
           session: sessionId,
           cursor,
           isHistory: true,
-          event: {
-            type: eventType,
-            message: row.content,
-            data: meta,
-            timestamp: new Date(row.created_at).getTime()
-          }
+          event
         });
       }
     } catch {
@@ -539,7 +590,57 @@ function handleAgentSubscribe(ws, msg, sm, state) {
     }
   });
   state.agentUnsubs.set(sessionId, unsub);
-  reply(ws, msg, { cursor });
+  reply(ws, msg, {
+    cursor,
+    hasMore,
+    ...oldestCursor !== void 0 ? { oldestCursor } : {}
+  });
+}
+function handleAgentGetMessages(ws, msg) {
+  const sessionId = msg.session;
+  if (!sessionId) return replyError(ws, msg, "session is required");
+  const before = typeof msg.before === "number" && msg.before > 0 ? Math.floor(msg.before) : null;
+  const requestedLimit = typeof msg.limit === "number" && msg.limit > 0 ? Math.floor(msg.limit) : 50;
+  const limit = Math.min(requestedLimit, 200);
+  try {
+    const db = getDb();
+    const total = countChatMessages(sessionId);
+    let offset;
+    let take;
+    if (before === null) {
+      offset = Math.max(0, total - limit);
+      take = Math.min(limit, total);
+    } else {
+      const upperOrdinalExclusive = before;
+      const available = upperOrdinalExclusive - 1;
+      take = Math.max(0, Math.min(limit, available));
+      offset = available - take;
+    }
+    if (take <= 0) {
+      return reply(ws, msg, { events: [], hasMore: false });
+    }
+    const rows = db.prepare(
+      `SELECT actor, kind, content, meta, created_at FROM chat_messages
+       WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?`
+    ).all(sessionId, take, offset);
+    const events = [];
+    for (let i = 0; i < rows.length; i++) {
+      const cursor = offset + i + 1;
+      const event = mapChatRowToEvent(rows[i]);
+      if (!event) continue;
+      events.push({ cursor, event });
+    }
+    const hasMore = offset > 0;
+    const oldestCursor = rows.length > 0 ? offset + 1 : void 0;
+    reply(ws, msg, {
+      events,
+      hasMore,
+      ...oldestCursor !== void 0 ? { oldestCursor } : {}
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "DB error";
+    replyError(ws, msg, message);
+  }
 }
 function handleAgentUnsubscribe(ws, msg, state) {
   const sessionId = msg.session ?? "default";

--- a/packages/core/src/server/ws.ts
+++ b/packages/core/src/server/ws.ts
@@ -20,8 +20,17 @@
  *   agent.send        { session?, message, meta? }
  *   agent.kill        { session? }
  *   agent.status      { session? }
- *   agent.subscribe   { session?, since? }
+ *   agent.subscribe   { session?, since?, includeHistory?, tail? }
+ *                     Reply: { cursor, oldestCursor?, hasMore }
+ *                     - tail=N replays only the last N persisted messages then live-streams.
+ *                     - oldestCursor / hasMore let clients page older messages via agent.getMessages.
+ *                     - since / includeHistory keep the legacy "all-history" behavior.
  *   agent.unsubscribe { session? }
+ *   agent.getMessages { session, before?, limit? }
+ *                     Reply: { events: [{ cursor, event }], oldestCursor?, hasMore }
+ *                     Stateless reverse-paginated history fetch. `before` is the smallest
+ *                     cursor the client currently holds; returns the `limit` events
+ *                     immediately preceding it, in ascending cursor order.
  *   agent.run-once    { message, model?, systemPrompt?, appendSystemPrompt?, permissionMode?, cwd?, timeout?, provider?, extraArgs? }
  *   agent.completion  { prompt, model?, label?, systemPrompt?, appendSystemPrompt?, timeout?, extraArgs?, env? }
  *
@@ -230,6 +239,8 @@ function handleMessage(
       return handleAgentSubscribe(ws, msg, sm, state);
     case "agent.unsubscribe":
       return handleAgentUnsubscribe(ws, msg, state);
+    case "agent.getMessages":
+      return handleAgentGetMessages(ws, msg);
 
     // ── Skill events ──────────────────────────────────
 
@@ -632,6 +643,47 @@ async function handleAgentCompletion(ws: WebSocket, msg: WsRequest): Promise<voi
 
 // ── Agent event subscription handlers ─────────────────────────────
 
+interface ChatMessageRow {
+  actor: string;
+  kind: string;
+  content: string;
+  meta: string | null;
+  created_at: string;
+}
+
+/**
+ * Map a chat_messages row to a replayable AgentEvent. Returns null for rows
+ * that aren't surfaced as events (e.g. system bookkeeping). Callers that
+ * track ordinals must increment the cursor regardless of mappability —
+ * cursor == row ordinal, not event ordinal — otherwise live-event cursors
+ * (which derive from chat_messages COUNT(*)) will diverge from history cursors.
+ */
+function mapChatRowToEvent(row: ChatMessageRow): AgentEvent | null {
+  const eventType = row.actor === "user" ? "user_message"
+    : row.actor === "assistant" && row.kind === "text" ? "assistant"
+    : row.actor === "assistant" && row.kind === "thinking" ? "thinking"
+    : row.actor === "assistant" && row.kind === "tool_use" ? "tool_use"
+    : row.actor === "system" && row.kind === "tool_result" ? "tool_result"
+    : row.actor === "system" && row.kind === "error" ? "error"
+    : null;
+  if (!eventType) return null;
+  const meta = row.meta ? JSON.parse(row.meta) : undefined;
+  return {
+    type: eventType,
+    message: row.content,
+    data: meta,
+    timestamp: new Date(row.created_at).getTime(),
+  } as AgentEvent;
+}
+
+function countChatMessages(sessionId: string): number {
+  const db = getDb();
+  const row = db.prepare(
+    `SELECT COUNT(*) as c FROM chat_messages WHERE session_id = ?`,
+  ).get(sessionId) as { c: number } | undefined;
+  return row?.c ?? 0;
+}
+
 function handleAgentSubscribe(
   ws: WebSocket,
   msg: WsRequest,
@@ -644,49 +696,78 @@ function handleAgentSubscribe(
   // Unsubscribe existing for this session
   state.agentUnsubs.get(sessionId)?.();
 
-  // If since=0 (or includeHistory=true), replay DB history as events first
-  const includeHistory = msg.since === 0 || msg.includeHistory === true;
+  // Three replay modes:
+  //   tail:N        — last N persisted messages, then live (paginated client UI)
+  //   includeHistory — full history, then live (legacy default for clients
+  //                    that haven't adopted tail; also triggered by since=0)
+  //   default       — no history, live from current cursor
+  const tail = typeof msg.tail === "number" && msg.tail > 0 ? Math.floor(msg.tail) : null;
+  const includeHistory = tail === null && (msg.since === 0 || msg.includeHistory === true);
   let cursor = 0;
+  let oldestCursor: number | undefined;
+  let hasMore = false;
 
-  if (includeHistory) {
+  if (tail !== null) {
+    try {
+      const db = getDb();
+      const total = countChatMessages(sessionId);
+      const offset = Math.max(0, total - tail);
+      hasMore = offset > 0;
+
+      const rows = db.prepare(
+        `SELECT actor, kind, content, meta, created_at FROM chat_messages
+         WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?`,
+      ).all(sessionId, tail, offset) as ChatMessageRow[];
+
+      cursor = offset;
+      if (rows.length > 0) oldestCursor = offset + 1;
+      for (const row of rows) {
+        cursor++;
+        const event = mapChatRowToEvent(row);
+        if (!event) continue;
+        send(ws, {
+          type: "agent.event",
+          session: sessionId,
+          cursor,
+          isHistory: true,
+          event,
+        });
+      }
+    } catch { /* DB not ready */ }
+
+    // Replay in-memory buffer events past `cursor` — same logic as legacy path.
+    if (cursor < session.eventCounter) {
+      const unpersisted = session.eventCounter - cursor;
+      const bufferSlice = session.eventBuffer.slice(-unpersisted);
+      for (const event of bufferSlice) {
+        cursor++;
+        send(ws, { type: "agent.event", session: sessionId, cursor, event });
+      }
+    }
+  } else if (includeHistory) {
     // Replay all persisted messages from DB
     try {
       const db = getDb();
       const rows = db.prepare(
         `SELECT actor, kind, content, meta, created_at FROM chat_messages
          WHERE session_id = ? ORDER BY id ASC`,
-      ).all(sessionId) as { actor: string; kind: string; content: string; meta: string | null; created_at: string }[];
+      ).all(sessionId) as ChatMessageRow[];
 
       for (const row of rows) {
         cursor++;
-        // Map (actor, kind) → event type for replay. status blocks are bookkeeping and skipped.
-        const eventType = row.actor === "user" ? "user_message"
-          : row.actor === "assistant" && row.kind === "text" ? "assistant"
-          : row.actor === "assistant" && row.kind === "thinking" ? "thinking"
-          : row.actor === "assistant" && row.kind === "tool_use" ? "tool_use"
-          : row.actor === "system" && row.kind === "tool_result" ? "tool_result"
-          : row.actor === "system" && row.kind === "error" ? "error"
-          : null;
-        if (!eventType) continue;
-        const meta = row.meta ? JSON.parse(row.meta) : undefined;
+        const event = mapChatRowToEvent(row);
+        if (!event) continue;
         send(ws, {
           type: "agent.event",
           session: sessionId,
           cursor,
           isHistory: true,
-          event: {
-            type: eventType,
-            message: row.content,
-            data: meta,
-            timestamp: new Date(row.created_at).getTime(),
-          },
+          event,
         });
       }
     } catch { /* DB not ready */ }
 
     // Replay in-memory buffer events that haven't been persisted to DB yet.
-    // These are events emitted since the last DB write (current turn in-flight).
-    // Only include events whose counter exceeds the history cursor to avoid duplicates.
     if (cursor < session.eventCounter) {
       const unpersisted = session.eventCounter - cursor;
       const bufferSlice = session.eventBuffer.slice(-unpersisted);
@@ -721,7 +802,78 @@ function handleAgentSubscribe(
   });
   state.agentUnsubs.set(sessionId, unsub);
 
-  reply(ws, msg, { cursor });
+  reply(ws, msg, {
+    cursor,
+    hasMore,
+    ...(oldestCursor !== undefined ? { oldestCursor } : {}),
+  });
+}
+
+/**
+ * Stateless reverse-paginated history fetch. Used by clients (e.g. Loom) to
+ * load older messages when the user scrolls up, without disturbing the live
+ * subscription. Cursors are chat_messages row ordinals — same numbering as
+ * agent.subscribe replay — so prepending these into the client buffer keeps
+ * dedup against live events working unchanged.
+ */
+function handleAgentGetMessages(ws: WebSocket, msg: WsRequest): void {
+  const sessionId = msg.session as string | undefined;
+  if (!sessionId) return replyError(ws, msg, "session is required");
+
+  const before = typeof msg.before === "number" && msg.before > 0 ? Math.floor(msg.before) : null;
+  const requestedLimit = typeof msg.limit === "number" && msg.limit > 0 ? Math.floor(msg.limit) : 50;
+  const limit = Math.min(requestedLimit, 200);
+
+  try {
+    const db = getDb();
+    const total = countChatMessages(sessionId);
+
+    // Compute the row range to read (ordinals are 1-based).
+    //   before == null: tail of history (last `limit` rows).
+    //   before > 0    : `limit` rows ending at ordinal (before - 1).
+    let offset: number;
+    let take: number;
+    if (before === null) {
+      offset = Math.max(0, total - limit);
+      take = Math.min(limit, total);
+    } else {
+      const upperOrdinalExclusive = before;
+      const available = upperOrdinalExclusive - 1;
+      take = Math.max(0, Math.min(limit, available));
+      offset = available - take;
+    }
+
+    if (take <= 0) {
+      return reply(ws, msg, { events: [], hasMore: false });
+    }
+
+    const rows = db.prepare(
+      `SELECT actor, kind, content, meta, created_at FROM chat_messages
+       WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?`,
+    ).all(sessionId, take, offset) as ChatMessageRow[];
+
+    const events: Array<{ cursor: number; event: AgentEvent }> = [];
+    for (let i = 0; i < rows.length; i++) {
+      const cursor = offset + i + 1;
+      const event = mapChatRowToEvent(rows[i]);
+      if (!event) continue;
+      events.push({ cursor, event });
+    }
+
+    // hasMore reflects rows, not mapped events — clients can keep paging back
+    // even if the just-returned batch was filtered down to nothing by mapping.
+    const hasMore = offset > 0;
+    const oldestCursor = rows.length > 0 ? offset + 1 : undefined;
+
+    reply(ws, msg, {
+      events,
+      hasMore,
+      ...(oldestCursor !== undefined ? { oldestCursor } : {}),
+    });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "DB error";
+    replyError(ws, msg, message);
+  }
 }
 
 function handleAgentUnsubscribe(ws: WebSocket, msg: WsRequest, state: ConnState): void {

--- a/packages/core/test/ws-handler.test.ts
+++ b/packages/core/test/ws-handler.test.ts
@@ -432,6 +432,91 @@ describe("WebSocket Handler", () => {
     assert.equal(events[1].event.message, "hi from DB");
   });
 
+  it("agent.subscribe with tail replays only the last N messages", async () => {
+    send(ctx, "chat.sessions.create", { id: "tail-test" });
+    await waitForReply(ctx, ctx.rid.toString());
+    for (let i = 1; i <= 5; i++) {
+      send(ctx, "chat.messages.create", { session: "tail-test", actor: "user", kind: "text", content: `msg-${i}` });
+      await waitForReply(ctx, ctx.rid.toString());
+    }
+
+    const events: any[] = [];
+    const handler = (raw: any) => {
+      const msg = JSON.parse(raw.toString());
+      if (msg.type === "agent.event" && msg.session === "tail-test") events.push(msg);
+    };
+    ctx.ws.on("message", handler);
+
+    const rid = send(ctx, "agent.subscribe", { session: "tail-test", tail: 2 });
+    const reply = await waitForReply(ctx, rid);
+
+    // Allow event push to flush
+    await new Promise((r) => setTimeout(r, 200));
+    ctx.ws.off("message", handler);
+
+    assert.equal(events.length, 2, `Expected 2 tail events, got ${events.length}`);
+    assert.equal(events[0].event.message, "msg-4");
+    assert.equal(events[1].event.message, "msg-5");
+    assert.equal(events[0].cursor, 4);
+    assert.equal(events[1].cursor, 5);
+    assert.equal(reply.hasMore, true);
+    assert.equal(reply.oldestCursor, 4);
+    assert.equal(reply.cursor, 5);
+  });
+
+  it("agent.subscribe with tail >= total reports hasMore=false", async () => {
+    send(ctx, "chat.sessions.create", { id: "tail-small-test" });
+    await waitForReply(ctx, ctx.rid.toString());
+    send(ctx, "chat.messages.create", { session: "tail-small-test", actor: "user", kind: "text", content: "only" });
+    await waitForReply(ctx, ctx.rid.toString());
+
+    const rid = send(ctx, "agent.subscribe", { session: "tail-small-test", tail: 20 });
+    const reply = await waitForReply(ctx, rid);
+    assert.equal(reply.hasMore, false);
+    assert.equal(reply.oldestCursor, 1);
+  });
+
+  it("agent.getMessages paginates older history", async () => {
+    send(ctx, "chat.sessions.create", { id: "paginate-test" });
+    await waitForReply(ctx, ctx.rid.toString());
+    for (let i = 1; i <= 7; i++) {
+      send(ctx, "chat.messages.create", { session: "paginate-test", actor: "user", kind: "text", content: `m-${i}` });
+      await waitForReply(ctx, ctx.rid.toString());
+    }
+
+    // Tail of 3 leaves cursors 5..7 visible; backfill 1..4 in two pages.
+    const firstRid = send(ctx, "agent.getMessages", { session: "paginate-test", before: 5, limit: 3 });
+    const first = await waitForReply(ctx, firstRid);
+    assert.equal(first.events.length, 3);
+    assert.equal(first.events[0].cursor, 2);
+    assert.equal(first.events[2].cursor, 4);
+    assert.equal(first.events[2].event.message, "m-4");
+    assert.equal(first.hasMore, true);
+    assert.equal(first.oldestCursor, 2);
+
+    const secondRid = send(ctx, "agent.getMessages", { session: "paginate-test", before: first.oldestCursor, limit: 3 });
+    const second = await waitForReply(ctx, secondRid);
+    assert.equal(second.events.length, 1);
+    assert.equal(second.events[0].cursor, 1);
+    assert.equal(second.hasMore, false);
+  });
+
+  it("agent.getMessages with no before returns the tail", async () => {
+    send(ctx, "chat.sessions.create", { id: "tail-fetch-test" });
+    await waitForReply(ctx, ctx.rid.toString());
+    for (let i = 1; i <= 4; i++) {
+      send(ctx, "chat.messages.create", { session: "tail-fetch-test", actor: "user", kind: "text", content: `t-${i}` });
+      await waitForReply(ctx, ctx.rid.toString());
+    }
+
+    const rid = send(ctx, "agent.getMessages", { session: "tail-fetch-test", limit: 2 });
+    const reply = await waitForReply(ctx, rid);
+    assert.equal(reply.events.length, 2);
+    assert.equal(reply.events[0].cursor, 3);
+    assert.equal(reply.events[1].cursor, 4);
+    assert.equal(reply.hasMore, true);
+  });
+
   it("permission.subscribe replays existing pending", async () => {
     // No pending permissions exist, so pendingCount should be 0
     const rid = send(ctx, "permission.subscribe");


### PR DESCRIPTION
## Summary

- `agent.subscribe` accepts `tail: N` — replays only the last N persisted messages, then live-streams. Reply now includes `oldestCursor` and `hasMore` so clients can drive reverse pagination.
- New `agent.getMessages { session, before?, limit? }` — stateless reverse pagination from chat_messages, returns events in ascending cursor order. Caps at 200 per request.
- Cursors are `chat_messages.id` ordinals (same numbering as subscribe replay), so clients can prepend older batches into existing dedup pipelines without translation.
- Row→event mapping factored into `mapChatRowToEvent` so subscribe replay and getMessages share the same logic.

## Why

Loom (and any other consumer) can open sessions with thousands of messages without replaying the entire history on connect. Tail-mode subscribe + on-demand backfill replaces the current "all-or-nothing" semantics.

## Test plan
- [x] Existing ws-handler tests pass (39/39)
- [x] New tests cover: `tail` replays exactly N, `tail >= total` reports hasMore=false, `getMessages` paginates older history, `getMessages` with no `before` returns the tail
- [x] Verify in Loom against a large imported session