### PR TITLE
fix(codex): migrate to [features].hooks, merge safely into existing table

### DIFF
--- a/packages/core/src/core/providers/codex.ts
+++ b/packages/core/src/core/providers/codex.ts
@@ -255,7 +255,11 @@ export interface CodexHooksJson {
  * servers and tool calls silently failed.
  *
  * Idempotent for repeat callers on the same CODEX_HOME — config.toml is
- * appended to and codex_hooks is enabled at most once.
+ * appended to and the `[features].hooks` flag is enabled at most once.
+ *
+ * The flag's name changed from `codex_hooks` to `hooks` in codex-cli
+ * 0.130; this function writes the new name and migrates legacy values
+ * in place so daemons stop emitting deprecation notices.
  */
 export function applyCodexConfig(
   codexHome: string,
@@ -338,10 +342,58 @@ export function applyCodexConfig(
   const hooksJson = buildCodexHooksJson(preToolUseHooks, consumerSettings);
   if (hooksJson) {
     fs.writeFileSync(path.join(codexHome, "hooks.json"), JSON.stringify(hooksJson));
-    const existingConfig = fs.existsSync(configTomlPath) ? fs.readFileSync(configTomlPath, "utf8") : "";
-    if (!existingConfig.includes("codex_hooks")) {
-      fs.appendFileSync(configTomlPath, "\n[features]\ncodex_hooks = true\n");
-    }
+    enableCodexHooksFeature(configTomlPath);
+  }
+}
+
+/**
+ * Ensure `[features].hooks = true` is set in the given config.toml.
+ *
+ * Codex CLI 0.130 renamed the feature flag from `codex_hooks` to `hooks`;
+ * the old name still works but produces a deprecation notice on every
+ * `turn/start`. We handle four cases without bringing in a TOML parser:
+ *
+ *  1. Nothing about hooks in the file → inject `hooks = true` inside any
+ *     existing `[features]` table, or create one if missing.
+ *  2. New `hooks = …` key already present → no-op.
+ *  3. Only the legacy `codex_hooks = …` key is present → rewrite it
+ *     in-place so the daemon stops emitting deprecation notices.
+ *  4. Both keys present (mixed state from a previous toolchain) →
+ *     no-op; the new key already wins, and we don't want to delete
+ *     the user's other config.
+ *
+ * Critically we do NOT append a fresh `[features]` table when one
+ * already exists — TOML's table semantics treat that as a duplicate
+ * definition.
+ */
+export function enableCodexHooksFeature(configTomlPath: string): void {
+  const existing = fs.existsSync(configTomlPath)
+    ? fs.readFileSync(configTomlPath, "utf8")
+    : "";
+
+  const hasNewKey = /^\s*hooks\s*=/m.test(existing);
+  const hasLegacyKey = /^\s*codex_hooks\s*=/m.test(existing);
+
+  if (hasNewKey) {
+    return; // cases 2 + 4
+  }
+
+  if (hasLegacyKey) {
+    // Case 3: migrate `codex_hooks = …` → `hooks = …` in place. Keep
+    // the existing RHS so a value like `false` survives the rename.
+    const migrated = existing.replace(/^(\s*)codex_hooks(\s*=)/m, "$1hooks$2");
+    fs.writeFileSync(configTomlPath, migrated);
+    logger.log("agent", `codex: migrated legacy [features].codex_hooks → hooks in ${configTomlPath}`);
+    return;
+  }
+
+  // Case 1: no hooks key at all. Inject into an existing [features]
+  // table or append a new one.
+  if (/^\[features\]\s*$/m.test(existing)) {
+    const updated = existing.replace(/^(\[features\]\s*\n)/m, "$1hooks = true\n");
+    fs.writeFileSync(configTomlPath, updated);
+  } else {
+    fs.appendFileSync(configTomlPath, "\n[features]\nhooks = true\n");
   }
 }
 

--- a/packages/core/test/codex-hooks-feature-flag.test.ts
+++ b/packages/core/test/codex-hooks-feature-flag.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for `enableCodexHooksFeature` — the helper that writes the
+ * `[features].hooks = true` flag into a CODEX_HOME's `config.toml`.
+ *
+ * Codex CLI 0.130 renamed `codex_hooks` → `hooks`; the helper has to
+ * (a) write the new key on fresh installs, (b) migrate legacy keys in
+ * place, (c) merge safely into an existing `[features]` table without
+ * producing a duplicate-table-definition.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { enableCodexHooksFeature } from "../src/core/providers/codex.js";
+
+describe("enableCodexHooksFeature", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sna-codex-hooks-"));
+    configPath = path.join(tmpDir, "config.toml");
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  });
+
+  it("creates a [features] table with `hooks = true` when the file is empty/missing", () => {
+    // file doesn't exist yet
+    enableCodexHooksFeature(configPath);
+    const content = fs.readFileSync(configPath, "utf8");
+    assert.match(content, /^\[features\]\s*$/m);
+    assert.match(content, /^hooks\s*=\s*true\s*$/m);
+    assert.doesNotMatch(content, /codex_hooks/);
+  });
+
+  it("injects `hooks = true` inside an existing [features] table instead of appending a duplicate", () => {
+    fs.writeFileSync(configPath, [
+      "model = \"gpt-5.5\"",
+      "",
+      "[features]",
+      "run_logs = true",
+      "",
+    ].join("\n"));
+
+    enableCodexHooksFeature(configPath);
+    const content = fs.readFileSync(configPath, "utf8");
+
+    // Only one [features] header.
+    const headerCount = content.match(/^\[features\]\s*$/gm)?.length ?? 0;
+    assert.equal(headerCount, 1, "should not duplicate the [features] table");
+    // Both keys present.
+    assert.match(content, /^hooks\s*=\s*true\s*$/m);
+    assert.match(content, /^run_logs\s*=\s*true\s*$/m);
+    // hooks sits directly under [features], above the pre-existing key.
+    assert.match(content, /\[features\]\s*\nhooks\s*=\s*true\s*\nrun_logs\s*=\s*true/);
+  });
+
+  it("migrates legacy `codex_hooks = …` to `hooks = …` in place", () => {
+    fs.writeFileSync(configPath, [
+      "[features]",
+      "codex_hooks = true",
+      "",
+    ].join("\n"));
+
+    enableCodexHooksFeature(configPath);
+    const content = fs.readFileSync(configPath, "utf8");
+
+    assert.match(content, /^hooks\s*=\s*true\s*$/m);
+    assert.doesNotMatch(content, /codex_hooks/);
+  });
+
+  it("preserves the legacy key's RHS during migration (e.g. `= false` stays `= false`)", () => {
+    fs.writeFileSync(configPath, [
+      "[features]",
+      "codex_hooks = false",
+      "",
+    ].join("\n"));
+
+    enableCodexHooksFeature(configPath);
+    const content = fs.readFileSync(configPath, "utf8");
+
+    assert.match(content, /^hooks\s*=\s*false\s*$/m);
+    assert.doesNotMatch(content, /codex_hooks/);
+  });
+
+  it("is a no-op when `hooks = …` already exists", () => {
+    const before = [
+      "[features]",
+      "hooks = true",
+      "other_flag = false",
+      "",
+    ].join("\n");
+    fs.writeFileSync(configPath, before);
+
+    enableCodexHooksFeature(configPath);
+    const after = fs.readFileSync(configPath, "utf8");
+
+    assert.equal(after, before);
+  });
+
+  it("when both legacy and new keys somehow coexist, leaves the file untouched", () => {
+    const before = [
+      "[features]",
+      "hooks = true",
+      "codex_hooks = true",
+      "",
+    ].join("\n");
+    fs.writeFileSync(configPath, before);
+
+    enableCodexHooksFeature(configPath);
+    const after = fs.readFileSync(configPath, "utf8");
+
+    // We don't try to delete the legacy line — the new key already wins
+    // and a stray line is harmless. Just confirm nothing got duplicated.
+    assert.equal(after, before);
+  });
+
+  it("appends a fresh [features] section when no existing one is present", () => {
+    fs.writeFileSync(configPath, "model = \"gpt-5.5\"\n");
+
+    enableCodexHooksFeature(configPath);
+    const content = fs.readFileSync(configPath, "utf8");
+
+    assert.match(content, /model\s*=\s*"gpt-5\.5"/);
+    assert.match(content, /\[features\]\s*\nhooks\s*=\s*true/);
+  });
+});


