### PR TITLE
feat(codex): forward image_generation + unknown items, add durationMs

### DIFF
--- a/packages/core/src/core/providers/codex.ts
+++ b/packages/core/src/core/providers/codex.ts
@@ -438,6 +438,15 @@ class CodexProcess implements AgentProcess {
   /** Accumulated token usage from tokenUsage/updated notifications. */
   private _lastUsage: { inputTokens: number; outputTokens: number; cachedInputTokens: number } | null = null;
 
+  /**
+   * Per-item start timestamps, indexed by item.id. Populated when
+   * `item/started` arrives and consumed by `item/completed` to compute
+   * `durationMs` on the resulting tool_result. Long-running hosted tools
+   * (image_generation, web_search) have no intermediate progress signal,
+   * so duration is the only honest latency metric we can surface.
+   */
+  private _itemStartedAt: Map<string, number> = new Map();
+
   /** FIFO event queue for ordered emission. */
   private eventQueue: AgentEvent[] = [];
   private drainTimer: ReturnType<typeof setInterval> | null = null;
@@ -1190,6 +1199,11 @@ class CodexProcess implements AgentProcess {
   }
 
   private normalizeItemStarted(item: any): AgentEvent | null {
+    // Record start timestamp for any item with an id, so item/completed can
+    // compute durationMs. Cheap to do unconditionally — items without an id
+    // (rare) just don't get duration tracking.
+    if (item.id) this._itemStartedAt.set(item.id, Date.now());
+
     switch (item.type) {
       case "command_execution":
       case "commandExecution":
@@ -1242,16 +1256,53 @@ class CodexProcess implements AgentProcess {
           timestamp: Date.now(),
         };
 
+      case "image_generation":
+      case "imageGeneration":
+        // OpenAI's hosted image_generation tool — `revised_prompt` and
+        // `result` are empty at start; they get populated in item/completed.
+        return {
+          type: "tool_use",
+          message: "image_generation",
+          data: {
+            toolName: "image_generation",
+            id: item.id,
+            streaming: true,
+          },
+          timestamp: Date.now(),
+        };
+
       case "userMessage":
       case "user_message":
         return null; // echo of user input — skip
 
       default:
-        return null;
+        // Fail-open: forward any item.type SNA doesn't have a specific
+        // shape for as a generic tool_use. Without this, new Codex tool
+        // types ship to consumers as silent invisibility — they happen
+        // but nothing surfaces. `data.raw` carries the full payload so
+        // advanced consumers can render it specifically before SNA
+        // catches up with an explicit case.
+        return {
+          type: "tool_use",
+          message: item.type ?? "unknown",
+          data: {
+            toolName: item.type ?? "unknown",
+            id: item.id,
+            streaming: true,
+            raw: item,
+          },
+          timestamp: Date.now(),
+        };
     }
   }
 
   private normalizeItemCompleted(item: any): AgentEvent | null {
+    // Pop the start timestamp if we recorded one, so the Map doesn't grow
+    // unbounded across a long-running session.
+    const startedAt = item.id ? this._itemStartedAt.get(item.id) : undefined;
+    if (item.id) this._itemStartedAt.delete(item.id);
+    const durationMs = startedAt !== undefined ? Date.now() - startedAt : undefined;
+
     switch (item.type) {
       case "agent_message":
       case "agentMessage":
@@ -1279,6 +1330,7 @@ class CodexProcess implements AgentProcess {
             exitCode: item.exit_code ?? item.exitCode,
             status: item.status,
             isError: item.status === "failed" || item.status === "declined",
+            durationMs,
           },
           timestamp: Date.now(),
         };
@@ -1294,6 +1346,7 @@ class CodexProcess implements AgentProcess {
             changes: item.changes,
             status: item.status,
             isError: item.status === "failed",
+            durationMs,
           },
           timestamp: Date.now(),
         };
@@ -1309,6 +1362,7 @@ class CodexProcess implements AgentProcess {
             toolName: `${item.server}:${item.tool}`,
             id: item.id,
             isError: !!item.error || item.status === "failed",
+            durationMs,
           },
           timestamp: Date.now(),
         };
