### PR TITLE
fix(release): drop dead plugin/marketplace updates from set-version

### DIFF
--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -1,18 +1,11 @@
 /**
- * set-version.ts — Sync version across all packages, plugin, and marketplace.
+ * set-version.ts — Sync version across all SDK packages.
  *
  * Usage:
  *   tsx scripts/set-version.ts <version>
  *
- * Updates:
- *   - packages/core/package.json
- *   - packages/react/package.json
- *   - plugins/sna-builder/.claude-plugin/plugin.json
- *   - .claude-plugin/marketplace.json
- *
- * Validates:
- *   - semver format
- *   - version is higher than current
+ * Updates packages/{core,react,client,testing}/package.json. Validates
+ * semver format and that the new version is higher than current.
  */
 
 import fs from "fs";
@@ -78,15 +71,5 @@ updateJson("packages/core/package.json", (j) => { j.version = version; });
 updateJson("packages/react/package.json", (j) => { j.version = version; });
 updateJson("packages/client/package.json", (j) => { j.version = version; });
 updateJson("packages/testing/package.json", (j) => { j.version = version; });
-
-// plugin
-updateJson("plugins/sna-builder/.claude-plugin/plugin.json", (j) => { j.version = version; });
-
-// marketplace
-updateJson(".claude-plugin/marketplace.json", (j) => {
-  for (const plugin of j.plugins) {
-    plugin.version = version;
-  }
-});
 
 console.log(`\n✓ All set to ${version}`);


### PR DESCRIPTION
## Summary

\`66bdfff\` ('drop skill-centric layer') removed the \`.claude-plugin/\` and \`plugins/\` trees but left their references in \`scripts/set-version.ts\`. The release workflow's first step (\`Set version and commit\`) crashes with \`ENOENT: plugins/sna-builder/.claude-plugin/plugin.json\` for any tag push, so v0.11.1 (and any future tag) fails before publish.

The SDK is no longer published as a Claude Code plugin — only the four npm packages ship — so the lines just go away.

## Repro
\`git tag vX.Y.Z && git push --tags\` → \`Set version and commit\` step fails.

## Test plan
- [ ] Re-tag once merged; release workflow proceeds past the version-bump step.