### PR TITLE
feat(codex): accept consumer PreToolUse hooks via providerOptions.settings

### DIFF
--- a/packages/core/src/core/providers/codex.ts
+++ b/packages/core/src/core/providers/codex.ts
@@ -200,6 +200,81 @@ interface JsonRpcRequest {
   params?: Record<string, unknown>;
 }
 
+// ── PreToolUse hook merge ─────────────────────────────────────────────────
+//
+// Codex consumes hooks.json with shape:
+//   { hooks: { PreToolUse: [{ matcher: <regex>, hooks: [{type, command, …}] }] } }
+//
+// SNA's provider always writes its own permission-bridge + tool-filter
+// scripts in a single ".*" matcher. Consumers (e.g. Loom) can supply extra
+// matchers — for example, a Bash-only wrapper that rewrites long-running
+// commands. Those extra matchers append after SNA's so the canonical
+// permission + filter chain runs first.
+//
+// Mirrors `mergeAppSettings()` in claude-code.ts; kept as a pure function
+// to make the merge testable without spinning up a CodexProvider instance.
+
+export interface CodexHookEntry {
+  type: string;
+  command: string;
+  timeout?: number;
+}
+
+export interface CodexHookMatcher {
+  matcher: string;
+  hooks: CodexHookEntry[];
+}
+
+export interface CodexHooksJson {
+  hooks: { PreToolUse: CodexHookMatcher[] };
+}
+
+/**
+ * Build the hooks.json content from SNA's internal PreToolUse chain plus
+ * any consumer-provided settings.
+ *
+ * @param internalHooks Permission/tool-filter scripts SNA always wants to run.
+ * @param appSettings   Optional `providerOptions.settings` object — the same
+ *                      shape claude-code accepts. Only `hooks.PreToolUse`
+ *                      (an array of `{matcher, hooks}` entries) is honored
+ *                      here; other settings keys are ignored because Codex
+ *                      has no equivalent surface.
+ * @returns The hooks.json payload, or null when nothing needs to be written.
+ *
+ * @internal Exported for unit tests.
+ */
+export function buildCodexHooksJson(
+  internalHooks: CodexHookEntry[],
+  appSettings?: Record<string, unknown> | undefined,
+): CodexHooksJson | null {
+  const matchers: CodexHookMatcher[] = [];
+  if (internalHooks.length > 0) {
+    matchers.push({ matcher: ".*", hooks: internalHooks });
+  }
+
+  if (appSettings && typeof appSettings === "object") {
+    const appHooks = (appSettings as { hooks?: unknown }).hooks;
+    if (appHooks && typeof appHooks === "object") {
+      const appPreToolUse = (appHooks as { PreToolUse?: unknown }).PreToolUse;
+      if (Array.isArray(appPreToolUse)) {
+        for (const entry of appPreToolUse) {
+          if (
+            entry &&
+            typeof entry === "object" &&
+            typeof (entry as { matcher?: unknown }).matcher === "string" &&
+            Array.isArray((entry as { hooks?: unknown }).hooks)
+          ) {
+            matchers.push(entry as CodexHookMatcher);
+          }
+        }
+      }
+    }
+  }
+
+  if (matchers.length === 0) return null;
+  return { hooks: { PreToolUse: matchers } };
+}
+
 function rpcRequest(method: string, params?: Record<string, unknown>): JsonRpcRequest & { id: number } {
   return { method, id: ++rpcIdCounter, params: params ?? {} };
 }
@@ -1462,7 +1537,7 @@ export class CodexProvider implements AgentProvider {
       pkgRoot = parent;
     }
 
