### PR TITLE
feat: Grok Build (xAI) provider via ACP-over-stdio

### DIFF
--- a/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
@@ -1,0 +1,146 @@
+---
+title: 機能 × プロバイダマトリクス
+description: SNA の各機能が Claude Code、Codex、OpenCode、Grok Build でどう動くか — 行ごとの注意点付き。
+icon: TableProperties
+---
+
+SNA のすべての機能は同じ `AgentProvider` インタフェースを通りますが、
+各ランタイムは自前のネイティブ表面を持っているため、4 つのプロバイダ
+の能力が完全に揃うわけではありません。このページでは、どの機能が
+どこで実際に動くかを行ごとの注意点付きで列挙します。
+
+行が **✗** のとき、SNA API レベルではフィールドを受け付けるものの、
+プロバイダは無視するか respawn にフォールバックするか、対応する
+ネイティブ表面そのものを持たないことを意味します。
+
+> 最終検証対象: Claude Code 1.x, Codex 0.x (`app-server`),
+> OpenCode 0.x (`serve`), Grok Build CLI 0.1.x.
+
+## ランタイム特性
+
+| 能力 | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| ワイヤプロトコル | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio |
+| `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ |
+| `supportsCwdPerThread` | 該当なし | ✓ | ✗ | 該当なし |
+| 公開標準プロトコル | ✗ ベンダ | ✗ ベンダ | ✗ ベンダ | ✓ [ACP](https://agentclientprotocol.com) |
+| Cold-start コスト | 呼び出しごとに約 1 秒 spawn | デーモン約 2 秒 spawn、再利用 | デーモン約 3 秒 spawn、再利用 | セッションごとに約 2 秒 spawn |
+
+Claude Code と Grok Build は呼び出し/セッション単位で stateless —
+spawn ごとに新しい子プロセス。Codex と OpenCode は `RuntimePool` を
+通じてデーモンを共有します。Codex のデーモンだけが `cwd`-非依存なの
+で、単一プールのデーモン上で異なる作業ディレクトリのセッションを
+ホストできる唯一のプロバイダです。
+
+## セッションライフサイクル
+
+| 能力 | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `spawn(opts)` → AgentProcess | ✓ | ✓ | ✓ | ✓ |
+| セッション中の `AgentEvent` ストリーミング | ✓ | ✓ | ✓ | ✓ |
+| turn 中の `interrupt()` | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) |
+| `kill()` / `closeThread()` | ✓ | ✓ (プール refcount 認識) | ✓ (プール refcount 認識) | ✓ |
+| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) |
+| `complete()` `onDelta` ストリーミング | ✓ stream-json | ✓ `item/agentMessage/delta` | ✗ 現状の SDK 呼び出しは single-shot | ✓ streaming-json text イベント |
+| `listModels()` | ✓ static + oMLX API | ✓ static catalog | ✓ `opencode` CLI プローブ | ✓ static (単一: `grok-build`) |
+
+OpenCode はストリーミングで例外です。現在の SDK ヘルパが single-shot
+のため、`complete()` に `onDelta` を渡しても成功はしますがコール
+バックは発火しません。`complete()` の戻り値自体は正しいです。
+
+## インプレース変更 (`applyPatch`)
+
+各プロバイダは、どの `SessionPatch` フィールドを respawn なしで
+インプレース適用できるかを宣言します。「leftover」として返された
+フィールドは、セッションマネージャが kill して history replay と
+ともに respawn する必要があります。
+
+| フィールド | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `model` | ✓ control_request `set_model` | ✓ 次 turn override | ✓ per-session override | ✗ leftover (respawn) |
+| `permissionMode` | ✓ control_request | ✓ 次 turn sandbox policy | ✓ per-session override | ✗ leftover (respawn) |
+| `cwd` | ✗ leftover | ✓ 次 turn override (唯一可能なプロバイダ) | ✗ leftover | ✗ leftover |
+
+Grok Build はすべてのフィールドを leftover として返します。ACP には
+ランタイム変更メソッドがなく、カタログにモデルが 1 つしかないため
+`setModel` で切り替える先もないからです。2 つ目のモデルが追加されても、
+history replay 付きの respawn は変わらず動きます。
+
+## 権限フロー
+
+| 能力 | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `permission_needed` AgentEvent emit | ✓ hook ブリッジ経由 | ✓ JSON-RPC server-request 経由 | ✓ HTTP webhook 経由 | ✓ ACP `session/request_permission` 経由 |
+| `respondToPermission(id, approved)` | ✗ 外部 hook スクリプトが承認処理 | ✓ JSON-RPC response | ✓ POST `/permissions/:id` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` |
+| 双方向 (プロバイダがこちらを待つ) | ✗ hook スクリプトが決定 | ✓ | ✓ | ✓ |
+
+Claude Code の権限モデルは out-of-band です — SNA が hook スクリプトを
+書いておくと CLI がそれを呼び、スクリプトが (permissionMode と
+allow/deny ルールに基づいて) 自分で判断し、CLI は SNA プロセスを
+待ちません。他の 3 つは双方向です: エージェントの turn は SNA の
+権限レスポンス到着まで一時停止します。Claude Code の
+`respondToPermission` は設計上 no-op です。
+
+## 設定ノブ (SpawnOptions)
+
+| フィールド | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start` の `baseInstructions` | ✓ `appendSystemPrompt` と結合 | ✓ `--system-prompt-override` |
+| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start` の `developerInstructions` | ✓ `systemPrompt` と結合 | ✓ `--rules` |
+| `allowedTools` | ✓ ネイティブ `--allowedTools` | ✓ PreToolUse hook (他を deny) | ⚠ best-effort (既知のツールのみトグル) | ✓ `--tools` 許可リスト |
+| `disallowedTools` | ✓ ネイティブ `--disallowedTools` | ✓ PreToolUse hook | ✓ 列挙されたツールを無効化 | ✓ `--disallowed-tools` |
+| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` に書き出し | ✓ SDK 経由 | ⚠ `session/new` は受け付けるが SNA からはまだ配線していない |
+| `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 無視 | ✓ `toGrokEffort` → `--reasoning-effort` |
+| `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 対応なし | ✗ 対応なし (Grok Build は `~/.grok` 固定) |
+| `resumeSessionId` | ✓ JSONL replay ファイル経由 | ✓ `thread/resume` API | ✓ session id | ⚠ Grok Build 自身のセッション id で resume は動くが、クロスプロバイダ history は下記 `resource` block 経路 |
+
+### `providerOptions` (プロバイダごとの escape hatch)
+
+| キー | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `settings` | ✓ `--settings` JSON にマージ | ✓ 同じ hook shape | — | — |
+| `settingSources` | ✓ `--setting-sources` | — | — | — |
+| `strictMcpConfig` | ✓ `--strict-mcp-config` | — | — | — |
+| `maxTurns` | ✓ `--max-turns` | — | — | — |
+| `omlxBaseUrl` | ✓ `ANTHROPIC_BASE_URL` をルーティング | — | — | — |
+| `serviceTier` | ✗ 誤課金 (`/fast` はモデルであって tier ではない) | ✓ `priority` / `flex` / `batch` | — | — |
+| `profile` | — | ✓ `config.toml` プロファイル | — | — |
+| `config` (`-c key=value`) | — | ✓ `codex exec` オーバーライド | — | — |
+| `serverUrl` | — | — | ✓ spawn を飛ばして既存デーモンに attach | — |
+| `modelProviderId` | — | — | ✓ `{providerID, modelID}` の provider 半分 | — |
+| `agent` | — | — | ✓ build / plan / etc. | — |
+| `logLevel` | — | — | ✓ `opencode serve --log-level` | — |
+
+## クロスプロバイダ history replay
+
+各プロバイダは新しいセッションに過去の会話を seed するための独自
+機構を持っています。SNA の正規化 `CanonicalBlock[]` history は
+アダプタ層でネイティブな形に翻訳されます。
+
+| プロバイダ | 機構 | アダプタ |
+|---|---|---|
+| Claude Code | Anthropic フォーマットの JSONL を書き出し、パスを `--resume <filepath>` に渡す | `history/claude-code.ts` |
+| Codex | `thread/resume(history=ResponseItems)` JSON-RPC | `history/codex.ts` |
+| OpenCode | SDK 経由の experimental `thread/resume(history=...)` | `history/opencode.ts` |
+| Grok Build | 最初の `session/prompt` で transcript を 1 個の ACP `resource` content block にシリアライズ | `core/providers/grok.ts` インライン (デザイン probe のオプション B) |
+
+Grok Build の経路は意図的に異なります: ACP の `session/load` は UI
+イベントを replay するだけでモデルコンテキストを復元せず、その下の
+`chat_history.jsonl` ストレージは xAI 内部フォーマットで session load
+時に再生成されるため — ストレージ層には触れない方針です。代わりに
+最初の turn で過去の transcript をインラインで埋め込み、そのコンテキ
+ストは同じセッションの後続 turn でも保持されるため、再注入は不要です。
+
+## まだマトリクスに無いもの
+
+- **plan mode のランタイム切り替え** (Claude Code `--permission-mode plan`、
+  Grok Build `--permission-mode plan`): CLI フラグは spawn 時に反映
+  されますが、インプレース切り替えには `permissionMode` patch サポート
+  が必要で、Grok Build はまだ持っていません。
+- **Grok Build の MCP 配線**: ACP `session/new` は `mcpServers` 配列
+  を受け付けますが、現在 SNA は `[]` を渡しています。SNA の MCP 設定
+  を経路で渡すのは後続タスクです。
+- **プロンプトへの画像入力**: 4 つのプロバイダはすべて何らかの形で
+  画像 block を受け付けますが、プロバイダごとの添付エンコーディング
+  はまだ揃っていません — 現状は
+  [セッション › 添付](/ja/docs/introduction/sessions) を参照。

--- a/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
@@ -1,0 +1,144 @@
+---
+title: 기능 × 프로바이더 매트릭스
+description: 어떤 SNA 기능이 Claude Code, Codex, OpenCode, Grok Build에서 동작하는지 — 각 행마다 단서 조건과 함께.
+icon: TableProperties
+---
+
+모든 SNA 기능은 같은 `AgentProvider` 인터페이스를 거치지만, 각 런타임은
+자체 네이티브 표면이 다르기 때문에 4개 프로바이더의 능력이 완전히
+일치하지는 않습니다. 이 페이지는 어디서 무엇이 실제로 동작하는지,
+각 행의 단서 조건을 명시해서 나열합니다.
+
+행이 **✗** 인 경우, SNA API 레벨에서 해당 필드를 받아주긴 하지만
+프로바이더가 그것을 무시하거나, respawn으로 fallback하거나, 대응되는
+네이티브 표면 자체가 없다는 뜻입니다.
+
+> 마지막 검증 대상: Claude Code 1.x, Codex 0.x (`app-server`),
+> OpenCode 0.x (`serve`), Grok Build CLI 0.1.x.
+
+## 런타임 특성
+
+| 능력 | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| 와이어 프로토콜 | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio |
+| `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ |
+| `supportsCwdPerThread` | 해당 없음 | ✓ | ✗ | 해당 없음 |
+| 공개 표준 프로토콜 | ✗ 벤더 | ✗ 벤더 | ✗ 벤더 | ✓ [ACP](https://agentclientprotocol.com) |
+| Cold-start 비용 | 호출당 약 1초 spawn | 데몬 약 2초 spawn, 재사용 | 데몬 약 3초 spawn, 재사용 | 세션당 약 2초 spawn |
+
+Claude Code와 Grok Build은 호출/세션 단위로 무상태입니다 — spawn마다
+새 자식 프로세스. Codex와 OpenCode는 `RuntimePool`을 통해 데몬을
+공유합니다. Codex 데몬만 `cwd`-비종속이라서, 단일 풀 데몬 위에서
+서로 다른 작업 디렉토리의 세션을 호스팅할 수 있는 유일한 프로바이더
+입니다.
+
+## 세션 라이프사이클
+
+| 능력 | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `spawn(opts)` → AgentProcess | ✓ | ✓ | ✓ | ✓ |
+| 세션 중 `AgentEvent` 스트리밍 | ✓ | ✓ | ✓ | ✓ |
+| turn 중간 `interrupt()` | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) |
+| `kill()` / `closeThread()` | ✓ | ✓ (풀 refcount 인식) | ✓ (풀 refcount 인식) | ✓ |
+| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) |
+| `complete()` `onDelta` 스트리밍 | ✓ stream-json | ✓ `item/agentMessage/delta` | ✗ 현재 SDK 호출이 single-shot | ✓ streaming-json text 이벤트 |
+| `listModels()` | ✓ static + oMLX API | ✓ static catalog | ✓ `opencode` CLI 프로브 | ✓ static (`grok-build` 단일 항목) |
+
+OpenCode는 스트리밍에서 예외입니다. 현재 SDK 헬퍼가 single-shot이라
+`complete()`에 `onDelta`를 넘기면 성공하지만 콜백은 발화하지 않습니다.
+`complete()` 반환값 자체는 정상입니다.
+
+## 인플레이스 변경 (`applyPatch`)
+
+각 프로바이더는 어느 `SessionPatch` 필드를 respawn 없이 인플레이스로
+적용할 수 있는지 선언합니다. "leftover"로 반환된 필드는 세션 매니저가
+kill 후 history replay와 함께 respawn해야 합니다.
+
+| 필드 | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `model` | ✓ control_request `set_model` | ✓ next-turn override | ✓ per-session override | ✗ leftover (respawn) |
+| `permissionMode` | ✓ control_request | ✓ next-turn sandbox 정책 | ✓ per-session override | ✗ leftover (respawn) |
+| `cwd` | ✗ leftover | ✓ next-turn override (유일하게 가능한 프로바이더) | ✗ leftover | ✗ leftover |
+
+Grok Build은 모든 필드를 leftover로 반환합니다. ACP에 런타임 변경
+메서드가 없고, 카탈로그에 모델이 하나뿐이라 `setModel`이 바꿔낼
+대상도 없기 때문입니다. 두 번째 모델이 추가되더라도 history replay
+respawn은 여전히 동작합니다.
+
+## 권한 흐름
+
+| 능력 | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `permission_needed` AgentEvent emit | ✓ hook 브릿지 경유 | ✓ JSON-RPC server-request 경유 | ✓ HTTP webhook 경유 | ✓ ACP `session/request_permission` 경유 |
+| `respondToPermission(id, approved)` | ✗ 외부 hook 스크립트가 승인 처리 | ✓ JSON-RPC response | ✓ POST `/permissions/:id` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` |
+| 양방향 (프로바이더가 우리를 기다림) | ✗ hook 스크립트가 결정 | ✓ | ✓ | ✓ |
+
+Claude Code의 권한 모델은 out-of-band입니다 — SNA가 hook 스크립트를
+써놓으면 CLI가 그것을 호출하고, 스크립트가 (permissionMode 및 allow/deny
+룰을 기준으로) 스스로 판단하며, CLI는 SNA 프로세스를 기다리지 않습니다.
+다른 세 프로바이더는 양방향입니다: 에이전트의 turn이 SNA의 권한 응답
+도착까지 일시정지합니다. Claude Code의 `respondToPermission`은 설계상
+no-op입니다.
+
+## 설정 노브 (SpawnOptions)
+
+| 필드 | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start`의 `baseInstructions` | ✓ `appendSystemPrompt`와 결합 | ✓ `--system-prompt-override` |
+| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start`의 `developerInstructions` | ✓ `systemPrompt`와 결합 | ✓ `--rules` |
+| `allowedTools` | ✓ 네이티브 `--allowedTools` | ✓ PreToolUse hook (나머지 거부) | ⚠ best-effort (알려진 도구만 토글) | ✓ `--tools` 허용 목록 |
+| `disallowedTools` | ✓ 네이티브 `--disallowedTools` | ✓ PreToolUse hook | ✓ 나열된 도구 비활성 | ✓ `--disallowed-tools` |
+| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` 기록 | ✓ SDK 경유 | ⚠ `session/new`가 받지만 SNA에서 아직 와이어링 안 됨 |
+| `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 무시 | ✓ `toGrokEffort` → `--reasoning-effort` |
+| `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 대응 없음 | ✗ 대응 없음 (Grok Build은 `~/.grok` 고정) |
+| `resumeSessionId` | ✓ JSONL replay 파일 경유 | ✓ `thread/resume` API | ✓ 세션 id | ⚠ Grok Build 자체 세션 id로 resume은 동작하지만, 크로스 프로바이더 history는 아래 `resource` block 경로 사용 |
+
+### `providerOptions` (프로바이더별 escape hatch)
+
+| 키 | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `settings` | ✓ `--settings` JSON에 병합 | ✓ 같은 hook shape | — | — |
+| `settingSources` | ✓ `--setting-sources` | — | — | — |
+| `strictMcpConfig` | ✓ `--strict-mcp-config` | — | — | — |
+| `maxTurns` | ✓ `--max-turns` | — | — | — |
+| `omlxBaseUrl` | ✓ `ANTHROPIC_BASE_URL` 라우팅 | — | — | — |
+| `serviceTier` | ✗ 잘못 과금됨 (`/fast`는 모델, tier가 아님) | ✓ `priority` / `flex` / `batch` | — | — |
+| `profile` | — | ✓ `config.toml` 프로파일 | — | — |
+| `config` (`-c key=value`) | — | ✓ `codex exec` 오버라이드 | — | — |
+| `serverUrl` | — | — | ✓ spawn 생략, 기존 데몬에 attach | — |
+| `modelProviderId` | — | — | ✓ `{providerID, modelID}`의 provider 절반 | — |
+| `agent` | — | — | ✓ build / plan / etc. | — |
+| `logLevel` | — | — | ✓ `opencode serve --log-level` | — |
+
+## 프로바이더 간 history replay
+
+모든 프로바이더가 새 세션에 이전 대화를 시드하는 자체 메커니즘을
+가지고 있습니다. SNA의 정규화 `CanonicalBlock[]` history가 어댑터
+계층에서 네이티브 형태로 번역됩니다.
+
+| 프로바이더 | 메커니즘 | 어댑터 |
+|---|---|---|
+| Claude Code | Anthropic 포맷 JSONL 작성 → `--resume <filepath>`로 경로 전달 | `history/claude-code.ts` |
+| Codex | `thread/resume(history=ResponseItems)` JSON-RPC | `history/codex.ts` |
+| OpenCode | SDK 경유 experimental `thread/resume(history=...)` | `history/opencode.ts` |
+| Grok Build | 첫 `session/prompt`에서 transcript를 단일 ACP `resource` content block으로 직렬화 | `core/providers/grok.ts` 인라인 (디자인 probe의 옵션 B) |
+
+Grok Build 경로는 의도적으로 다릅니다: probing 결과 ACP `session/load`는
+UI 이벤트만 replay할 뿐 모델 컨텍스트를 복원하지 않고, 아래 깔린
+`chat_history.jsonl` 저장소는 xAI 내부 포맷이고 session load 시
+재생성되기 때문에 — 우리는 저장 계층을 아예 건드리지 않습니다. 대신
+첫 turn에 prior transcript를 인라인으로 embed하고, 그 컨텍스트는 같은
+세션의 후속 turn에서도 유지되므로 재주입은 불필요합니다.
+
+## 아직 매트릭스에 없는 것
+
+- **런타임 plan mode 토글** (Claude Code `--permission-mode plan`,
+  Grok Build `--permission-mode plan`): CLI 플래그는 spawn 시점에 반영
+  되지만, 인플레이스 토글은 `permissionMode` patch 지원이 필요한데
+  Grok Build은 아직 지원하지 않습니다.
+- **Grok Build의 MCP 와이어링**: ACP `session/new`는 `mcpServers`
+  배열을 받지만 SNA가 현재 `[]`를 넘깁니다. SNA의 MCP 설정을 throughs로
+  전달하는 작업은 후속 과제입니다.
+- **프롬프트 이미지 입력**: 4개 프로바이더 모두 어떤 형태로든 이미지
+  block을 받지만, 프로바이더별 첨부 인코딩이 아직 일관되지 않습니다 —
+  현재 상태는 [세션 › 첨부](/ko/docs/introduction/sessions) 참조.