@@ -1318,7 +1372,26 @@ class CodexProcess implements AgentProcess {
         return {
           type: "tool_result",
           message: "Web search completed",
-          data: { toolName: "web_search", id: item.id },
+          data: { toolName: "web_search", id: item.id, durationMs },
+          timestamp: Date.now(),
+        };
+
+      case "image_generation":
+      case "imageGeneration":
+        // saved_path is set by codex daemon after writing the PNG;
+        // see codex-rs/core/src/stream_events_utils.rs:save_image_generation_result.
+        return {
+          type: "tool_result",
+          message: item.saved_path ?? item.savedPath ?? "Image generation completed",
+          data: {
+            toolName: "image_generation",
+            id: item.id,
+            savedPath: item.saved_path ?? item.savedPath,
+            revisedPrompt: item.revised_prompt ?? item.revisedPrompt,
+            status: item.status,
+            isError: item.status === "failed",
+            durationMs,
+          },
           timestamp: Date.now(),
         };
 
@@ -1334,7 +1407,25 @@ class CodexProcess implements AgentProcess {
         };
 
       default:
-        return null;
+        // Fail-open: forward any item.type SNA doesn't have a specific
+        // shape for. Without this, new Codex tool types ship to consumers
+        // as silent invisibility — the model invoked something but the
+        // event never surfaces. `data.raw` carries the full payload so
+        // advanced consumers can render it before SNA catches up with an
+        // explicit case.
+        return {
+          type: "tool_result",
+          message: item.text ?? item.message ?? `${item.type ?? "unknown"} completed`,
+          data: {
+            toolName: item.type ?? "unknown",
+            id: item.id,
+            status: item.status,
+            isError: item.status === "failed",
+            durationMs,
+            raw: item,
+          },
+          timestamp: Date.now(),
+        };
     }
   }
 }