-    const preToolUseHooks: Array<{ type: string; command: string; timeout?: number }> = [];
+    const preToolUseHooks: CodexHookEntry[] = [];
 
     // 1. Permission hook (skip when bypassPermissions)
     if (options.permissionMode !== "bypassPermissions") {
@@ -1492,16 +1567,14 @@ export class CodexProvider implements AgentProvider {
       logger.log("agent", `codex: tool-filter hook → ${options.allowedTools ? `allowed=[${options.allowedTools}]` : `disallowed=[${options.disallowedTools}]`}`);
     }
 
-    // Write hooks.json if any hooks are configured
-    if (preToolUseHooks.length > 0) {
-      const hooksJson = {
-        hooks: {
-          PreToolUse: [{
-            matcher: ".*",
-            hooks: preToolUseHooks,
-          }],
-        },
-      };
+    // 3. Consumer-provided hooks via providerOptions.settings (parity with
+    //    the claude-code provider). Same shape: `{ hooks: { PreToolUse: [...] } }`.
+    //    Only PreToolUse is plumbed through to Codex today — that's the only
+    //    hook event Codex's engine supports.
+    const consumerSettings = (options.providerOptions as { settings?: Record<string, unknown> } | undefined)?.settings;
+    const hooksJson = buildCodexHooksJson(preToolUseHooks, consumerSettings);
+
+    if (hooksJson) {
       fs.writeFileSync(path.join(codexHome, "hooks.json"), JSON.stringify(hooksJson));
 
       // Enable codex_hooks feature in config.toml

--- a/packages/core/test/codex-provider.test.ts
+++ b/packages/core/test/codex-provider.test.ts
@@ -12,6 +12,7 @@ import {
   extractResumeArg,
   extractSystemPromptArgs,
   validateCodexPath,
+  buildCodexHooksJson,
   // @ts-ignore — toCodexSandboxPolicy is not exported but we test via toCodexSandbox
 } from "../src/core/providers/codex.js";
 import { canonicalToCodexResponseItems } from "../src/history/codex.js";
@@ -223,5 +224,89 @@ describe("permission response format", () => {
   it("decline decision format matches Codex protocol", () => {
     const response = { id: 0, result: { decision: "decline" } };
     assert.equal(response.result.decision, "decline");
+  });
+});
+
+// ── buildCodexHooksJson ─────────────────────────────────────────────────────
+//
+// Codex's hooks.json mirrors claude-code's settings.hooks: a list of matchers
+// each with their own hook scripts. SNA writes one ".*" matcher with the
+// permission + tool-filter chain; consumers (Loom) layer additional matchers
+// for tool-specific wrappers (e.g. a Bash-only `lbash` rewrite). The merge
+// function below preserves SNA's matcher first so its permission gate always
+// runs ahead of consumer logic.
+
+describe("buildCodexHooksJson", () => {
+  const internal = [
+    { type: "command", command: "node sna-hook.js", timeout: 300 },
+  ];
+
+  it("returns null when no internal and no app hooks", () => {
+    assert.equal(buildCodexHooksJson([], undefined), null);
+    assert.equal(buildCodexHooksJson([], {}), null);
+    assert.equal(buildCodexHooksJson([], { hooks: {} }), null);
+  });
+
+  it("wraps internal-only hooks in a single .* matcher", () => {
+    const out = buildCodexHooksJson(internal, undefined);
+    assert.deepEqual(out, {
+      hooks: { PreToolUse: [{ matcher: ".*", hooks: internal }] },
+    });
+  });
+
+  it("appends consumer matchers after the internal one (order matters)", () => {
+    const appBash = { matcher: "Bash", hooks: [{ type: "command", command: "node lbash-hook.js" }] };
+    const out = buildCodexHooksJson(internal, { hooks: { PreToolUse: [appBash] } });
+    assert.deepEqual(out, {
+      hooks: {
+        PreToolUse: [
+          { matcher: ".*", hooks: internal },
+          appBash,
+        ],
+      },
+    });
+  });
+
+  it("emits a consumer-only PreToolUse array when SNA has no internal hooks", () => {
+    // Happens when permissionMode is bypassPermissions and no tool filter is set.
+    const appBash = { matcher: "Bash", hooks: [{ type: "command", command: "node lbash-hook.js" }] };
+    const out = buildCodexHooksJson([], { hooks: { PreToolUse: [appBash] } });
+    assert.deepEqual(out, { hooks: { PreToolUse: [appBash] } });
+  });
+
+  it("ignores non-PreToolUse hook events from app settings", () => {
+    // Codex's engine only supports PreToolUse today. Other event names are
+    // silently dropped instead of being written through and producing a
+    // confusing hooks.json that the runtime would reject.
+    const out = buildCodexHooksJson(internal, {
+      hooks: {
+        PostToolUse: [{ matcher: ".*", hooks: [{ type: "command", command: "node post.js" }] }],
+      },
+    });
+    assert.deepEqual(out, {
+      hooks: { PreToolUse: [{ matcher: ".*", hooks: internal }] },
+    });
+  });
+
+  it("skips malformed matcher entries", () => {
+    const out = buildCodexHooksJson(internal, {
+      hooks: {
+        PreToolUse: [
+          { matcher: "Bash", hooks: [{ type: "command", command: "node ok.js" }] },
+          null,
+          { matcher: "Read" }, // missing hooks
+          { hooks: [] }, // missing matcher
+          "garbage",
+        ],
+      },
+    });
+    assert.deepEqual(out, {
+      hooks: {
+        PreToolUse: [
+          { matcher: ".*", hooks: internal },
+          { matcher: "Bash", hooks: [{ type: "command", command: "node ok.js" }] },
+        ],
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

Brings the codex provider to parity with claude-code: consumers can now layer their own PreToolUse hooks via `providerOptions.settings.hooks.PreToolUse` for Codex sessions, the same way they already do for Claude Code.

## Why

Before this change, `codex.ts` wrote a fresh \`\$CODEX_HOME/hooks.json\` containing only SNA's own permission-bridge + tool-filter scripts. There was no path for an embedding app to register additional PreToolUse hooks, even though the equivalent surface exists on \`claude-code.ts\` (see \`mergeAppSettings()\` at line 813-839).

Concrete motivation: Loom wants to inject a Bash-only PreToolUse hook that wraps long-running commands with an observability harness (\`lbash\`) for Codex sessions, mirroring what already works on Claude Code.

## What

- Pure helper \`buildCodexHooksJson(internalHooks, appSettings)\` produces the \`hooks.json\` payload.
- SNA's \`.*\` matcher stays first (permission gate must run before consumer logic); consumer-supplied matchers append after.
- Same accepted shape as claude-code: \`providerOptions.settings.hooks.PreToolUse: [{matcher, hooks}]\`.
- Unsupported hook events (PostToolUse, etc.) are silently dropped from consumer input — Codex's hook engine only honors PreToolUse today, and forwarding would just produce a \`hooks.json\` the runtime rejects.

## Test plan

- [x] \`pnpm test test/codex-provider.test.ts\` — 32 passing (8 suites). New suite \`buildCodexHooksJson\` covers:
  - empty input → null
  - internal-only → single \`.*\` matcher
  - consumer-only (used when \`permissionMode: bypassPermissions\` + no tool filter)
  - combined order (internal first, consumer matchers appended)
  - unsupported event (PostToolUse) dropped
  - malformed matcher entries skipped (null, missing fields, non-object)
- [x] Pre-existing test suite still has the same 46 failures (unchanged from baseline; my diff adds +6 passes, 0 new fails).
- [x] \`tsc --noEmit\` clean.
- [x] \`pnpm build\` clean.