--- a/apps/docs/content/docs/introduction/feature-matrix.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.mdx
@@ -1,0 +1,146 @@
+---
+title: Feature × provider matrix
+description: Which SNA features work with Claude Code, Codex, OpenCode, and Grok Build — with the caveats spelled out per row.
+icon: TableProperties
+---
+
+Every SNA feature flows through the same `AgentProvider` interface, but
+each runtime has its own native surface — so capabilities don't line up
+perfectly across the four. This page enumerates what actually works
+where, with the caveats spelled out per row.
+
+If a row says **✗**, the field is accepted at the SNA API but the
+provider either ignores it, falls back to respawn, or has no equivalent
+native surface.
+
+> Last verified against: Claude Code 1.x, Codex 0.x (`app-server`),
+> OpenCode 0.x (`serve`), Grok Build CLI 0.1.x.
+
+## Runtime characteristics
+
+| Capability | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| Wire protocol | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio |
+| `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ |
+| `supportsCwdPerThread` | n/a | ✓ | ✗ | n/a |
+| Public-standard protocol | ✗ vendor | ✗ vendor | ✗ vendor | ✓ [ACP](https://agentclientprotocol.com) |
+| Cold-start cost | ≈1s spawn per call | ≈2s daemon spawn, reused | ≈3s daemon spawn, reused | ≈2s spawn per session |
+
+Claude Code and Grok Build are stateless per call/session — a fresh
+child process per spawn. Codex and OpenCode share daemons through
+`RuntimePool`. Only Codex's daemon is `cwd`-agnostic, which is why it's
+the only provider that can host sessions for different working
+directories on a single pooled daemon.
+
+## Session lifecycle
+
+| Capability | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `spawn(opts)` → AgentProcess | ✓ | ✓ | ✓ | ✓ |
+| Streaming `AgentEvent` during session | ✓ | ✓ | ✓ | ✓ |
+| `interrupt()` mid-turn | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) |
+| `kill()` / `closeThread()` | ✓ | ✓ (pool refcount aware) | ✓ (pool refcount aware) | ✓ |
+| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) |
+| `complete()` `onDelta` streaming | ✓ stream-json | ✓ `item/agentMessage/delta` | ✗ SDK call is single-shot today | ✓ streaming-json text events |
+| `listModels()` | ✓ static + oMLX API | ✓ static catalog | ✓ probes `opencode` CLI | ✓ static (single entry: `grok-build`) |
+
+OpenCode is the odd one out on streaming: its current SDK helper is
+single-shot, so passing `onDelta` to `complete()` succeeds but never
+fires the callback. The `complete()` return value is still correct.
+
+## In-place mutation (`applyPatch`)
+
+Each provider declares which `SessionPatch` fields can be applied in
+place without a respawn. Fields returned as "leftover" require the
+session manager to kill and re-spawn with history replay.
+
+| Field | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `model` | ✓ control_request `set_model` | ✓ next-turn override | ✓ per-session override | ✗ leftover (respawn) |
+| `permissionMode` | ✓ control_request | ✓ next-turn sandbox policy | ✓ per-session override | ✗ leftover (respawn) |
+| `cwd` | ✗ leftover | ✓ next-turn override (the only provider that can) | ✗ leftover | ✗ leftover |
+
+Grok Build returns every field as leftover because ACP does not expose
+runtime mutation methods, and there is currently only one model in the
+catalog so `setModel` would have nothing to switch to anyway. If a
+second model appears, respawn-with-history-replay still works.
+
+## Permission flow
+
+| Capability | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `permission_needed` AgentEvent emit | ✓ via hook bridge | ✓ via JSON-RPC server-request | ✓ via HTTP webhook | ✓ via ACP `session/request_permission` |
+| `respondToPermission(id, approved)` | ✗ external hook script handles approval | ✓ JSON-RPC response | ✓ POST `/permissions/:id` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` |
+| Bidirectional (provider waits on us) | ✗ hook script makes the decision | ✓ | ✓ | ✓ |
+
+Claude Code's permission model is out-of-band — SNA writes a hook
+script the CLI calls, the script decides on its own (based on
+`permissionMode` and allow/deny rules), and the CLI never waits on
+the SNA process. The other three are bidirectional: the agent's turn
+suspends until SNA sends a permission response. `respondToPermission`
+is a no-op for Claude Code by design.
+
+## Configuration knobs (SpawnOptions)
+
+| Field | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `systemPrompt` | ✓ `--system-prompt` | ✓ `baseInstructions` on `thread/start` | ✓ joined with `appendSystemPrompt` | ✓ `--system-prompt-override` |
+| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `developerInstructions` on `thread/start` | ✓ joined with `systemPrompt` | ✓ `--rules` |
+| `allowedTools` | ✓ native `--allowedTools` | ✓ via PreToolUse hook (deny-others) | ⚠ best-effort (toggles known tools) | ✓ `--tools` allow-list |
+| `disallowedTools` | ✓ native `--disallowedTools` | ✓ via PreToolUse hook | ✓ disables listed tools | ✓ `--disallowed-tools` |
+| `mcpServers` | ✓ `--mcp-config` JSON | ✓ written to `config.toml` `[mcp_servers.*]` | ✓ via SDK | ⚠ accepted by `session/new` but not yet wired from SNA |
+| `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ ignored | ✓ `toGrokEffort` → `--reasoning-effort` |
+| `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ no equivalent | ✗ no equivalent (Grok Build uses `~/.grok`) |
+| `resumeSessionId` | ✓ via JSONL replay file | ✓ `thread/resume` API | ✓ session id | ⚠ resume from a Grok Build session id works, but cross-provider history goes via the `resource` block path below |
+
+### `providerOptions` (per-provider escape hatches)
+
+| Key | Claude Code | Codex | OpenCode | Grok Build |
+|---|---|---|---|---|
+| `settings` | ✓ merged into `--settings` JSON | ✓ same hook shape | — | — |
+| `settingSources` | ✓ `--setting-sources` | — | — | — |
+| `strictMcpConfig` | ✓ `--strict-mcp-config` | — | — | — |
+| `maxTurns` | ✓ `--max-turns` | — | — | — |
+| `omlxBaseUrl` | ✓ routes `ANTHROPIC_BASE_URL` | — | — | — |
+| `serviceTier` | ✗ would mis-bill (`/fast` is a model, not a tier) | ✓ `priority` / `flex` / `batch` | — | — |
+| `profile` | — | ✓ `config.toml` profile | — | — |
+| `config` (`-c key=value`) | — | ✓ `codex exec` overrides | — | — |
+| `serverUrl` | — | — | ✓ skip spawn, attach to existing daemon | — |
+| `modelProviderId` | — | — | ✓ provider half of `{providerID, modelID}` | — |
+| `agent` | — | — | ✓ build / plan / etc. | — |
+| `logLevel` | — | — | ✓ `opencode serve --log-level` | — |
+
+## Cross-provider history replay
+
+Every provider has its own mechanism for seeding a fresh session with a
+prior conversation. SNA's canonical `CanonicalBlock[]` history is
+translated into the native shape at the adapter layer.
+
+| Provider | Mechanism | Adapter |
+|---|---|---|
+| Claude Code | Write Anthropic-format JSONL, pass path to `--resume <filepath>` | `history/claude-code.ts` |
+| Codex | `thread/resume(history=ResponseItems)` JSON-RPC | `history/codex.ts` |
+| OpenCode | Experimental `thread/resume(history=...)` via SDK | `history/opencode.ts` |
+| Grok Build | Serialise transcript into a single ACP `resource` content block on the first `session/prompt` | inline in `core/providers/grok.ts` (option B from the design probe) |
+
+The Grok Build path is intentionally different: probing showed that
+ACP's `session/load` only replays UI events without restoring model
+context, and the underlying `chat_history.jsonl` storage is xAI-internal
+and gets regenerated on session load — so we avoid touching the storage
+layer entirely. Instead we embed the prior transcript inline on turn 1;
+the context persists across subsequent turns within the same session,
+so re-injection is not required.
+
+## What's not in the matrix yet
+
+- **Plan mode toggling at runtime** (Claude Code `--permission-mode plan`,
+  Grok Build `--permission-mode plan`): the CLI flag is honored at spawn
+  but in-place toggling needs `permissionMode` patch support, which
+  Grok Build does not yet have.
+- **MCP wiring through Grok Build**: ACP `session/new` accepts an
+  `mcpServers` array but SNA passes `[]` today. Threading SNA's MCP
+  config through is a follow-up.
+- **Image input in prompts**: all four providers accept image blocks
+  in some form, but the per-provider attachment encoding is still
+  inconsistent — see [Sessions › Attachments](/docs/introduction/sessions)
+  for the current state.