### PR DESCRIPTION
## Summary

Two related issues in `applyCodexConfig`'s hook-feature-flag writer,
both surfaced by Fude while running SNA 0.15.0:

1. **Deprecation warning every turn.** Codex CLI 0.130 renamed the
   feature flag from `codex_hooks` to `hooks` and now emits a
   `deprecationNotice` on every `turn/start` when the old key is set:

   > `[features].codex_hooks` is deprecated. Use `[features].hooks` instead.

   SNA was still appending the legacy name, so the warning fires on
   every consumer call.

2. **Duplicate `[features]` table.** The old guard was just
   `existingConfig.includes("codex_hooks")`. If the user's
   `~/.codex/config.toml` already had a `[features]` table for any
   other flag, SNA would append a second `[features]` header — which
   is a duplicate-table-definition under TOML spec. Codex happens to
   tolerate it today, but that's not contractual.

## Fix

`applyCodexConfig`'s inline block is replaced by an exported helper
`enableCodexHooksFeature(configTomlPath)`. Four cases handled without
bringing in a TOML parser:

| state | action |
|---|---|
| no hooks key | inject `hooks = true` into existing `[features]` table, or append a fresh one |
| `hooks = …` already there | no-op (idempotent for repeat boots) |
| legacy `codex_hooks = …` | rewrite in place to `hooks = …`; RHS preserved so `= false` survives |
| both keys somehow coexist | no-op; new key wins and we don't want to touch user config |

## Test plan

- [x] 7 new unit tests in `codex-hooks-feature-flag.test.ts` cover
      every branch — empty config, existing `[features]` without hooks
      (the duplicate-table case), legacy-key migration, `= false`
      preservation, already-correct no-op, mixed state, append-new.
- [x] 74/74 tests pass (existing 67 + new 7).
- [x] `pnpm exec tsc --noEmit` clean.

## Release note (whoever cuts the next patch)

Bump to `0.15.1` — pure bug fix, no API changes. Consumers running
codex-cli >= 0.130 will stop seeing the deprecation warning on every
turn. Stale `codex_hooks = …` lines in user CODEX_HOMEs from older
SNA installs get migrated automatically on next boot.

Reported by Fude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)