--- a/packages/core/test/codex-item-normalization.test.ts
+++ b/packages/core/test/codex-item-normalization.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Verifies how CodexProcess normalizes turn-level item events.
+ *
+ * The interesting cases are the ones that *weren't* surfaced before:
+ *   - image_generation gets its own shape (toolName, savedPath, revisedPrompt)
+ *   - unknown item types are forwarded as generic tool_use/tool_result with
+ *     `data.raw` (fail-open), instead of silently dropped (fail-closed).
+ *   - tool_result events carry `durationMs` derived from the item/started
+ *     → item/completed delta, so consumers can show "this took N seconds"
+ *     for hosted tools that have no intermediate progress signal.
+ */
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { CodexProvider } from "../src/core/providers/codex.js";
+import type { AgentEvent } from "../src/core/providers/types.js";
+import { startMockCodexAppServer, type MockCodexServer } from "./mock-codex-app-server.js";
+
+async function waitFor(fn: () => boolean, timeoutMs = 2500, intervalMs = 25): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+describe("CodexProcess — item normalization", () => {
+  let mock: MockCodexServer;
+  const origCodexCmd = process.env.SNA_CODEX_COMMAND;
+  const origTurnNotifications = process.env.CODEX_MOCK_TURN_NOTIFICATIONS;
+
+  before(() => {
+    mock = startMockCodexAppServer();
+    process.env.SNA_CODEX_COMMAND = mock.command;
+  });
+
+  after(() => {
+    if (origCodexCmd === undefined) delete process.env.SNA_CODEX_COMMAND;
+    else process.env.SNA_CODEX_COMMAND = origCodexCmd;
+    if (origTurnNotifications === undefined) delete process.env.CODEX_MOCK_TURN_NOTIFICATIONS;
+    else process.env.CODEX_MOCK_TURN_NOTIFICATIONS = origTurnNotifications;
+    mock.close();
+  });
+
+  beforeEach(() => {
+    mock.reset();
+    delete process.env.CODEX_MOCK_TURN_NOTIFICATIONS;
+  });
+
+  it("forwards image_generation lifecycle as tool_use (start) + tool_result (savedPath + revisedPrompt + duration)", async () => {
+    process.env.CODEX_MOCK_TURN_NOTIFICATIONS = JSON.stringify([
+      {
+        jsonrpc: "2.0",
+        method: "item/started",
+        params: {
+          item: {
+            type: "image_generation",
+            id: "ig_42",
+            status: "in_progress",
+          },
+        },
+      },
+      // brief pause so duration is non-zero in the test
+      // (the mock writes events synchronously, but Date.now ticks ms)
+      {
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          item: {
+            type: "image_generation",
+            id: "ig_42",
+            status: "completed",
+            revised_prompt: "A watercolor of a cat hugging an otter",
+            saved_path: "/tmp/codex_home/sess1/ig_42.png",
+          },
+        },
+      },
+    ]);
+
+    const provider = new CodexProvider();
+    const proc = provider.spawn({ cwd: process.cwd(), prompt: "draw me a cat" });
+    const events: AgentEvent[] = [];
+    proc.on("event", (e) => events.push(e));
+
+    await waitFor(() => events.some((e) => e.type === "complete"));
+    proc.kill();
+
+    const toolUses = events.filter(
+      (e) => e.type === "tool_use" && (e.data as any)?.toolName === "image_generation",
+    );
+    const toolResults = events.filter(
+      (e) => e.type === "tool_result" && (e.data as any)?.toolName === "image_generation",
+    );
+
+    assert.equal(toolUses.length, 1, "exactly one image_generation tool_use (the start)");
+    assert.equal((toolUses[0]?.data as any)?.streaming, true);
+    assert.equal((toolUses[0]?.data as any)?.id, "ig_42");
+
+    assert.equal(toolResults.length, 1);
+    const completed = toolResults[0]!;
+    assert.equal((completed.data as any).savedPath, "/tmp/codex_home/sess1/ig_42.png");
+    assert.equal((completed.data as any).revisedPrompt, "A watercolor of a cat hugging an otter");
+    assert.equal((completed.data as any).status, "completed");
+    assert.equal((completed.data as any).isError, false);
+    assert.equal(typeof (completed.data as any).durationMs, "number");
+    assert.ok((completed.data as any).durationMs >= 0);
+  });
+
+  it("forwards unknown item types as generic tool_use / tool_result with raw payload (fail-open)", async () => {
+    process.env.CODEX_MOCK_TURN_NOTIFICATIONS = JSON.stringify([
+      {
+        jsonrpc: "2.0",
+        method: "item/started",
+        params: {
+          item: {
+            type: "future_widget",
+            id: "fw_7",
+            status: "in_progress",
+            custom_field: "hello",
+          },
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          item: {
+            type: "future_widget",
+            id: "fw_7",
+            status: "completed",
+            custom_field: "hello",
+            result_value: 42,
+          },
+        },
+      },
+    ]);
+
+    const provider = new CodexProvider();
+    const proc = provider.spawn({ cwd: process.cwd(), prompt: "do the future widget thing" });
+    const events: AgentEvent[] = [];
+    proc.on("event", (e) => events.push(e));
+
+    await waitFor(() => events.some((e) => e.type === "complete"));
+    proc.kill();
+
+    const toolUses = events.filter(
+      (e) => e.type === "tool_use" && (e.data as any)?.toolName === "future_widget",
+    );
+    const toolResults = events.filter(
+      (e) => e.type === "tool_result" && (e.data as any)?.toolName === "future_widget",
+    );
+
+    assert.equal(toolUses.length, 1, "unknown item.type should still produce a tool_use");
+    assert.equal((toolUses[0]?.data as any)?.id, "fw_7");
+    assert.equal((toolUses[0]?.data as any)?.streaming, true);
+    // Raw payload is attached so consumers can introspect.
+    assert.equal((toolUses[0]?.data as any)?.raw?.custom_field, "hello");
+
+    assert.equal(toolResults.length, 1);
+    const completed = toolResults[0]!;
+    assert.equal((completed.data as any).id, "fw_7");
+    assert.equal((completed.data as any).status, "completed");
+    assert.equal((completed.data as any).isError, false);
+    assert.equal((completed.data as any).raw?.result_value, 42);
+    assert.equal(typeof (completed.data as any).durationMs, "number");
+  });
+
+  it("marks unknown items as isError when status is 'failed'", async () => {
+    process.env.CODEX_MOCK_TURN_NOTIFICATIONS = JSON.stringify([
+      {
+        jsonrpc: "2.0",
+        method: "item/started",
+        params: { item: { type: "future_widget", id: "fw_8", status: "in_progress" } },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: { item: { type: "future_widget", id: "fw_8", status: "failed" } },
+      },
+    ]);
+
+    const provider = new CodexProvider();
+    const proc = provider.spawn({ cwd: process.cwd(), prompt: "fail it" });
+    const events: AgentEvent[] = [];
+    proc.on("event", (e) => events.push(e));
+
+    await waitFor(() => events.some((e) => e.type === "complete"));
+    proc.kill();
+
+    const result = events.find(
+      (e) => e.type === "tool_result" && (e.data as any)?.toolName === "future_widget",
+    );
+    assert.ok(result, "fail-open default should still emit a tool_result");
+    assert.equal((result!.data as any).isError, true);
+    assert.equal((result!.data as any).status, "failed");
+  });
+});