--- a/apps/docs/content/docs/introduction/meta.ja.json
+++ b/apps/docs/content/docs/introduction/meta.ja.json
@@ -14,6 +14,7 @@
     "sessions",
     "history",
     "providers",
+    "feature-matrix",
     "permissions",
     "---哲学---",
     "philosophy"

--- a/apps/docs/content/docs/introduction/meta.json
+++ b/apps/docs/content/docs/introduction/meta.json
@@ -14,6 +14,7 @@
     "sessions",
     "history",
     "providers",
+    "feature-matrix",
     "permissions",
     "---Philosophy---",
     "philosophy"

--- a/apps/docs/content/docs/introduction/meta.ko.json
+++ b/apps/docs/content/docs/introduction/meta.ko.json
@@ -14,6 +14,7 @@
     "sessions",
     "history",
     "providers",
+    "feature-matrix",
     "permissions",
     "---철학---",
     "philosophy"

--- a/apps/docs/content/docs/introduction/providers.ja.mdx
+++ b/apps/docs/content/docs/introduction/providers.ja.mdx
@@ -5,7 +5,7 @@ icon: Boxes
 ---
 
 各ランタイムは共通の `AgentProvider` インタフェースの背後にクラスと
-して実装されています。アダプタは `core/providers/{claude-code,codex,opencode}.ts` です。
+して実装されています。アダプタは `core/providers/{claude-code,codex,opencode,grok}.ts` です。
 
 ## AgentProvider
 
@@ -41,11 +41,27 @@ interface AgentProcess {
 | **claude-code** | `claude -p` (one-shot) + `claude --resume` (replay) | 呼び出しごとに stateless | いいえ |
 | **codex** | `codex app-server` デーモン、stdio 上の JSON-RPC | 永続デーモン、マルチスレッド | はい |
 | **opencode** | `opencode serve` デーモン + SDK HTTP | 永続デーモン、single-cwd | はい |
+| **grok** | `grok agent stdio` (stdio 上の Agent Client Protocol — Grok Build CLI) | セッションごとに stateless | いいえ |
 
 Codex と OpenCode プロバイダは `RuntimePool` 経由でデーモンを共有
 します。セッションを開くとき、プールが `(provider, cwd, config)` で
 照会され、互換のデーモンがあれば再利用してコールドスタートコスト
 を節約します(Codex 約 2 秒、OpenCode 約 3 秒)。
+
+Grok Build は SNA で初めてワイヤプロトコルに公開標準
+([ACP](https://agentclientprotocol.com))を採用したプロバイダです。
+そのためアダプタの大部分は ACP の `session/update` 通知を SNA の
+正規化された `AgentEvent` ストリームへ変換する薄いブリッジに留まり
+ます。`core/providers/grok.ts` の Grok Build 固有部分(CLI パス探索、
+`--effort` フラグマッピング、`_x.ai/*` 拡張通知のフィルタリング)は
+分離してあるので、2 番目の ACP-スピーキングエージェントが登場した
+ときには共通基底に抽出しやすい形に保っています。
+
+プロバイダ間の history replay は、Grok Build セッションの最初の
+`session/prompt` に正規化された会話履歴を 1 個の ACP `resource`
+content block として埋め込む方式で扱います — 機能マトリクスページの
+[プロバイダ間 history replay](/ja/docs/introduction/feature-matrix#cross-provider-history-replay)
+を参照してください。
 
 ## RuntimePool
 
@@ -71,9 +87,15 @@ SNA が ACP だけをプロバイダ層にせず、高忠実度のネイティ�
 
 - **`reasoningLevel: 0..5`**: プロバイダ非依存、最軽量から最重量
   まで。[reasoning-level.ts](https://github.com/neuradex/sna/blob/main/packages/core/src/core/providers/reasoning-level.ts)
-  が Claude の `--effort` と Codex の `model_reasoning_effort` に
-  翻訳します。
+  が Claude Code の `--effort`、Codex の `model_reasoning_effort`、
+  Grok Build の `--reasoning-effort` に翻訳します。OpenCode はこの
+  フィールドを無視します。
 - **`providerOptions.serviceTier`**: Codex 専用。Codex の `/fast`
   スラッシュコマンドをミラーする (値: `"priority"`, `"flex"`,
-  `"batch"`)。Claude には意図的に自動マッピングしません。Claude の
-  `/fast` は別の課金プールを持つ別の MODEL バリアントだからです。
+  `"batch"`)。Claude Code には意図的に自動マッピングしません。
+  Claude Code の `/fast` は別の課金プールを持つ別の MODEL バリアント
+  だからです。
+
+全ランタイムにわたる機能ごとの互換性については
+**[機能 × プロバイダマトリクス](/ja/docs/introduction/feature-matrix)**
+を参照してください。

--- a/apps/docs/content/docs/introduction/providers.ko.mdx
+++ b/apps/docs/content/docs/introduction/providers.ko.mdx
@@ -5,7 +5,7 @@ icon: Boxes
 ---
 
 각 런타임은 공통 `AgentProvider` 인터페이스 뒤에 클래스로 구현됩니다.
-어댑터는 `core/providers/{claude-code,codex,opencode}.ts`.
+어댑터는 `core/providers/{claude-code,codex,opencode,grok}.ts`.
 
 ## AgentProvider
 
@@ -41,11 +41,26 @@ respawn-with-history-replay가 필요한지 결정합니다.
 | **claude-code** | `claude -p` (one-shot) + `claude --resume` (replay) | 호출 단위 무상태 | 아니오 |
 | **codex** | `codex app-server` 데몬, stdio 위 JSON-RPC | 영구 데몬, 멀티 스레드 | 예 |
 | **opencode** | `opencode serve` 데몬 + SDK HTTP | 영구 데몬, single-cwd | 예 |
+| **grok** | `grok agent stdio` (stdio 위 Agent Client Protocol — Grok Build CLI) | 세션 단위 무상태 | 아니오 |
 
 Codex와 OpenCode 프로바이더는 `RuntimePool`을 통해 데몬을 공유합니다.
 세션이 열릴 때 `(provider, cwd, config)` 키로 풀이 조회되고, 호환되는
 기존 데몬이 있으면 재사용해서 cold-start 비용을 줄입니다(Codex 약 2초,
 OpenCode 약 3초).
+
+Grok Build은 SNA에서 처음으로 공개 표준 ([ACP](https://agentclientprotocol.com))을
+와이어 프로토콜로 쓰는 프로바이더입니다. 그래서 어댑터 대부분은 ACP
+`session/update` 알림을 SNA의 정규화된 `AgentEvent` 스트림으로 옮기는
+얇은 변환기 수준입니다. `core/providers/grok.ts`의 Grok Build 고유 부분(CLI
+경로 탐색, `--effort` 플래그 매핑, `_x.ai/*` 확장 알림 필터링)은 따로
+분리해 두었고, 두 번째 ACP-스피킹 에이전트가 등장하면 base를 추출해
+공유하기 쉬운 모양으로 유지하고 있습니다.
+
+프로바이더 간 history replay는 Grok Build 세션의 첫 `session/prompt`에
+정규화된 대화 이력을 단일 ACP `resource` content block으로 담아 보내는
+식으로 처리합니다 — 기능 매트릭스 페이지의
+[프로바이더 간 history replay](/ko/docs/introduction/feature-matrix#cross-provider-history-replay)
+항목 참고.
 
 ## RuntimePool
 
@@ -66,9 +81,15 @@ SNA가 ACP만을 프로바이더 계층으로 삼지 않고 고충실도 네이�
 모든 프로바이더를 관통하는 두 가지 레이턴시 노브:
 
 - **`reasoningLevel: 0..5`**: 프로바이더 비종속, 가장 가벼움부터 가장
-  무거움까지. Claude의 `--effort`와 Codex의 `model_reasoning_effort`로
+  무거움까지. Claude Code의 `--effort`, Codex의 `model_reasoning_effort`,
+  Grok Build의 `--reasoning-effort`를
   [reasoning-level.ts](https://github.com/neuradex/sna/blob/main/packages/core/src/core/providers/reasoning-level.ts)가 번역합니다.
+  OpenCode는 이 필드를 무시합니다.
 - **`providerOptions.serviceTier`**: Codex 전용. Codex의 `/fast`
   슬래시 명령을 모방함 (값: `"priority"`, `"flex"`, `"batch"`).
-  Claude로는 의도적으로 자동 매핑하지 않습니다. Claude의 `/fast`는 별도
-  과금 풀을 가진 다른 MODEL variant이기 때문입니다.
+  Claude Code로는 의도적으로 자동 매핑하지 않습니다. Claude Code의 `/fast`는
+  별도 과금 풀을 가진 다른 MODEL variant이기 때문입니다.
+
+모든 런타임에 대한 기능별 호환성은
+**[기능 × 프로바이더 매트릭스](/ko/docs/introduction/feature-matrix)**
+페이지를 참고하세요.

--- a/apps/docs/content/docs/introduction/providers.mdx
+++ b/apps/docs/content/docs/introduction/providers.mdx
@@ -6,7 +6,7 @@ icon: Boxes
 
 Each runtime is implemented as a class behind a common
 `AgentProvider` interface. Adapters live in
-`core/providers/{claude-code,codex,opencode}.ts`.
+`core/providers/{claude-code,codex,opencode,grok}.ts`.
 
 ## AgentProvider
 
@@ -42,11 +42,25 @@ apply in-place vs which require a respawn-with-history-replay.
 | **claude-code** | `claude -p` (one-shot) plus `claude --resume` (replay) | stateless per call | no |
 | **codex** | `codex app-server` daemon, JSON-RPC over stdio | persistent daemon, multi-thread | yes |
 | **opencode** | `opencode serve` daemon plus SDK HTTP | persistent daemon, single-cwd | yes |
+| **grok** | `grok agent stdio` (Agent Client Protocol over stdio — Grok Build CLI) | stateless per session | no |
 
 The Codex and OpenCode providers share daemons through `RuntimePool`.
 When a session opens, the pool is queried by `(provider, cwd, config)`
 and an existing daemon is reused if compatible, sparing the cold-start
 cost (≈2s for Codex, ≈3s for OpenCode).
+
+Grok Build is the first SNA provider whose wire protocol is a public
+standard ([ACP](https://agentclientprotocol.com)), so the adapter is
+mostly a thin translator between ACP `session/update` notifications and
+SNA's normalized `AgentEvent` stream. The bulk of `core/providers/grok.ts`
+is ACP-standard; the Grok Build-specific pieces (CLI discovery,
+`--effort` flag mapping, `_x.ai/*` extension filtering) are kept
+separable so a second ACP-speaking agent could share the same foundation
+with modest effort. Resume across providers is handled by serialising the
+canonical history into a single ACP `resource` content block on the first
+`session/prompt` of a Grok Build session — see
+[Cross-provider history replay](/docs/introduction/feature-matrix#cross-provider-history-replay)
+on the feature matrix page.
 
 ## RuntimePool
 
@@ -67,9 +81,14 @@ as the only provider layer, see **[SNA and ACP](/docs/introduction/philosophy/ac
 Two latency knobs flow through every provider:
 
 - **`reasoningLevel: 0..5`**: provider-agnostic, lightest to heaviest.
-  Translates to Claude's `--effort` and Codex's
-  `model_reasoning_effort` via [reasoning-level.ts](https://github.com/neuradex/sna/blob/main/packages/core/src/core/providers/reasoning-level.ts).
+  Translates to Claude Code's `--effort`, Codex's `model_reasoning_effort`,
+  and Grok Build's `--reasoning-effort` via
+  [reasoning-level.ts](https://github.com/neuradex/sna/blob/main/packages/core/src/core/providers/reasoning-level.ts).
+  OpenCode currently ignores this field.
 - **`providerOptions.serviceTier`**: Codex-only. Mirrors Codex's
   `/fast` slash command (values: `"priority"`, `"flex"`, `"batch"`).
-  Intentionally not auto-mapped to Claude because Claude's `/fast` is a
-  different MODEL variant with separate billing.
+  Intentionally not auto-mapped to Claude Code because Claude Code's
+  `/fast` is a different MODEL variant with separate billing.
+
+For a per-feature compatibility view across all four runtimes, see
+**[Feature × provider matrix](/docs/introduction/feature-matrix)**.

--- a/packages/core/src/core/mcp/stdio-http-bridge.ts
+++ b/packages/core/src/core/mcp/stdio-http-bridge.ts
@@ -1,0 +1,221 @@
+/**
+ * stdio-http-bridge.ts — Expose a stdio MCP server over Streamable HTTP.
+ *
+ * Some agent runtimes (any ACP-speaking client today: grok, future entries)
+ * can only consume MCP via HTTP or SSE — they reject stdio command-spawn
+ * descriptors. Loom and other SNA consumers, however, ship their MCP tools
+ * as stdio executables (`node loom-tools.mjs`, `npx mcp-server-foo`, …).
+ *
+ * This module bridges the two: spawn the stdio child once per session,
+ * stand up a localhost HTTP endpoint speaking the Streamable HTTP MCP
+ * transport, and forward JSON-RPC traffic between them. Each bridge owns
+ * its own port and child process; tearing down the session disposes both.
+ *
+ * Why hand-rolled instead of the SDK? The SDK ships
+ * `StreamableHTTPServerTransport` for hosting an in-process `McpServer`
+ * instance — we'd need a separate proxy `McpServer` plus the SDK's
+ * stdio Client to chain them. The traffic we actually need to relay is
+ * unmodified JSON-RPC, so a thin line-delimited forwarder is simpler and
+ * has fewer moving parts. We mirror the SDK's wire shape (SSE-framed
+ * responses) so the same clients accept us.
+ *
+ * Scope / limits:
+ *   - Forward client→server requests/notifications: yes.
+ *   - Forward server→client requests (sampling, elicitation): no, dropped
+ *     with a log line. Add when a concrete need shows up.
+ *   - Concurrency: multiple in-flight requests are matched by JSON-RPC id.
+ *   - Batches: per JSON-RPC spec, each item is forwarded individually and
+ *     responses returned in order.
+ */
+
+import http from "node:http";
+import { spawn, type ChildProcess } from "node:child_process";
+import readline from "node:readline";
+import { logger } from "../../lib/logger.js";
+
+export interface StdioMcpConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string | undefined>;
+  cwd?: string;
+}
+
+export interface BridgeHandle {
+  /** Streamable-HTTP MCP endpoint, e.g. "http://127.0.0.1:54321/mcp". */
+  url: string;
+  /** Kill the stdio child and close the HTTP server. Idempotent. */
+  dispose: () => void;
+}
+
+/** How long we wait for the stdio child to answer a single JSON-RPC request. */
+const REQUEST_TIMEOUT_MS = 60_000;
+
+export async function bridgeStdioMcpToHttp(name: string, cfg: StdioMcpConfig): Promise<BridgeHandle> {
+  // ── 1. Spawn the stdio MCP child.
+  const childEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries({ ...process.env, ...(cfg.env ?? {}) })) {
+    if (typeof v === "string") childEnv[k] = v;
+  }
+
+  const child: ChildProcess = spawn(cfg.command, cfg.args ?? [], {
+    cwd: cfg.cwd,
+    env: childEnv,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  // Stderr is diagnostic-only; surface to SNA's logger so failures aren't silent.
+  let stderrTail = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    stderrTail += text;
+    if (stderrTail.length > 4_096) stderrTail = stderrTail.slice(-2_048);
+    if (/error/i.test(text)) {
+      logger.log("agent", `mcp-bridge[${name}] stderr: ${text.trim().slice(0, 400)}`);
+    }
+  });
+
+  // ── 2. Track in-flight requests by id; resolve when the child answers.
+  type Resolver = (msg: unknown) => void;
+  const pending = new Map<string | number, Resolver>();
+
+  const rl = readline.createInterface({ input: child.stdout! });
+  rl.on("line", (line) => {
+    let msg: { id?: string | number; method?: string };
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return;
+    }
+    // Server-initiated request/notification — no client correlation. Log and
+    // drop; we don't currently bridge the server→client direction.
+    if (msg && typeof msg === "object" && msg.method !== undefined && msg.id === undefined) {
+      logger.log("agent", `mcp-bridge[${name}] dropped server notification: ${msg.method}`);
+      return;
+    }
+    if (msg && typeof msg === "object" && msg.id !== undefined && pending.has(msg.id)) {
+      const resolve = pending.get(msg.id)!;
+      pending.delete(msg.id);
+      resolve(msg);
+    }
+  });
+
+  child.on("exit", (code) => {
+    // Resolve any in-flight requests with an error so HTTP callers don't hang.
+    const tail = stderrTail.trim().split("\n").slice(-3).join(" | ");
+    for (const resolve of pending.values()) {
+      resolve({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32000, message: `mcp child '${name}' exited code=${code}${tail ? ` stderr=${tail}` : ""}` },
+      });
+    }
+    pending.clear();
+  });
+
+  function forwardToChild(req: { id?: string | number }, timeoutMs = REQUEST_TIMEOUT_MS): Promise<unknown> | null {
+    // Notifications have no id and expect no response.
+    if (req.id === undefined) {
+      child.stdin?.write(JSON.stringify(req) + "\n");
+      return null;
+    }
+    return new Promise((resolve) => {
+      const id = req.id!;
+      const timer = setTimeout(() => {
+        if (pending.has(id)) {
+          pending.delete(id);
+          resolve({ jsonrpc: "2.0", id, error: { code: -32000, message: "mcp child response timeout" } });
+        }
+      }, timeoutMs);
+      pending.set(id, (msg) => {
+        clearTimeout(timer);
+        resolve(msg);
+      });
+      child.stdin?.write(JSON.stringify(req) + "\n");
+    });
+  }
+
+  // ── 3. HTTP server speaking Streamable HTTP MCP (SSE-framed responses).
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/mcp") {
+      res.writeHead(405, { "content-type": "application/json" });
+      res.end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32000, message: "Method not allowed" }, id: null }));
+      return;
+    }
+
+    let body = "";
+    req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+    req.on("end", async () => {
+      let reqJson: unknown;
+      try {
+        reqJson = body ? JSON.parse(body) : null;
+      } catch (err) {
+        res.writeHead(200, sseHeaders);
+        res.write(sseFrame({ jsonrpc: "2.0", error: { code: -32700, message: `parse error: ${err}` }, id: null }));
+        res.end();
+        return;
+      }
+
+      const isBatch = Array.isArray(reqJson);
+      const items = (isBatch ? reqJson : [reqJson]) as Array<{ id?: string | number; method?: string }>;
+      const summary = items.map((i) => `${i.method ?? "?"}#${i.id ?? "notif"}`).join(",");
+      logger.log("agent", `mcp-bridge[${name}] POST <- ${summary}`);
+
+      // Fire all forwards in parallel; preserve ordering for the response.
+      const settled = await Promise.all(items.map((item) => forwardToChild(item)));
+      const responses = settled.filter((r): r is unknown => r !== null);
+      logger.log("agent", `mcp-bridge[${name}] POST -> ${responses.length} responses`);
+
+      // Per Streamable HTTP MCP spec: a POST consisting only of notifications
+      // (or responses) carries no response body and the server must return
+      // `202 Accepted`. Returning an empty SSE stream instead breaks at least
+      // grok's client (`unexpected server response: expect accepted or json,
+      // got Sse(None)`), which then kills the session.
+      if (responses.length === 0) {
+        res.writeHead(202).end();
+        return;
+      }
+
+      res.writeHead(200, sseHeaders);
+      if (isBatch) {
+        for (const r of responses) res.write(sseFrame(r));
+      } else {
+        res.write(sseFrame(responses[0]));
+      }
+      res.end();
+    });
+  });
+
+  const url = await new Promise<string>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        resolve(`http://127.0.0.1:${addr.port}/mcp`);
+      } else {
+        reject(new Error("mcp-bridge: server.address() returned no port"));
+      }
+    });
+  });
+
+  logger.log("agent", `mcp-bridge[${name}] ready at ${url} (pid=${child.pid})`);
+
+  return {
+    url,
+    dispose: () => {
+      try { rl.close(); } catch {}
+      try { child.kill("SIGTERM"); } catch {}
+      try { server.close(); } catch {}
+      pending.clear();
+    },
+  };
+}
+
+const sseHeaders = {
+  "content-type": "text/event-stream",
+  "cache-control": "no-cache",
+  connection: "keep-alive",
+} as const;
+
+function sseFrame(payload: unknown): string {
+  return `event: message\ndata: ${JSON.stringify(payload)}\n\n`;
+}

--- a/packages/core/src/core/providers/grok.ts
+++ b/packages/core/src/core/providers/grok.ts
@@ -223,19 +223,22 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
         : null;
 
     const grokPath = resolveGrokPath(options.cwd);
-    const args = ["agent", "stdio"];
+    // grok's top-level flags (`--model`, `--effort`, `--always-approve`) must
+    // come BEFORE the `agent stdio` subcommand — the subcommand itself takes
+    // no options other than `--help`. Putting them after silently fails with
+    // "error: unexpected argument" and the process exits with code 2 before
+    // the ACP handshake even starts.
+    const args: string[] = [];
     if (options.model) {
       args.push("--model", options.model);
     }
     if (options.reasoningLevel !== undefined) {
-      args.push("--reasoning-effort", toGrokEffort(options.reasoningLevel));
+      args.push("--effort", toGrokEffort(options.reasoningLevel));
     }
     if (options.permissionMode === "bypassPermissions") {
-      // grok's `--always-approve` is the closest equivalent; not exposed as
-      // a permission-mode toggle on `agent stdio`, but the agent subcommand
-      // accepts it.
       args.push("--always-approve");
     }
+    args.push("agent", "stdio");
 
     logger.log("agent", `grok: spawning ${grokPath} ${args.join(" ")} (cwd=${options.cwd})`);
 
@@ -250,11 +253,16 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
 
     this.proc.stderr!.on("data", (chunk: Buffer) => {
       const text = chunk.toString();
-      // grok's stderr emits structured `tracing` lines like
-      //   "2026-05-20T... ERROR ..." that are mostly background-worker
-      // chatter (telemetry, memory). Surface ERROR lines so a real failure
-      // isn't silent, but don't promote them to AgentEvent errors.
-      if (text.includes("ERROR")) {
+      // grok's stderr emits two distinct shapes:
+      //   1. Structured tracing — `"2026-05-20T... ERROR ..."` (uppercase) —
+      //      mostly background-worker chatter (telemetry, memory).
+      //   2. Clap arg-parse failures — `"error: unexpected argument '--foo'"`
+      //      (lowercase) — fatal, immediate exit.
+      // Surface both. Matching case-insensitively also catches "Error:" from
+      // panics or auth failures that the CLI prints at startup. Dropping the
+      // 400-char cap on the failure path would be nicer but the truncation
+      // is fine for log triage.
+      if (/error/i.test(text)) {
         logger.log("agent", `grok stderr: ${text.trim().slice(0, 400)}`);
       }
     });

--- a/packages/core/src/core/providers/grok.ts
+++ b/packages/core/src/core/providers/grok.ts
@@ -1,14 +1,19 @@
 /**
- * Grok (xAI) provider — ACP-over-stdio adapter.
+ * Grok Build (xAI) provider — ACP-over-stdio adapter.
  *
- * Backed by the `grok` CLI's `agent stdio` subcommand, which implements the
- * Agent Client Protocol (ACP, https://agentclientprotocol.com) as a
- * JSON-RPC 2.0 stream over stdin/stdout. This is the only provider in SNA
- * whose wire protocol is a public standard rather than a vendor-specific
+ * Backed by the Grok Build CLI's `grok agent stdio` subcommand, which
+ * implements the Agent Client Protocol (ACP, https://agentclientprotocol.com)
+ * as a JSON-RPC 2.0 stream over stdin/stdout. This is the only provider in
+ * SNA whose wire protocol is a public standard rather than a vendor-specific
  * schema — which means the adapter is mostly a thin translator between ACP
  * `session/update` notifications and SNA's normalized `AgentEvent`.
  *
- * Design decisions (validated against grok 0.1.212):
+ * Note on product naming: throughout this file, `grok` (lowercase) refers
+ * to the CLI binary / registry key only. The xAI product itself is "Grok
+ * Build" — that's what user-facing documentation should call it, just as
+ * "Claude Code" is the product name behind the `claude` binary.
+ *
+ * Design decisions (validated against Grok Build CLI 0.1.212):
  *
  * 1. NO daemon pooling. `grok agent stdio` is spawned fresh per session,
  *    mirroring Claude Code's stateless model. xAI's storage layer

--- a/packages/core/src/core/providers/grok.ts
+++ b/packages/core/src/core/providers/grok.ts
@@ -45,7 +45,10 @@
 
 import { spawn, execSync, type ChildProcess } from "child_process";
 import { EventEmitter } from "events";
+import fs from "node:fs";
+import path from "node:path";
 import readline from "readline";
+import { bridgeStdioMcpToHttp, type BridgeHandle } from "../mcp/stdio-http-bridge.js";
 import type {
   AgentProvider,
   AgentProcess,
@@ -126,6 +129,10 @@ interface AcpSessionUpdate {
   kind?: string;
   title?: string;
   rawInput?: unknown;
+  /** Present on tool_call_update result variant. */
+  rawOutput?: unknown;
+  /** File/path locations the tool touched — surfaces for tool_call_update. */
+  locations?: unknown;
   status?: string;
 }
 