--- a/packages/core/test/mock-codex-app-server.ts
+++ b/packages/core/test/mock-codex-app-server.ts
@@ -64,6 +64,22 @@ const writeLine = (obj) => {
 let threadCounter = 0;
 let turnCounter = 0;
 
+// Tests inject custom notifications between turn/started and turn/completed
+// by setting CODEX_MOCK_TURN_NOTIFICATIONS to a JSON-encoded array of
+// JSON-RPC notification objects. Used to simulate hosted-tool lifecycles
+// (image_generation, web_search, ...) and unknown item types without
+// touching the real codex binary.
+function mockTurnNotifications() {
+  const raw = process.env.CODEX_MOCK_TURN_NOTIFICATIONS;
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 function handle(msg) {
   appendLog(msg);
 
@@ -128,6 +144,9 @@ function handle(msg) {
         method: "turn/started",
         params: { turn: { id: turnId } },
       });
+      for (const notification of mockTurnNotifications()) {
+        writeLine(notification);
+      }
       writeLine({
         jsonrpc: "2.0",
         method: "turn/completed",


### PR DESCRIPTION
## Summary

Three improvements to `CodexProcess.normalizeItem{Started,Completed}`,
sharing the same fix shape:

### 1. Fail-open default (architectural)

The `default: return null` in both switches silently dropped any item
whose `type` SNA didn't have an explicit case for. That means every
new Codex tool type ships to consumers as **invisibility** — the model
invoked something but no event reaches the chat UI. `image_generation`
is the current symptom, but the trap catches any future addition.

`default` now forwards as generic `tool_use` / `tool_result` with
`data.toolName = item.type` and `data.raw = item` carrying the full
payload. Known types still get their specific shapes (shell with
`command`, web_search with `query`, etc.); unknown types get something
honest the UI can render as `"🔧 <type>"` rather than nothing.

The top-level method switch is unchanged — it deals in session/thread
metadata (`thread/name/updated`, `mcpServer/startupStatus/updated`,
...) where silent drops are the right behaviour.

### 2. image_generation explicit shape

OpenAI's hosted `image_generation` tool fires `item/started` with an
empty result and `item/completed` with `revised_prompt` + `result`
(base64 PNG) + `saved_path` set by the daemon. SNA now emits:

  - `tool_use { toolName: "image_generation", id, streaming: true }`
    on `item/started` — for spinner UX
  - `tool_result { toolName: "image_generation", id, savedPath, revisedPrompt, status, isError, durationMs }`
    on `item/completed` — for chat-embed insertion

Consumers wanting browser-side rendering still need to handle the
absolute filesystem path (e.g. via a future `/agent/artifacts/...`
HTTP route or by reading directly in Electron); that's deliberately
out of scope here.

### 3. durationMs on every tool_result

Hosted tools (image_generation, web_search) have no intermediate
progress signal — they go silent between started and completed for up
to tens of seconds. **Duration is the only honest latency metric we
can surface.**

`_itemStartedAt: Map<itemId, ms>` records the start timestamp on every
`item/started`; `item/completed` pops it and computes
`durationMs = Date.now() - startedAt`. Cheap to track unconditionally,
and the map is bounded by turn lifetime since item ids are turn-scoped.
durationMs flows through every tool_result shape (shell, file_change,
mcp_tool_call, web_search, image_generation, and the fail-open default).

## Why this matters

A consumer doing this today:

```ts
sna.agent.onEvent(({ event }) => {
  if (event.type === "tool_use" && event.data?.toolName === "image_generation" && event.data?.streaming) {
    showSpinner("Generating image...");
  }
  if (event.type === "tool_result" && event.data?.toolName === "image_generation") {
    hideSpinner();
    renderImage(event.data.savedPath);
    console.log(`Took ${event.data.durationMs}ms`);
  }
});
```

…can now build the entire image-generation chat UX. Same pattern works
for any future Codex tool because of fail-open: even if SNA doesn't
recognize the type, the consumer still sees the event and can render
`data.toolName` generically while we iterate.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] 70/70 tests pass (existing 67 + new 3 in `codex-item-normalization.test.ts`)
- [x] Three end-to-end cases via mock codex app-server:
  - image_generation lifecycle: tool_use (start) + tool_result with savedPath + revisedPrompt + durationMs
  - unknown item.type (`future_widget`): forwarded with `data.raw` carrying the full payload
  - unknown item.type with status: "failed": still emitted, isError = true

## Test scaffolding restored

`mock-codex-app-server.ts` regains the `CODEX_MOCK_TURN_NOTIFICATIONS`
hook that was present in the v0.13.0-era work but got lost during the
v0.14.0 reconciliation (we thought origin's PR #20 superseded it;
turns out those were different changes). The hook lets tests inject
arbitrary JSON-RPC notifications between turn/started and turn/completed.

## Release notes

Patch-level (0.15.x → 0.15.2 or 0.16.0). Behaviour change:
- Existing consumers that explicitly check `event.data?.toolName` against
  the known set ("shell", "file_change", "mcp_tool_call", "web_search")
  see no change.
- Consumers that handle "any tool_use" generically now receive events
  for image_generation and any future Codex item types they previously
  didn't know about.
- `tool_result.data.durationMs` is a new optional field. Strict-mode
  consumers can ignore it; consumers wanting "this took N seconds"
  display can use it.

Triggered by user feedback noting that image_generation events were
invisible in the chat UI even though the model was clearly invoking
the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)