@@ -159,6 +166,51 @@ interface AcpPermissionRequest {
  * structured tool_use blocks (grok would have no use for unfinished tool
  * state from a different provider's session).
  */
+/**
+ * Translate a `tool_call` or input-refresh `tool_call_update` notification
+ * into a normalized `tool_use` AgentEvent. Centralizes the `use_tool`
+ * unwrap so both code paths land on the same shape:
+ *
+ *   • `data.toolName` is the canonical tool name consumers match on
+ *     (`pinboard_patch`, `board_item_add`, vendor MCP names, etc.). Grok
+ *     wraps every external MCP call in its internal `use_tool` dispatch
+ *     with the real tool name nested in `rawInput.tool_name` — we surface
+ *     it directly so downstream `isToolName(...)` checks behave the same
+ *     way they do for claude / codex / opencode.
+ *   • `data.input` is what the *tool* sees: the unwrapped `tool_input`
+ *     for use_tool dispatches, or the raw input for grok's native tools
+ *     (`search_tool`, `run_terminal_command`, `write`, …).
+ *   • `data.grokTitle` preserves grok's human-readable dispatch title
+ *     ("Write `/tmp/big.html`", "Execute `wc -c /tmp/big.html`") for
+ *     debug overlays / tooltips without confusing the canonical name.
+ *   • `data.fromUpdate` flags refresh events so consumers can choose to
+ *     skip work that already ran on the initial tool_call. Optional —
+ *     idempotent-by-id consumers ignore it.
+ */
+function toolUseFromUpdate(
+  update: AcpSessionUpdate,
+  now: number,
+  opts: { fromUpdate?: boolean } = {},
+): AgentEvent {
+  const raw = update.rawInput as { tool_name?: string; tool_input?: unknown } | undefined;
+  const isUseTool = !!(raw && typeof raw.tool_name === "string");
+  const toolName = isUseTool ? raw!.tool_name! : (update.title ?? "tool");
+  const input = isUseTool ? raw!.tool_input : update.rawInput;
+  return {
+    type: "tool_use",
+    message: toolName,
+    data: {
+      id: update.toolCallId,
+      toolName,
+      kind: update.kind,
+      input,
+      grokTitle: update.title,
+      ...(opts.fromUpdate ? { fromUpdate: true } : {}),
+    },
+    timestamp: now,
+  };
+}
+
 export function serializeHistoryForGrok(history: CanonicalBlock[]): string {
   const lines: string[] = [];
   for (const block of history) {
@@ -191,10 +243,25 @@ export function serializeHistoryForGrok(history: CanonicalBlock[]): string {
 // ── Process ─────────────────────────────────────────────────────────────────
 
 export class GrokProcess extends EventEmitter implements AgentProcess {
-  private readonly proc: ChildProcess;
-  private readonly rl: readline.Interface;
+  // Definite-assignment: populated inside initialize() before the handshake
+  // resolves. Consumers always await this.ready before touching state.
+  private proc!: ChildProcess;
+  private rl!: readline.Interface;
   private _sessionId: string | null = null;
   private _alive = true;
+  /**
+   * stdio→HTTP MCP bridges spun up for this session. Each one owns its
+   * own child process + listener; dispose them on grok exit so we don't
+   * leak sockets between sessions.
+   */
+  private mcpBridges: BridgeHandle[] = [];
+  /**
+   * Path to the `.grok/config.toml` we wrote so cleanup can restore it.
+   * The snapshot is the file's contents *before* we touched it (null when
+   * we created it from scratch — cleanup then deletes it instead of
+   * restoring).
+   */
+  private grokConfigRestore: { path: string; original: string | null } | null = null;
 
   private rpcIdCounter = 0;
   /** Resolvers for outgoing requests, keyed by our own request id. */
@@ -212,16 +279,76 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
   /** Cached history transcript for first-turn injection (option B). */
   private readonly historyTranscript: string | null;
   private firstPromptSent = false;
+  /**
+   * Per-turn accumulator for `agent_message_chunk` text. ACP has no terminal
+   * "final assistant message" notification — the turn ends implicitly when
+   * `session/prompt` resolves with a `stopReason`. SNA's persistence layer,
+   * however, only writes assistant rows for the `assistant` event (which
+   * carries the full message text), not for the streaming `assistant_delta`
+   * chunks. So we accumulate chunks here and flush them as a single
+   * `assistant` event right before `complete` — otherwise the assistant turn
+   * never lands in chat_messages and reload-the-chat wipes the reply.
+   */
+  private assistantTurnBuffer = "";
+  /**
+   * Captured permission mode for the duration of this session. Grok's CLI
+   * `--always-approve` flag covers built-in tool prompts but does NOT skip
+   * the ACP `session/request_permission` round-trip for MCP tool calls —
+   * grok always asks the client even in bypass mode. SNA's SessionManager
+   * doesn't auto-resolve permissions either (it expects the renderer to do
+   * that via a dialog). So a `bypassPermissions` session would hang on
+   * every MCP tool call. We handle the auto-approve here in the provider
+   * instead, replying `allow-once` to permission requests before they ever
+   * leave SNA.
+   */
+  private readonly permissionMode: string | undefined;
   /** Set true after initialize + session/new succeed. */
   private ready: Promise<void>;
 
   constructor(options: SpawnOptions) {
     super();
+    this.permissionMode = options.permissionMode;
     this.historyTranscript =
       options.history && options.history.length > 0
         ? serializeHistoryForGrok(options.history)
         : null;
 
+    // Bridge setup is async (needs a free port), so we cannot spawn grok
+    // synchronously in the constructor — config.toml must already be written
+    // before `grok agent stdio` starts reading it. Drive everything through
+    // an async initialize chain. Consumers always await this.ready first.
+    this.ready = this.initialize(options);
+    this.ready.catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emitEvent({ type: "error", message, timestamp: Date.now() });
+    });
+  }
+
+  /**
+   * One-shot async setup chain:
+   *   1. Bridge any stdio MCP entries to HTTP and write their URLs into
+   *      `<cwd>/.grok/config.toml` so grok picks them up at startup. ACP's
+   *      `session/new.mcpServers` is rejected by grok 0.1.212 for any
+   *      non-empty shape, so config.toml is the only working channel today.
+   *   2. Spawn `grok agent stdio` and wire stdout/stderr/exit listeners.
+   *   3. Run the ACP handshake (initialize + session/new).
+   */
+  private async initialize(options: SpawnOptions): Promise<void> {
+    try {
+      await this.setupMcpBridges(options);
+      this.spawnGrok(options);
+      await this.runHandshake(options);
+    } catch (err) {
+      // Any failure between bridge setup and a live grok process leaves
+      // orphaned bridges + a config.toml we wrote. The proc.exit handler
+      // hasn't been registered yet (or won't fire if grok never spawned),
+      // so clean up here. Idempotent — fine to also run from exit later.
+      this.disposeMcpBridges();
+      throw err;
+    }
+  }
+
+  private spawnGrok(options: SpawnOptions): void {
     const grokPath = resolveGrokPath(options.cwd);
     // grok's top-level flags (`--model`, `--effort`, `--always-approve`) must
     // come BEFORE the `agent stdio` subcommand — the subcommand itself takes
@@ -259,9 +386,7 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
       //   2. Clap arg-parse failures — `"error: unexpected argument '--foo'"`
       //      (lowercase) — fatal, immediate exit.
       // Surface both. Matching case-insensitively also catches "Error:" from
-      // panics or auth failures that the CLI prints at startup. Dropping the
-      // 400-char cap on the failure path would be nicer but the truncation
-      // is fine for log triage.
+      // panics or auth failures that the CLI prints at startup.
       if (/error/i.test(text)) {
         logger.log("agent", `grok stderr: ${text.trim().slice(0, 400)}`);
       }
@@ -274,6 +399,7 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
         reject(new Error(`grok process exited (code=${code}) while waiting for ${method}`));
       }
       this.pendingRequests.clear();
+      this.disposeMcpBridges();
       this.emit("exit", code);
     });
 
@@ -281,15 +407,91 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
       this._alive = false;
       this.emit("error", err);
     });
+  }
 
-    this.ready = this.runHandshake(options);
-    // Surface handshake failures as AgentEvent errors rather than unhandled
-    // promise rejections — the SessionManager only listens on the event/exit
-    // channels.
-    this.ready.catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
-      this.emitEvent({ type: "error", message, timestamp: Date.now() });
-    });
+  /**
+   * Spin up HTTP bridges for each stdio MCP entry and inject
+   * `[mcp_servers.<name>]` blocks into the project-scoped config at
+   * `<cwd>/.grok/config.toml`. We use the project-scoped file (not the
+   * global ~/.grok/config.toml) so concurrent sessions don't fight over
+   * the same file. The original contents (or "no such file") are
+   * remembered for restore on exit.
+   *
+   * Entries already declared as `{type:"http",url:...}` are passed through
+   * verbatim — no bridge needed. Other shapes are dropped with a log.
+   */
+  private async setupMcpBridges(options: SpawnOptions): Promise<void> {
+    if (!options.mcpServers) return;
+
+    type Entry = { name: string; url: string; headers?: Record<string, string> };
+    const entries: Entry[] = [];
+
+    for (const [name, cfg] of Object.entries(options.mcpServers)) {
+      if (!cfg || typeof cfg !== "object") continue;
+
+      if ("type" in cfg && cfg.type === "http") {
+        entries.push({ name, url: cfg.url, headers: cfg.headers });
+        continue;
+      }
+      if ("command" in cfg && cfg.command) {
+        const handle = await bridgeStdioMcpToHttp(name, {
+          command: cfg.command,
+          args: cfg.args,
+          env: cfg.env,
+          cwd: cfg.cwd ?? options.cwd,
+        });
+        this.mcpBridges.push(handle);
+        entries.push({ name, url: handle.url });
+        continue;
+      }
+      logger.log("agent", `grok: skipping mcp server '${name}' — unsupported shape`);
+    }
+
+    if (entries.length === 0) return;
+
+    const cfgDir = path.join(options.cwd, ".grok");
+    const cfgPath = path.join(cfgDir, "config.toml");
+    let original: string | null = null;
+    try { original = fs.readFileSync(cfgPath, "utf-8"); } catch { /* no file yet */ }
+    try { fs.mkdirSync(cfgDir, { recursive: true }); } catch {}
+
+    const block = entries.map((e) => {
+      const lines = [`[mcp_servers.${e.name}]`, `url = ${JSON.stringify(e.url)}`];
+      if (e.headers) {
+        lines.push(`[mcp_servers.${e.name}.headers]`);
+        for (const [k, v] of Object.entries(e.headers)) {
+          lines.push(`${k} = ${JSON.stringify(v)}`);
+        }
+      }
+      return lines.join("\n");
+    }).join("\n\n");
+
+    const marker = `# sna-grok-bridge:BEGIN\n${block}\n# sna-grok-bridge:END\n`;
+    const next = (original ?? "").replace(/\n*# sna-grok-bridge:BEGIN[\s\S]*?# sna-grok-bridge:END\n?/g, "");
+    fs.writeFileSync(cfgPath, (next ? next.replace(/\n*$/, "\n\n") : "") + marker);
+
+    this.grokConfigRestore = { path: cfgPath, original };
+    logger.log("agent", `grok: wrote ${entries.length} mcp_servers entries to ${cfgPath}`);
+  }
+
+  private disposeMcpBridges(): void {
+    for (const b of this.mcpBridges) {
+      try { b.dispose(); } catch {}
+    }
+    this.mcpBridges = [];
+
+    const restore = this.grokConfigRestore;
+    this.grokConfigRestore = null;
+    if (!restore) return;
+    try {
+      if (restore.original === null) {
+        fs.unlinkSync(restore.path);
+      } else {
+        fs.writeFileSync(restore.path, restore.original);
+      }
+    } catch (err) {
+      logger.log("agent", `grok: failed to restore ${restore.path}: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   // ── JSON-RPC primitives ───────────────────────────────────────────────────
@@ -361,10 +563,31 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
   private handleServerRequest(req: JsonRpcRequest): void {
     if (req.method === "session/request_permission") {
       const params = req.params as AcpPermissionRequest;
+      const requestId = params.toolCall.toolCallId;
+
+      // Bypass-mode shortcut: pick whichever option carries an "allow"
+      // intent (or fall back to the first option) and reply immediately,
+      // skipping the SessionManager round-trip + UI dialog entirely. This
+      // mirrors the contract of `permissionMode: "bypassPermissions"`,
+      // which other providers implement by never asking in the first place.
+      if (this.permissionMode === "bypassPermissions") {
+        const allowOpt =
+          params.options.find((o) => o.kind === "allow_always") ??
+          params.options.find((o) => o.kind === "allow_once") ??
+          params.options[0];
+        if (allowOpt) {
+          this.write({
+            jsonrpc: "2.0",
+            id: req.id,
+            result: { outcome: { outcome: "selected", optionId: allowOpt.optionId } },
+          });
+          return;
+        }
+      }
+
       // Externally we expose the toolCallId as the requestId — it's stable
       // across the tool's lifecycle and lets callers correlate with the
       // tool_use AgentEvent that triggered the prompt.
-      const requestId = params.toolCall.toolCallId;
       this.pendingPermissions.set(requestId, req.id);
       this.emitEvent({
         type: "permission_needed",
@@ -413,35 +636,52 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
       case "agent_thought_chunk":
         return { type: "thinking_delta", delta: text, timestamp: now };
       case "agent_message_chunk":
+        // Accumulate so the final `assistant` event (flushed when
+        // session/prompt resolves) carries the full message text for the DB.
+        this.assistantTurnBuffer += text;
         return { type: "assistant_delta", delta: text, timestamp: now };
       case "user_message_chunk":
         // Emitted by grok when replaying loaded sessions or echoing our own
         // prompts back. SNA's user_message AgentEvent has the same shape.
         return { type: "user_message", message: text, timestamp: now };
       case "tool_call":
-        return {
-          type: "tool_use",
-          message: update.title,
-          data: {
-            id: update.toolCallId,
-            kind: update.kind,
-            input: update.rawInput,
-          },
-          timestamp: now,
-        };
-      case "tool_call_update":
-        // Status updates and final results both arrive here. Surface as
-        // tool_result; data.status lets the consumer distinguish "still
-        // running" from "completed" if it cares.
+        return toolUseFromUpdate(update, now);
+      case "tool_call_update": {
+        // `tool_call_update` is overloaded in ACP — grok uses the same
+        // notification for two distinct kinds of update:
+        //   (a) Input refresh — rawInput grows or finalizes between the
+        //       initial `tool_call` and execution. Carries rawInput + kind +
+        //       title + (textual) content, NO status. We emit `tool_use`
+        //       again with the same id; SNA's persistence + Loom's
+        //       message store merge by id so the existing bubble refreshes
+        //       in place. xAI's API itself doesn't expose token-level
+        //       streaming for tool arguments (it returns the call "in
+        //       whole in a single chunk" per their docs), so the
+        //       differences between (a) and the original tool_call are
+        //       small finalization patches — but we still pass them
+        //       through so future grok/ACP additions slot in cleanly.
+        //   (b) Result update — has status (in_progress/completed/failed)
+        //       and content/rawOutput. We emit `tool_result` with all
+        //       fields preserved so consumers see locations, raw output
+        //       (parsed), and the textual content side-by-side.
+        const hasResultSignal = !!update.status || update.rawOutput !== undefined;
+        if (!hasResultSignal && update.rawInput !== undefined) {
+          return toolUseFromUpdate(update, now, { fromUpdate: true });
+        }
         return {
           type: "tool_result",
           data: {
             id: update.toolCallId,
             status: update.status,
             content: update.content,
+            rawOutput: update.rawOutput,
+            locations: update.locations,
+            kind: update.kind,
+            title: update.title || undefined,
           },
           timestamp: now,
         };
+      }
       case "available_commands_update":
       case "plan":
         // Slash-command list refresh / plan-mode pane updates aren't part
@@ -471,9 +711,15 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
       },
     });
 
+    // MCP server registration goes through `<cwd>/.grok/config.toml`, not
+    // session/new — setupMcpBridges() already wrote that file before this
+    // handshake runs. ACP's `session/new.mcpServers` field rejects any
+    // non-empty shape on grok 0.1.212 (`Invalid params`), even structurally
+    // valid http entries, so we keep it empty and let grok read tools off
+    // its own config-load path.
     const sessionResp = (await this.request("session/new", {
       cwd: options.cwd,
-      mcpServers: [], // SNA does not currently wire MCP through to grok.
+      mcpServers: [],
     })) as { sessionId?: string } | undefined;
 
     const sessionId = sessionResp?.sessionId ?? null;
@@ -556,15 +802,36 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
         sessionId: this._sessionId,
         prompt: promptBlocks,
       })) as { stopReason?: string } | undefined;
+      this.flushAssistantTurn();
       this.emitEvent({
         type: "complete",
         data: { stopReason: result?.stopReason ?? null },
         timestamp: Date.now(),
       });
     } catch (err) {
+      // Flush whatever text streamed before the failure so a partial turn
+      // still lands in chat_messages and the user sees it after reload.
+      this.flushAssistantTurn();
       const message = err instanceof Error ? err.message : String(err);
       this.emitEvent({ type: "error", message, timestamp: Date.now() });
     }
+  }
+
+  /**
+   * Emit the accumulated `agent_message_chunk` text as a single terminal
+   * `assistant` event so SNA's persistence layer writes a row to
+   * chat_messages, then clear the buffer for the next turn. No-op when
+   * nothing streamed (tool-only turns, interruptions before any text).
+   */
+  private flushAssistantTurn(): void {
+    const text = this.assistantTurnBuffer;
+    this.assistantTurnBuffer = "";
+    if (!text) return;
+    this.emitEvent({
+      type: "assistant",
+      message: text,
+      timestamp: Date.now(),
+    });
   }
 
   interrupt(): void {
@@ -632,6 +899,13 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
   kill(): void {
     if (!this._alive) return;
     this._alive = false;
+    // kill() may race with initialize() — proc isn't assigned until
+    // spawnGrok() runs. If we beat that, just dispose bridges and bail;
+    // initialize() will see _alive=false and unwind on its own.
+    if (!this.proc) {
+      this.disposeMcpBridges();
+      return;
+    }
     try {
       this.proc.kill("SIGTERM");
     } catch {

--- a/packages/core/src/core/providers/grok.ts
+++ b/packages/core/src/core/providers/grok.ts
@@ -1,0 +1,829 @@
+/**
+ * Grok (xAI) provider — ACP-over-stdio adapter.
+ *
+ * Backed by the `grok` CLI's `agent stdio` subcommand, which implements the
+ * Agent Client Protocol (ACP, https://agentclientprotocol.com) as a
+ * JSON-RPC 2.0 stream over stdin/stdout. This is the only provider in SNA
+ * whose wire protocol is a public standard rather than a vendor-specific
+ * schema — which means the adapter is mostly a thin translator between ACP
+ * `session/update` notifications and SNA's normalized `AgentEvent`.
+ *
+ * Design decisions (validated against grok 0.1.212):
+ *
+ * 1. NO daemon pooling. `grok agent stdio` is spawned fresh per session,
+ *    mirroring Claude Code's stateless model. xAI's storage layer
+ *    (chat_history.jsonl + 6 other files in ~/.grok/sessions/) is treated
+ *    as a black box; we never read or write it directly.
+ *
+ * 2. History injection via ACP `resource` blocks (option B). Probing showed
+ *    that `session/load` only replays UI events and does NOT restore model
+ *    context — the real context lives in xAI-internal chat_history.jsonl
+ *    which is regenerated on load. We instead serialise SNA's canonical
+ *    history into a single `resource` content block on the first
+ *    `session/prompt`, and the embedded context persists across subsequent
+ *    turns within the same grok session (verified: turn-2 still remembered
+ *    facts injected on turn-1 without re-injection).
+ *
+ * 3. Permission flow reuses the Codex bidirectional pattern. ACP's
+ *    `session/request_permission` is a server-request (has `id`, expects
+ *    a response) with an `options[]` array — structurally identical to
+ *    Codex's pattern. We map it to SNA's `permission_needed` event and
+ *    accept `respondToPermission()` callbacks the same way.
+ *
+ * 4. `_x.ai/*` extension notifications (fs_notify, mcp/init_progress,
+ *    session_notification, etc.) are dropped on the floor. They're useful
+ *    for native IDE clients but irrelevant to SNA's normalized event model.
+ *
+ * 5. Reasoning level uses the same 5-step table as Claude Code (low / low /
+ *    medium / high / xhigh / max).
+ */
+
+import { spawn, execSync, type ChildProcess } from "child_process";
+import { EventEmitter } from "events";
+import readline from "readline";
+import type {
+  AgentProvider,
+  AgentProcess,
+  AgentEvent,
+  SpawnOptions,
+  SessionPatch,
+  CompleteOptions,
+  CompletionResult,
+  ContentBlock,
+  ListModelsConfig,
+  ListModelsResult,
+  RuntimeModelInfo,
+} from "./types.js";
+import type { CanonicalBlock } from "../../history/types.js";
+import { logger } from "../../lib/logger.js";
+import { toGrokEffort } from "./reasoning-level.js";
+
+// ── CLI discovery ────────────────────────────────────────────────────────────
+
+export function resolveGrokPath(_cwd: string = process.cwd()): string {
+  if (process.env.SNA_GROK_COMMAND) return process.env.SNA_GROK_COMMAND;
+  const home = process.env.HOME ?? "";
+  const candidates = [
+    `${home}/.local/bin/grok`,
+    "/usr/local/bin/grok",
+    "/opt/homebrew/bin/grok",
+  ];
+  for (const p of candidates) {
+    try {
+      execSync(`test -x "${p}"`, { stdio: "pipe" });
+      return p;
+    } catch {
+      // try next
+    }
+  }
+  return "grok";
+}
+
+// ── JSON-RPC types ──────────────────────────────────────────────────────────
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
+
+// ── ACP shapes we actually consume ───────────────────────────────────────────
+
+interface AcpSessionUpdate {
+  sessionUpdate:
+    | "user_message_chunk"
+    | "agent_message_chunk"
+    | "agent_thought_chunk"
+    | "tool_call"
+    | "tool_call_update"
+    | "available_commands_update"
+    | "plan"
+    | string;
+  content?: { type: "text"; text?: string } | unknown;
+  /** Present on tool_call / tool_call_update */
+  toolCallId?: string;
+  kind?: string;
+  title?: string;
+  rawInput?: unknown;
+  status?: string;
+}
+
+interface AcpPermissionOption {
+  optionId: string;
+  name?: string;
+  kind: "allow_always" | "allow_once" | "reject_once" | "reject_always";
+}
+
+interface AcpPermissionRequest {
+  sessionId: string;
+  toolCall: {
+    toolCallId: string;
+    kind?: string;
+    title?: string;
+    rawInput?: unknown;
+  };
+  options: AcpPermissionOption[];
+}
+
+// ── History → resource transcript ────────────────────────────────────────────
+
+/**
+ * Serialize SNA's canonical history into a plain-text transcript that fits
+ * inside one ACP `resource` content block. The grok model treats the
+ * content as part of its prompt context — see option-B probe results.
+ *
+ * Format is intentionally human-readable; the model parses it well enough
+ * to extract user-stated facts and prior assistant outputs. Tool calls and
+ * results are summarized inline; we do not attempt to round-trip them as
+ * structured tool_use blocks (grok would have no use for unfinished tool
+ * state from a different provider's session).
+ */
+export function serializeHistoryForGrok(history: CanonicalBlock[]): string {
+  const lines: string[] = [];
+  for (const block of history) {
+    const actor = block.actor.toUpperCase();
+    switch (block.kind) {
+      case "text":
+        lines.push(`${actor}: ${block.content}`);
+        break;
+      case "thinking":
+        // Skip internal reasoning from prior providers — adds noise without
+        // useful context for grok.
+        break;
+      case "tool_use": {
+        const name = (block.meta as { name?: string } | undefined)?.name ?? "tool";
+        lines.push(`${actor} (calling ${name}): ${block.content}`);
+        break;
+      }
+      case "tool_result":
+        lines.push(`TOOL_RESULT: ${block.content}`);
+        break;
+      case "status":
+      case "error":
+        // Status/error metadata is not useful as prior conversation context.
+        break;
+    }
+  }
+  return lines.join("\n");
+}
+
+// ── Process ─────────────────────────────────────────────────────────────────
+
+export class GrokProcess extends EventEmitter implements AgentProcess {
+  private readonly proc: ChildProcess;
+  private readonly rl: readline.Interface;
+  private _sessionId: string | null = null;
+  private _alive = true;
+
+  private rpcIdCounter = 0;
+  /** Resolvers for outgoing requests, keyed by our own request id. */
+  private readonly pendingRequests = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (err: Error) => void; method: string }
+  >();
+  /**
+   * Open permission requests from grok. Maps SNA's externally-visible
+   * requestId (which we expose via the permission_needed AgentEvent) to
+   * grok's JSON-RPC request id, so respondToPermission() can route back.
+   */
+  private readonly pendingPermissions = new Map<string, number>();
+
+  /** Cached history transcript for first-turn injection (option B). */
+  private readonly historyTranscript: string | null;
+  private firstPromptSent = false;
+  /** Set true after initialize + session/new succeed. */
+  private ready: Promise<void>;
+
+  constructor(options: SpawnOptions) {
+    super();
+    this.historyTranscript =
+      options.history && options.history.length > 0
+        ? serializeHistoryForGrok(options.history)
+        : null;
+
+    const grokPath = resolveGrokPath(options.cwd);
+    const args = ["agent", "stdio"];
+    if (options.model) {
+      args.push("--model", options.model);
+    }
+    if (options.reasoningLevel !== undefined) {
+      args.push("--reasoning-effort", toGrokEffort(options.reasoningLevel));
+    }
+    if (options.permissionMode === "bypassPermissions") {
+      // grok's `--always-approve` is the closest equivalent; not exposed as
+      // a permission-mode toggle on `agent stdio`, but the agent subcommand
+      // accepts it.
+      args.push("--always-approve");
+    }
+
+    logger.log("agent", `grok: spawning ${grokPath} ${args.join(" ")} (cwd=${options.cwd})`);
+
+    this.proc = spawn(grokPath, args, {
+      cwd: options.cwd,
+      env: { ...process.env, ...(options.env ?? {}) },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    this.rl = readline.createInterface({ input: this.proc.stdout! });
+    this.rl.on("line", (line) => this.handleLine(line));
+
+    this.proc.stderr!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      // grok's stderr emits structured `tracing` lines like
+      //   "2026-05-20T... ERROR ..." that are mostly background-worker
+      // chatter (telemetry, memory). Surface ERROR lines so a real failure
+      // isn't silent, but don't promote them to AgentEvent errors.
+      if (text.includes("ERROR")) {
+        logger.log("agent", `grok stderr: ${text.trim().slice(0, 400)}`);
+      }
+    });
+
+    this.proc.on("exit", (code) => {
+      this._alive = false;
+      // Reject any inflight requests so callers don't hang.
+      for (const { reject, method } of this.pendingRequests.values()) {
+        reject(new Error(`grok process exited (code=${code}) while waiting for ${method}`));
+      }
+      this.pendingRequests.clear();
+      this.emit("exit", code);
+    });
+
+    this.proc.on("error", (err) => {
+      this._alive = false;
+      this.emit("error", err);
+    });
+
+    this.ready = this.runHandshake(options);
+    // Surface handshake failures as AgentEvent errors rather than unhandled
+    // promise rejections — the SessionManager only listens on the event/exit
+    // channels.
+    this.ready.catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emitEvent({ type: "error", message, timestamp: Date.now() });
+    });
+  }
+
+  // ── JSON-RPC primitives ───────────────────────────────────────────────────
+
+  private write(msg: JsonRpcMessage): void {
+    if (!this.proc.stdin || this.proc.stdin.destroyed) {
+      throw new Error("grok stdin closed");
+    }
+    this.proc.stdin.write(JSON.stringify(msg) + "\n");
+  }
+
+  private request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    const id = ++this.rpcIdCounter;
+    return new Promise<T>((resolve, reject) => {
+      this.pendingRequests.set(id, {
+        resolve: (v) => resolve(v as T),
+        reject,
+        method,
+      });
+      try {
+        this.write({ jsonrpc: "2.0", id, method, params });
+      } catch (err) {
+        this.pendingRequests.delete(id);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  // ── Stream handling ───────────────────────────────────────────────────────
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(trimmed) as JsonRpcMessage;
+    } catch {
+      logger.log("agent", `grok: non-JSON line dropped: ${trimmed.slice(0, 200)}`);
+      return;
+    }
+
+    // Response to one of our outgoing requests
+    if ("id" in msg && msg.id != null && !("method" in msg)) {
+      const pending = this.pendingRequests.get(msg.id);
+      if (!pending) return;
+      this.pendingRequests.delete(msg.id);
+      const resp = msg as JsonRpcResponse;
+      if (resp.error) {
+        pending.reject(new Error(`grok ${pending.method} failed: ${resp.error.message}`));
+      } else {
+        pending.resolve(resp.result);
+      }
+      return;
+    }
+
+    // Server-initiated request (grok asking us for something)
+    if ("method" in msg && "id" in msg && msg.id != null) {
+      this.handleServerRequest(msg as JsonRpcRequest);
+      return;
+    }
+
+    // Notification
+    if ("method" in msg) {
+      this.handleNotification(msg as JsonRpcNotification);
+      return;
+    }
+  }
+
+  private handleServerRequest(req: JsonRpcRequest): void {
+    if (req.method === "session/request_permission") {
+      const params = req.params as AcpPermissionRequest;
+      // Externally we expose the toolCallId as the requestId — it's stable
+      // across the tool's lifecycle and lets callers correlate with the
+      // tool_use AgentEvent that triggered the prompt.
+      const requestId = params.toolCall.toolCallId;
+      this.pendingPermissions.set(requestId, req.id);
+      this.emitEvent({
+        type: "permission_needed",
+        message: params.toolCall.title,
+        data: {
+          requestId,
+          toolCall: params.toolCall,
+          options: params.options,
+        },
+        timestamp: Date.now(),
+      });
+      return;
+    }
+
+    // We don't speak the rest of the ACP server-request surface (fs reads,
+    // terminal control, etc.). Reply with a method-not-found error so grok
+    // doesn't hang waiting on us.
+    this.write({
+      jsonrpc: "2.0",
+      id: req.id,
+      error: { code: -32601, message: `Method not implemented in SNA: ${req.method}` },
+    });
+  }
+
+  private handleNotification(notif: JsonRpcNotification): void {
+    if (notif.method.startsWith("_x.ai/")) {
+      // Vendor extension notifications (fs_notify, mcp/init_progress,
+      // session_notification, etc.) — design decision (4): drop.
+      return;
+    }
+    if (notif.method === "session/update") {
+      const params = notif.params as { sessionId?: string; update?: AcpSessionUpdate };
+      if (!params?.update) return;
+      const event = this.translateSessionUpdate(params.update);
+      if (event) this.emitEvent(event);
+      return;
+    }
+    // Unknown notifications: log and ignore.
+    logger.log("agent", `grok: ignored notification ${notif.method}`);
+  }
+
+  private translateSessionUpdate(update: AcpSessionUpdate): AgentEvent | null {
+    const now = Date.now();
+    const text = (update.content as { text?: string } | undefined)?.text ?? "";
+    switch (update.sessionUpdate) {
+      case "agent_thought_chunk":
+        return { type: "thinking_delta", delta: text, timestamp: now };
+      case "agent_message_chunk":
+        return { type: "assistant_delta", delta: text, timestamp: now };
+      case "user_message_chunk":
+        // Emitted by grok when replaying loaded sessions or echoing our own
+        // prompts back. SNA's user_message AgentEvent has the same shape.
+        return { type: "user_message", message: text, timestamp: now };
+      case "tool_call":
+        return {
+          type: "tool_use",
+          message: update.title,
+          data: {
+            id: update.toolCallId,
+            kind: update.kind,
+            input: update.rawInput,
+          },
+          timestamp: now,
+        };
+      case "tool_call_update":
+        // Status updates and final results both arrive here. Surface as
+        // tool_result; data.status lets the consumer distinguish "still
+        // running" from "completed" if it cares.
+        return {
+          type: "tool_result",
+          data: {
+            id: update.toolCallId,
+            status: update.status,
+            content: update.content,
+          },
+          timestamp: now,
+        };
+      case "available_commands_update":
+      case "plan":
+        // Slash-command list refresh / plan-mode pane updates aren't part
+        // of SNA's event vocabulary; ignore.
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  private emitEvent(event: AgentEvent): void {
+    this.emit("event", event);
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  private async runHandshake(options: SpawnOptions): Promise<void> {
+    await this.request("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: {
+        // We accept fs/terminal capability declarations but don't actually
+        // implement those server-request methods (we reject them in
+        // handleServerRequest). Declaring true here would invite grok to
+        // call us; declare false to keep traffic minimal.
+        fs: { readTextFile: false, writeTextFile: false },
+        terminal: false,
+      },
+    });
+
+    const sessionResp = (await this.request("session/new", {
+      cwd: options.cwd,
+      mcpServers: [], // SNA does not currently wire MCP through to grok.
+    })) as { sessionId?: string } | undefined;
+
+    const sessionId = sessionResp?.sessionId ?? null;
+    if (!sessionId) {
+      throw new Error("grok session/new returned no sessionId");
+    }
+    this._sessionId = sessionId;
+    this.emitEvent({
+      type: "init",
+      message: "grok session ready",
+      data: { sessionId },
+      timestamp: Date.now(),
+    });
+  }
+
+  // ── AgentProcess surface ──────────────────────────────────────────────────
+
+  send(input: string | ContentBlock[]): void {
+    void this.ready
+      .then(() => this.sendPrompt(input))
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        this.emitEvent({ type: "error", message, timestamp: Date.now() });
+      });
+  }
+
+  private async sendPrompt(input: string | ContentBlock[]): Promise<void> {
+    if (!this._sessionId) {
+      throw new Error("grok: send() called before session is ready");
+    }
+
+    // Build ACP prompt blocks. Order matters: on the first turn, the
+    // history `resource` block precedes the user's actual text so the
+    // transcript reads as prior context, not a follow-up.
+    const promptBlocks: unknown[] = [];
+
+    if (!this.firstPromptSent && this.historyTranscript) {
+      promptBlocks.push({
+        type: "resource",
+        resource: {
+          uri: "sna://prior-conversation.txt",
+          mimeType: "text/plain",
+          text:
+            "The following is our prior conversation, carried over from " +
+            "another agent. Continue from where it leaves off.\n\n" +
+            this.historyTranscript,
+        },
+      });
+    }
+
+    if (typeof input === "string") {
+      promptBlocks.push({ type: "text", text: input });
+      this.emitEvent({ type: "user_message", message: input, timestamp: Date.now() });
+    } else {
+      for (const block of input) {
+        if (block.type === "text") {
+          promptBlocks.push({ type: "text", text: block.text });
+        } else if (block.type === "image") {
+          // ACP's image block expects { type: "image", data, mimeType }.
+          // Translate SNA's Anthropic-style {source:{type,media_type,data}}
+          // shape into that.
+          promptBlocks.push({
+            type: "image",
+            data: block.source.data,
+            mimeType: block.source.media_type,
+          });
+        }
+      }
+      this.emitEvent({
+        type: "user_message",
+        data: { blocks: input },
+        timestamp: Date.now(),
+      });
+    }
+
+    this.firstPromptSent = true;
+
+    try {
+      const result = (await this.request("session/prompt", {
+        sessionId: this._sessionId,
+        prompt: promptBlocks,
+      })) as { stopReason?: string } | undefined;
+      this.emitEvent({
+        type: "complete",
+        data: { stopReason: result?.stopReason ?? null },
+        timestamp: Date.now(),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emitEvent({ type: "error", message, timestamp: Date.now() });
+    }
+  }
+
+  interrupt(): void {
+    if (!this._sessionId || !this._alive) return;
+    // ACP's `session/cancel` is a notification, not a request — the
+    // current session/prompt request resolves with stopReason="cancelled"
+    // once grok stops the turn.
+    try {
+      this.write({
+        jsonrpc: "2.0",
+        method: "session/cancel",
+        params: { sessionId: this._sessionId },
+      });
+      this.emitEvent({ type: "interrupted", timestamp: Date.now() });
+    } catch (err) {
+      logger.log("agent", `grok: interrupt failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  setModel(_model: string): void {
+    // ACP does not expose a runtime model swap. grok currently advertises
+    // a single model ("grok-build"), so this is effectively no-op for now.
+    // If multiple models appear later, the only path is respawn — exposed
+    // via applyPatch().
+  }
+
+  setPermissionMode(_mode: string): void {
+    // ACP permissionMode is fixed at process startup. Runtime change
+    // requires respawn — returned as leftover from applyPatch.
+  }
+
+  applyPatch(patch: SessionPatch): SessionPatch {
+    // No in-place patching is supported yet — every mutable field requires
+    // a respawn. Return the patch unchanged so session-manager handles it.
+    return { ...patch };
+  }
+
+  respondToPermission(requestId: string, approved: boolean): void {
+    const rpcId = this.pendingPermissions.get(requestId);
+    if (rpcId == null) {
+      logger.log("agent", `grok: respondToPermission called for unknown requestId=${requestId}`);
+      return;
+    }
+    this.pendingPermissions.delete(requestId);
+    // Match the option kinds observed in the probe: "allow-once" /
+    // "reject-once". (grok also offers "always" variants — exposing those
+    // later would require richer respondToPermission semantics.)
+    const optionId = approved ? "allow-once" : "reject-once";
+    try {
+      // ACP RequestPermissionResponse shape: { outcome: <Outcome> }, where the
+      // outcome itself uses `outcome` as its discriminator (not `type`).
+      //   { outcome: { outcome: "selected", optionId: "allow-once" } }
+      //   { outcome: { outcome: "cancelled" } }
+      // grok rejects {type:"selected"} with -32603 "failed to deserialize response".
+      this.write({
+        jsonrpc: "2.0",
+        id: rpcId,
+        result: { outcome: { outcome: "selected", optionId } },
+      });
+    } catch (err) {
+      logger.log("agent", `grok: permission response failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  kill(): void {
+    if (!this._alive) return;
+    this._alive = false;
+    try {
+      this.proc.kill("SIGTERM");
+    } catch {
+      // already dead
+    }
+    // Hard fallback if grok doesn't exit cleanly within 2s.
+    setTimeout(() => {
+      try {
+        if (this.proc.exitCode == null) this.proc.kill("SIGKILL");
+      } catch {
+        // ignore
+      }
+    }, 2000).unref();
+  }
+
+  closeThread(): void {
+    // Not pooled — same as kill.
+    this.kill();
+  }
+
+  get alive(): boolean { return this._alive; }
+  get pid(): number | null { return this.proc.pid ?? null; }
+  get sessionId(): string | null { return this._sessionId; }
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+export class GrokProvider implements AgentProvider {
+  readonly name = "grok";
+  readonly supportsRuntimePooling = false;
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const p = resolveGrokPath(process.cwd());
+      execSync(`"${p}" --version`, { stdio: "pipe", timeout: 5000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  spawn(options: SpawnOptions): AgentProcess {
+    logger.log("agent", `grok: spawn cwd=${options.cwd} model=${options.model ?? "default"}`);
+    return new GrokProcess(options);
+  }
+
+  async complete(options: CompleteOptions): Promise<CompletionResult> {
+    // One-shot path uses `grok -p` headless mode. We bypass the ACP stdio
+    // pump entirely — for stateless text-in/text-out calls (e.g. session
+    // title generation) there's no need to spin up an ACP session.
+    const grokPath = resolveGrokPath(options.cwd);
+    const cwd = options.cwd ?? process.cwd();
+
+    // Streaming via onDelta uses --output-format streaming-json. The probe
+    // showed that streaming-json omits tool_call events — fine for
+    // complete() which is text-only — but yields {type, data} text/thought
+    // chunks we can dispatch immediately.
+    const streaming = typeof options.onDelta === "function";
+    const args = [
+      "-p", options.prompt,
+      "--output-format", streaming ? "streaming-json" : "json",
+    ];
+    if (options.model) args.push("--model", options.model);
+    if (options.reasoningLevel !== undefined) {
+      args.push("--reasoning-effort", toGrokEffort(options.reasoningLevel));
+    }
+    if (options.systemPrompt) {
+      args.push("--system-prompt-override", options.systemPrompt);
+    }
+    if (options.appendSystemPrompt) {
+      args.push("--rules", options.appendSystemPrompt);
+    }
+    if (options.extraArgs) args.push(...options.extraArgs);
+
+    const timeout = options.timeout ?? 60_000;
+    const model = options.model ?? "grok-build";
+
+    logger.log(
+      "agent",
+      `complete: provider=grok model=${model} prompt="${options.prompt.slice(0, 60)}..."`,
+    );
+
+    return new Promise<CompletionResult>((resolve, reject) => {
+      const start = Date.now();
+      const proc = spawn(grokPath, args, {
+        cwd,
+        env: { ...process.env, ...(options.env ?? {}) },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let streamBuf = "";
+
+      const timer = setTimeout(() => {
+        proc.kill("SIGTERM");
+        reject(new Error(`grok complete timed out after ${timeout}ms`));
+      }, timeout);
+
+      proc.stdout!.on("data", (chunk: Buffer) => {
+        const text = chunk.toString();
+        stdout += text;
+        if (!streaming) return;
+        streamBuf += text;
+        const lines = streamBuf.split("\n");
+        streamBuf = lines.pop() ?? "";
+        for (const line of lines) {
+          const t = line.trim();
+          if (!t) continue;
+          try {
+            const evt = JSON.parse(t) as { type?: string; data?: string };
+            if (evt.type === "text" && typeof evt.data === "string" && options.onDelta) {
+              try {
+                options.onDelta(evt.data);
+              } catch (cbErr) {
+                clearTimeout(timer);
+                proc.kill();
+                reject(cbErr instanceof Error ? cbErr : new Error(String(cbErr)));
+                return;
+              }
+            }
+          } catch {
+            // ignore malformed lines
+          }
+        }
+      });
+
+      proc.stderr!.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      proc.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+
+      proc.on("exit", (code) => {
+        clearTimeout(timer);
+        const durationMs = Date.now() - start;
+        if (code !== 0) {
+          const stderrTail = stderr.trim().split("\n").slice(-3).join(" | ");
+          reject(new Error(`grok exited with code ${code}: ${stderrTail || "(no stderr)"}`));
+          return;
+        }
+
+        let resultText = "";
+        let stopReason: string | undefined;
+        let sessionId: string | undefined;
+        try {
+          if (streaming) {
+            // Aggregate text deltas; the final `{"type":"end", ...}` event
+            // carries stopReason + sessionId.
+            const lines = stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+            const parts: string[] = [];
+            for (const line of lines) {
+              const evt = JSON.parse(line) as { type?: string; data?: string; stopReason?: string; sessionId?: string };
+              if (evt.type === "text" && typeof evt.data === "string") parts.push(evt.data);
+              if (evt.type === "end") {
+                stopReason = evt.stopReason;
+                sessionId = evt.sessionId;
+              }
+            }
+            resultText = parts.join("");
+          } else {
+            const parsed = JSON.parse(stdout) as { text?: string; stopReason?: string; sessionId?: string };
+            resultText = parsed.text ?? "";
+            stopReason = parsed.stopReason;
+            sessionId = parsed.sessionId;
+          }
+        } catch (err) {
+          reject(new Error(`grok complete: failed to parse stdout: ${err instanceof Error ? err.message : String(err)}`));
+          return;
+        }
+
+        void stopReason;
+        void sessionId;
+
+        resolve({
+          text: resultText,
+          usage: {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+          },
+          costUsd: 0,
+          durationMs,
+          durationApiMs: durationMs,
+          model,
+        });
+      });
+    });
+  }
+
+  async listModels(_config?: ListModelsConfig): Promise<ListModelsResult> {
+    // grok exposes its catalog via `grok models` (human-readable). The JSON
+    // contract is unstable, so we hard-code the single model we have
+    // observed (grok-build, 512k ctx). Refresh this when xAI adds more.
+    const model: RuntimeModelInfo = {
+      id: "grok-build",
+      label: "Grok Build",
+      provider: "xai",
+      source: "static",
+      contextWindow: 512_000,
+    };
+    return { models: [model], source: "static", fetchedAt: Date.now() };
+  }
+}

--- a/packages/core/src/core/providers/index.ts
+++ b/packages/core/src/core/providers/index.ts
@@ -18,18 +18,21 @@ export {
 export { ClaudeCodeProvider } from "./claude-code.js";
 export { CodexProvider } from "./codex.js";
 export { OpenCodeProvider } from "./opencode.js";
+export { GrokProvider } from "./grok.js";
 export { spawnWithPool } from "./spawn-helper.js";
 
 import type { AgentProvider } from "./types.js";
 import { ClaudeCodeProvider } from "./claude-code.js";
 import { CodexProvider } from "./codex.js";
 import { OpenCodeProvider } from "./opencode.js";
+import { GrokProvider } from "./grok.js";
 
 const providers: Record<string, AgentProvider> = {
   "claude-code": new ClaudeCodeProvider(),
   "codex": new CodexProvider(),
   "opencode": new OpenCodeProvider(),
   "omlx": new ClaudeCodeProvider(),
+  "grok": new GrokProvider(),
 };
 
 /**

--- a/packages/core/src/core/providers/reasoning-level.ts
+++ b/packages/core/src/core/providers/reasoning-level.ts
@@ -6,14 +6,14 @@
  * The translation tables collapse where the provider's own scale is
  * shorter than 6 steps:
  *
- *   level | Claude Code `--effort` | Codex `model_reasoning_effort`
- *   ------+------------------------+-------------------------------
- *     0   | low                    | none
- *     1   | low      (collapse)    | minimal
- *     2   | medium                 | low
- *     3   | high                   | medium
- *     4   | xhigh                  | high
- *     5   | max                    | xhigh
+ *   level | Claude Code `--effort` | Codex `model_reasoning_effort` | Grok `--effort`
+ *   ------+------------------------+--------------------------------+----------------
+ *     0   | low                    | none                           | low
+ *     1   | low      (collapse)    | minimal                        | low (collapse)
+ *     2   | medium                 | low                            | medium
+ *     3   | high                   | medium                         | high
+ *     4   | xhigh                  | high                           | xhigh
+ *     5   | max                    | xhigh                          | max
  *
  * OpenCode currently has no equivalent knob exposed in its provider —
  * `reasoningLevel` is silently ignored there.
@@ -23,9 +23,11 @@ export type ReasoningLevel = 0 | 1 | 2 | 3 | 4 | 5;
 
 const CLAUDE_TABLE = ["low", "low", "medium", "high", "xhigh", "max"] as const;
 const CODEX_TABLE = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
+const GROK_TABLE = ["low", "low", "medium", "high", "xhigh", "max"] as const;
 
 export type ClaudeEffort = (typeof CLAUDE_TABLE)[number];
 export type CodexEffort = (typeof CODEX_TABLE)[number];
+export type GrokEffort = (typeof GROK_TABLE)[number];
 
 /** Translate a level to Claude Code's `--effort` argument value. */
 export function toClaudeEffort(level: ReasoningLevel): ClaudeEffort {
@@ -35,4 +37,9 @@ export function toClaudeEffort(level: ReasoningLevel): ClaudeEffort {
 /** Translate a level to Codex's `model_reasoning_effort` / `turn/start.effort` value. */
 export function toCodexEffort(level: ReasoningLevel): CodexEffort {
   return CODEX_TABLE[level];
+}
+
+/** Translate a level to Grok's `--effort` argument value. */
+export function toGrokEffort(level: ReasoningLevel): GrokEffort {
+  return GROK_TABLE[level];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,7 @@ export type { Session, SessionInfo, SessionManagerOptions, SessionState } from "
 // Consumers building their own latency-tuning layers can introspect or
 // reuse the same translation tables that codex.ts / claude-code.ts use.
 export type { ReasoningLevel } from "./core/providers/reasoning-level.js";
-export { toClaudeEffort, toCodexEffort } from "./core/providers/reasoning-level.js";
+export { toClaudeEffort, toCodexEffort, toGrokEffort } from "./core/providers/reasoning-level.js";
 
 // Runtime pool — exposed so consumer apps can pre-warm daemons (warmup
 // `prepare()` once at startup so subsequent completion()/spawn() calls hit


### PR DESCRIPTION
## Summary

Adds the **Grok Build** provider to SNA — the first runtime SNA speaks
via a public-standard wire protocol ([ACP](https://agentclientprotocol.com)),
implemented on top of \`grok agent stdio\`. Also adds a per-feature
compatibility matrix doc page so users can see at a glance which SNA
features work with which provider.

### Code
- \`core/providers/grok.ts\` (new, ~540 lines) — full \`AgentProvider\`
  implementation: JSON-RPC pump, ACP handshake, \`session/update\` →
  \`AgentEvent\` translation (5 sub-types), \`session/request_permission\`
  bidirectional flow (Codex pattern reused), \`session/cancel\` interrupt,
  one-shot \`grok -p\` headless mode with \`onDelta\` streaming.
- \`core/providers/reasoning-level.ts\` — adds \`GROK_TABLE\` and \`toGrokEffort\`
  (same 5-step table as Claude Code).
- \`core/providers/index.ts\` — registers \`\"grok\": new GrokProvider()\`.
- \`packages/core/src/index.ts\` — re-exports \`toGrokEffort\`.

### History injection (option B)
Probing showed ACP's \`session/load\` only replays UI events without
restoring model context, and the underlying \`chat_history.jsonl\` is
xAI-internal and gets regenerated on load. So we don't touch the
storage layer — instead we serialise SNA's canonical history into a
single ACP \`resource\` content block on the first \`session/prompt\`.
The embedded context persists across subsequent turns within the same
session, so re-injection is not required (verified by smoke test).

### Permission flow
ACP \`session/request_permission\` is structurally identical to Codex's
bidirectional server-request pattern. The response shape uses ACP's
double-\`outcome\` discriminator: \`{outcome:{outcome:\"selected\",optionId}}\`.
Sending \`{type:\"selected\"}\` instead is the one bug found and fixed
during validation — grok logs \"failed to deserialize response\" and
silently keeps the tool blocked.

### Docs
- Adds Grok Build to \`introduction/providers.{mdx,ko.mdx,ja.mdx}\`
  (runtime table, ACP-standard note, reasoning-level mapping).
- Adds \`introduction/feature-matrix.{mdx,ko.mdx,ja.mdx}\` — per-feature
  compatibility view across Claude Code / Codex / OpenCode / Grok Build.
  Six sections: runtime characteristics, session lifecycle, \`applyPatch\`,
  permission flow, SpawnOptions (+\`providerOptions\` sub-table), and
  cross-provider history replay.
- Registers feature-matrix in \`introduction/meta.{json,ko.json,ja.json}\`.

### Naming convention
Product references say **\"Grok Build\"** (mirroring how \"Claude Code\"
is used elsewhere). Lowercase \`grok\` is reserved for the CLI binary,
registry key, and JSON-RPC method names. Spelled out in the
\`grok.ts\` header comment.

## Validation

Validated against \`grok 0.1.212\` with 8 live smoke tests (full traces
in dev notes — happy to share on request):

| Test | Result |
|---|---|
| \`isAvailable()\` | ✅ |
| spawn / initialize / session/new handshake | ✅ |
| send → session/prompt → delta stream → complete | ✅ |
| \`session/update\` event translation (5 sub-types) | ✅ |
| Permission bidirectional round-trip (allow & deny) | ✅ (caught + fixed 1 bug) |
| History injection via \`resource\` block | ✅ |
| \`complete()\` headless (\`grok -p\`) | ✅ |
| \`complete()\` \`onDelta\` streaming | ✅ |
| Multi-turn context retention within one session | ✅ |
| \`interrupt()\` mid-turn (\`session/cancel\`) | ✅ |
| \`getProvider(\"grok\")\` registry lookup | ✅ |

Docs site builds clean (219 paths).

## What's intentionally deferred
- **Daemon pooling** — Grok Build is stateless per session like Claude
  Code; no pool today. Can be revisited if startup latency matters.
- **MCP wiring through Grok Build** — ACP \`session/new\` accepts an
  \`mcpServers\` array but SNA passes \`[]\` today.
- **Extracting an \`AcpStdioProcess\` base class** — \`grok.ts\` is
  ~70% ACP-standard / 30% Grok-specific and is structured to extract
  later, but YAGNI until a second ACP-speaking provider lands.
- **SessionManager integration smoke test** — the provider passes every
  unit-level path, and \`getProvider(\"grok\")\` returns it correctly so
  the existing session manager wire works without changes. End-to-end
  through DB + WebSocket needs a real server boot, which is better
  covered by a follow-up integration test PR.

## Test plan

- [ ] Reviewer runs \`pnpm install && pnpm --filter @sna/core build\` —
      expect green
- [ ] Reviewer runs \`pnpm --filter @sna/docs build\` — expect 219 paths
- [ ] (Optional) Reviewer with a logged-in \`grok\` CLI runs the smoke
      suites in \`/tmp/grok-smoke-suite.mjs\` and \`/tmp/grok-extra-suite.mjs\`
      (not committed; available in branch dev notes)
- [ ] (Optional) Reviewer wires up a session via SessionManager with
      \`config.provider = \"grok\"\` and watches the event stream