### PR TITLE
feat: Cursor provider via ACP-over-stdio + AcpStdioProcess base

### DIFF
--- a/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
@@ -1,11 +1,11 @@
 ---
 title: 機能 × プロバイダマトリクス
-description: SNA の各機能が Claude Code、Codex、OpenCode、Grok Build でどう動くか — 行ごとの注意点付き。
+description: SNA の各機能が Claude Code、Codex、OpenCode、Grok Build、Cursor でどう動くか — 行ごとの注意点付き。
 icon: TableProperties
 ---
 
 SNA のすべての機能は同じ `AgentProvider` インタフェースを通りますが、
-各ランタイムは自前のネイティブ表面を持っているため、4 つのプロバイダ
+各ランタイムは自前のネイティブ表面を持っているため、5 つのプロバイダ
 の能力が完全に揃うわけではありません。このページでは、どの機能が
 どこで実際に動くかを行ごとの注意点付きで列挙します。
 
@@ -14,39 +14,40 @@ SNA のすべての機能は同じ `AgentProvider` インタフェースを通�
 ネイティブ表面そのものを持たないことを意味します。
 
 > 最終検証対象: Claude Code 1.x, Codex 0.x (`app-server`),
-> OpenCode 0.x (`serve`), Grok Build CLI 0.1.x.
+> OpenCode 0.x (`serve`), Grok Build CLI 0.1.x, Cursor CLI 2026.05.
 
 ## ランタイム特性
 
-| 能力 | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| ワイヤプロトコル | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio |
-| `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ |
-| `supportsCwdPerThread` | 該当なし | ✓ | ✗ | 該当なし |
-| 公開標準プロトコル | ✗ ベンダ | ✗ ベンダ | ✗ ベンダ | ✓ [ACP](https://agentclientprotocol.com) |
-| Cold-start コスト | 呼び出しごとに約 1 秒 spawn | デーモン約 2 秒 spawn、再利用 | デーモン約 3 秒 spawn、再利用 | セッションごとに約 2 秒 spawn |
+| 能力 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| ワイヤプロトコル | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio | `agent acp` ACP JSON-RPC stdio |
+| `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ | ✗ |
+| `supportsCwdPerThread` | 該当なし | ✓ | ✗ | 該当なし | 該当なし |
+| 公開標準プロトコル | ✗ ベンダ | ✗ ベンダ | ✗ ベンダ | ✓ [ACP](https://agentclientprotocol.com) | ✓ [ACP](https://agentclientprotocol.com) |
+| Cold-start コスト | 呼び出しごとに約 1 秒 spawn | デーモン約 2 秒 spawn、再利用 | デーモン約 3 秒 spawn、再利用 | セッションごとに約 2 秒 spawn | セッションごとに約 2 秒 spawn |
 
-Claude Code と Grok Build は呼び出し/セッション単位で stateless —
+Claude Code、Grok Build、Cursor は呼び出し/セッション単位で stateless —
 spawn ごとに新しい子プロセス。Codex と OpenCode は `RuntimePool` を
 通じてデーモンを共有します。Codex のデーモンだけが `cwd`-非依存なの
 で、単一プールのデーモン上で異なる作業ディレクトリのセッションを
-ホストできる唯一のプロバイダです。
+ホストできる唯一のプロバイダです。2 つの ACP-スピーキングプロバイダ
+(Grok Build, Cursor) は `core/providers/acp/base.ts` を共有します。
 
 ## セッションライフサイクル
 
-| 能力 | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `spawn(opts)` → AgentProcess | ✓ | ✓ | ✓ | ✓ |
-| セッション中の `AgentEvent` ストリーミング | ✓ | ✓ | ✓ | ✓ |
-| turn 中の `interrupt()` | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) |
-| `kill()` / `closeThread()` | ✓ | ✓ (プール refcount 認識) | ✓ (プール refcount 認識) | ✓ |
-| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) |
-| `complete()` `onDelta` ストリーミング | ✓ stream-json | ✓ `item/agentMessage/delta` | ✗ 現状の SDK 呼び出しは single-shot | ✓ streaming-json text イベント |
-| `listModels()` | ✓ static + oMLX API | ✓ static catalog | ✓ `opencode` CLI プローブ | ✓ static (単一: `grok-build`) |
+| 能力 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `spawn(opts)` → AgentProcess | ✓ | ✓ | ✓ | ✓ | ✓ |
+| セッション中の `AgentEvent` ストリーミング | ✓ | ✓ | ✓ | ✓ | ✓ |
+| turn 中の `interrupt()` | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) | ✓ (ACP `session/cancel`) |
+| `kill()` / `closeThread()` | ✓ | ✓ (プール refcount 認識) | ✓ (プール refcount 認識) | ✓ | ✓ |
+| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) | ✓ (`agent -p`) |
+| `complete()` `onDelta` ストリーミング | ✓ stream-json | ✓ `item/agentMessage/delta` | ✗ 現状の SDK 呼び出しは single-shot | ✓ streaming-json text イベント | ✓ stream-json `assistant` チャンク (`model_call_id` なし) |
+| `listModels()` | ✓ static + oMLX API | ✓ static catalog | ✓ `opencode` CLI プローブ | ✓ static (単一: `grok-build`) | ✓ `agent models` テキストパース + static fallback |
 
 OpenCode はストリーミングで例外です。現在の SDK ヘルパが single-shot
 のため、`complete()` に `onDelta` を渡しても成功はしますがコール
-バックは発火しません。`complete()` の戻り値自体は正しいです。
+バックは発火しません。
 
 ## インプレース変更 (`applyPatch`)
 
@@ -55,61 +56,64 @@ OpenCode はストリーミングで例外です。現在の SDK ヘルパが si
 フィールドは、セッションマネージャが kill して history replay と
 ともに respawn する必要があります。
 
-| フィールド | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `model` | ✓ control_request `set_model` | ✓ 次 turn override | ✓ per-session override | ✗ leftover (respawn) |
-| `permissionMode` | ✓ control_request | ✓ 次 turn sandbox policy | ✓ per-session override | ✗ leftover (respawn) |
-| `cwd` | ✗ leftover | ✓ 次 turn override (唯一可能なプロバイダ) | ✗ leftover | ✗ leftover |
+| フィールド | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `model` | ✓ control_request `set_model` | ✓ 次 turn override | ✓ per-session override | ✗ leftover (respawn) | ✗ leftover (respawn) |
+| `permissionMode` | ✓ control_request | ✓ 次 turn sandbox policy | ✓ per-session override | ✗ leftover (respawn) | ✗ leftover (respawn) |
+| `cwd` | ✗ leftover | ✓ 次 turn override (唯一可能なプロバイダ) | ✗ leftover | ✗ leftover | ✗ leftover |
 
-Grok Build はすべてのフィールドを leftover として返します。ACP には
-ランタイム変更メソッドがなく、カタログにモデルが 1 つしかないため
-`setModel` で切り替える先もないからです。2 つ目のモデルが追加されても、
-history replay 付きの respawn は変わらず動きます。
+2 つの ACP-スピーキングプロバイダはすべてのフィールドを leftover と
+して返します。ACP にランタイム変更メソッドがないためです。
+respawn-with-history-replay は変わらず動きます。
 
 ## 権限フロー
 
-| 能力 | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `permission_needed` AgentEvent emit | ✓ hook ブリッジ経由 | ✓ JSON-RPC server-request 経由 | ✓ HTTP webhook 経由 | ✓ ACP `session/request_permission` 経由 |
-| `respondToPermission(id, approved)` | ✗ 外部 hook スクリプトが承認処理 | ✓ JSON-RPC response | ✓ POST `/permissions/:id` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` |
-| 双方向 (プロバイダがこちらを待つ) | ✗ hook スクリプトが決定 | ✓ | ✓ | ✓ |
+| 能力 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `permission_needed` AgentEvent emit | ✓ hook ブリッジ経由 | ✓ JSON-RPC server-request 経由 | ✓ HTTP webhook 経由 | ✓ ACP `session/request_permission` 経由 | ✓ ACP `session/request_permission` 経由 |
+| `respondToPermission(id, approved)` | ✗ 外部 hook スクリプトが承認処理 | ✓ JSON-RPC response | ✓ POST `/permissions/:id` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` |
+| 双方向 (プロバイダがこちらを待つ) | ✗ hook スクリプトが決定 | ✓ | ✓ | ✓ | ✓ |
+| `bypassPermissions` 自動承認 | ✓ hook スクリプトが常に許可 | ✓ 次 turn override | ✓ per-session override | ✓ ACP base が自動で `allow_*` を返す | ✓ ACP base が自動で `allow_*` を返す |
 
 Claude Code の権限モデルは out-of-band です — SNA が hook スクリプトを
 書いておくと CLI がそれを呼び、スクリプトが (permissionMode と
 allow/deny ルールに基づいて) 自分で判断し、CLI は SNA プロセスを
-待ちません。他の 3 つは双方向です: エージェントの turn は SNA の
-権限レスポンス到着まで一時停止します。Claude Code の
-`respondToPermission` は設計上 no-op です。
+待ちません。他の 4 つは双方向です。
 
 ## 設定ノブ (SpawnOptions)
 
-| フィールド | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start` の `baseInstructions` | ✓ `appendSystemPrompt` と結合 | ✓ `--system-prompt-override` |
-| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start` の `developerInstructions` | ✓ `systemPrompt` と結合 | ✓ `--rules` |
-| `allowedTools` | ✓ ネイティブ `--allowedTools` | ✓ PreToolUse hook (他を deny) | ⚠ best-effort (既知のツールのみトグル) | ✓ `--tools` 許可リスト |
-| `disallowedTools` | ✓ ネイティブ `--disallowedTools` | ✓ PreToolUse hook | ✓ 列挙されたツールを無効化 | ✓ `--disallowed-tools` |
-| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` に書き出し | ✓ SDK 経由 | ⚠ `session/new` は受け付けるが SNA からはまだ配線していない |
-| `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 無視 | ✓ `toGrokEffort` → `--reasoning-effort` |
-| `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 対応なし | ✗ 対応なし (Grok Build は `~/.grok` 固定) |
-| `resumeSessionId` | ✓ JSONL replay ファイル経由 | ✓ `thread/resume` API | ✓ session id | ⚠ Grok Build 自身のセッション id で resume は動くが、クロスプロバイダ history は下記 `resource` block 経路 |
+| フィールド | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start` の `baseInstructions` | ✓ `appendSystemPrompt` と結合 | ✓ `--system-prompt-override` | ⚠ CLI フラグ無し。ユーザの `AGENTS.md` か最初のプロンプトに fold (SNA からはまだ配線していない) |
+| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start` の `developerInstructions` | ✓ `systemPrompt` と結合 | ✓ `--rules` | ⚠ `systemPrompt` と同様 |
+| `allowedTools` | ✓ ネイティブ `--allowedTools` | ✓ PreToolUse hook (他を deny) | ⚠ best-effort (既知のツールのみトグル) | ✓ `--tools` 許可リスト | ⚠ `~/.cursor/cli-config.json` の `permissions.allow` 経由 (user-global、SNA は管理しない) |
+| `disallowedTools` | ✓ ネイティブ `--disallowedTools` | ✓ PreToolUse hook | ✓ 列挙されたツールを無効化 | ✓ `--disallowed-tools` | ⚠ `allowedTools` と同様 (または `--mode plan` でセッション全体 read-only) |
+| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` に書き出し | ✓ SDK 経由 | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ⚠ ユーザの `~/.cursor/mcp.json` に依存; per-session stdio MCP 注入は後続タスク |
+| `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 無視 | ✓ `toGrokEffort` → `--effort` | ✓ `applyCursorReasoning` → モデル ID サフィックス (`gpt-5.3-codex` → `gpt-5.3-codex-high`) |
+| `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 対応なし | ✗ 対応なし (Grok Build は `~/.grok` 固定) | ✗ 対応なし (Cursor は `~/.cursor` 固定; `CURSOR_CONFIG_DIR` は `cli-config.json` だけリルート、hook はリルートしない) |
+| `resumeSessionId` | ✓ JSONL replay ファイル経由 | ✓ `thread/resume` API | ✓ session id | ⚠ Grok Build chat id で resume は動くが、クロスプロバイダ history は下記 `resource` block 経路 | ⚠ Cursor `chatId` で resume 動作 (`--resume <id>` / `session/load`)、クロスプロバイダ history は同じ経路 |
 
 ### `providerOptions` (プロバイダごとの escape hatch)
 
-| キー | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `settings` | ✓ `--settings` JSON にマージ | ✓ 同じ hook shape | — | — |
-| `settingSources` | ✓ `--setting-sources` | — | — | — |
-| `strictMcpConfig` | ✓ `--strict-mcp-config` | — | — | — |
-| `maxTurns` | ✓ `--max-turns` | — | — | — |
-| `omlxBaseUrl` | ✓ `ANTHROPIC_BASE_URL` をルーティング | — | — | — |
-| `serviceTier` | ✗ 誤課金 (`/fast` はモデルであって tier ではない) | ✓ `priority` / `flex` / `batch` | — | — |
-| `profile` | — | ✓ `config.toml` プロファイル | — | — |
-| `config` (`-c key=value`) | — | ✓ `codex exec` オーバーライド | — | — |
-| `serverUrl` | — | — | ✓ spawn を飛ばして既存デーモンに attach | — |
-| `modelProviderId` | — | — | ✓ `{providerID, modelID}` の provider 半分 | — |
-| `agent` | — | — | ✓ build / plan / etc. | — |
-| `logLevel` | — | — | ✓ `opencode serve --log-level` | — |
+| キー | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `settings` | ✓ `--settings` JSON にマージ | ✓ 同じ hook shape | — | — | — |
+| `settingSources` | ✓ `--setting-sources` | — | — | — | — |
+| `strictMcpConfig` | ✓ `--strict-mcp-config` | — | — | — | — |
+| `maxTurns` | ✓ `--max-turns` | — | — | — | — |
+| `omlxBaseUrl` | ✓ `ANTHROPIC_BASE_URL` をルーティング | — | — | — | — |
+| `serviceTier` | ✗ 誤課金 (`/fast` はモデルであって tier ではない) | ✓ `priority` / `flex` / `batch` | — | — | — |
+| `profile` | — | ✓ `config.toml` プロファイル | — | — | — |
+| `config` (`-c key=value`) | — | ✓ `codex exec` オーバーライド | — | — | — |
+| `serverUrl` | — | — | ✓ spawn を飛ばして既存デーモンに attach | — | — |
+| `modelProviderId` | — | — | ✓ `{providerID, modelID}` の provider 半分 | — | — |
+| `agent` | — | — | ✓ build / plan / etc. | — | — |
+| `logLevel` | — | — | ✓ `opencode serve --log-level` | — | — |
+
+Cursor には現状 SNA-specific の `providerOptions` キーはありません —
+CLI が受け付けるすべてのつまみ (model、reasoning、mode) は型付きの
+`SpawnOptions` フィールドにマップされます。将来 Cursor に新しいフラグ
+が増えればここに登場します。
 
 ## クロスプロバイダ history replay
 
@@ -122,25 +126,31 @@ allow/deny ルールに基づいて) 自分で判断し、CLI は SNA プロセ�
 | Claude Code | Anthropic フォーマットの JSONL を書き出し、パスを `--resume <filepath>` に渡す | `history/claude-code.ts` |
 | Codex | `thread/resume(history=ResponseItems)` JSON-RPC | `history/codex.ts` |
 | OpenCode | SDK 経由の experimental `thread/resume(history=...)` | `history/opencode.ts` |
-| Grok Build | 最初の `session/prompt` で transcript を 1 個の ACP `resource` content block にシリアライズ | `core/providers/grok.ts` インライン (デザイン probe のオプション B) |
+| Grok Build / Cursor | 最初の `session/prompt` で transcript を 1 個の ACP `resource` content block にシリアライズ | `core/providers/acp/base.ts` 共有 (`serializeHistoryForAcp` + `buildHistoryPromptBlock`) |
 
-Grok Build の経路は意図的に異なります: ACP の `session/load` は UI
-イベントを replay するだけでモデルコンテキストを復元せず、その下の
-`chat_history.jsonl` ストレージは xAI 内部フォーマットで session load
-時に再生成されるため — ストレージ層には触れない方針です。代わりに
-最初の turn で過去の transcript をインラインで埋め込み、そのコンテキ
-ストは同じセッションの後続 turn でも保持されるため、再注入は不要です。
+ACP 経路はネイティブ resume 経路と意図的に異なります: ACP の
+`session/load` は UI イベントを replay するだけでモデルコンテキストを
+復元せず、その下の session storage はベンダ内部フォーマット (Grok は
+xAI 内部、Cursor は `~/.cursor/chats/` 下の SQLite) で session load 時
+に再生成されるため — ストレージ層には触れない方針です。代わりに最初
+の turn で過去の transcript をインラインで埋め込み、そのコンテキスト
+は同じセッションの後続 turn でも保持されるため、再注入は不要です。
 
 ## まだマトリクスに無いもの
 
-- **plan mode のランタイム切り替え** (Claude Code `--permission-mode plan`、
-  Grok Build `--permission-mode plan`): CLI フラグは spawn 時に反映
-  されますが、インプレース切り替えには `permissionMode` patch サポート
-  が必要で、Grok Build はまだ持っていません。
-- **Grok Build の MCP 配線**: ACP `session/new` は `mcpServers` 配列
-  を受け付けますが、現在 SNA は `[]` を渡しています。SNA の MCP 設定
-  を経路で渡すのは後続タスクです。
-- **プロンプトへの画像入力**: 4 つのプロバイダはすべて何らかの形で
+- **plan mode のランタイム切り替え** (Claude Code
+  `--permission-mode plan`、Grok Build `--permission-mode plan`、
+  Cursor `--mode plan`): CLI フラグは spawn 時に反映されますが、
+  インプレース切り替えには `permissionMode` patch サポートが必要で、
+  ACP-スピーキングプロバイダはまだ持っていません。
+- **Cursor の MCP 配線**: Cursor の ACP は起動時にユーザの
+  `~/.cursor/mcp.json` を読みます。Per-session stdio MCP 注入 (Grok が
+  `.grok/config.toml` + stdio→HTTP bridge で扱う方式) は後続タスク。
+- **Cursor の `systemPrompt` / `appendSystemPrompt`**: Cursor には
+  エージェントのシステムプロンプトを CLI で override する手段が
+  ありません。`AGENTS.md` (プロジェクト単位、侵襲的) や最初の turn
+  への fold は可能ですが、まだ配線していません。
+- **プロンプトへの画像入力**: 5 つのプロバイダはすべて何らかの形で
   画像 block を受け付けますが、プロバイダごとの添付エンコーディング
   はまだ揃っていません — 現状は
   [セッション › 添付](/ja/docs/introduction/sessions) を参照。

--- a/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
@@ -1,11 +1,11 @@
 ---
 title: 기능 × 프로바이더 매트릭스
-description: 어떤 SNA 기능이 Claude Code, Codex, OpenCode, Grok Build에서 동작하는지 — 각 행마다 단서 조건과 함께.
+description: 어떤 SNA 기능이 Claude Code, Codex, OpenCode, Grok Build, Cursor에서 동작하는지 — 각 행마다 단서 조건과 함께.
 icon: TableProperties
 ---
 
 모든 SNA 기능은 같은 `AgentProvider` 인터페이스를 거치지만, 각 런타임은
-자체 네이티브 표면이 다르기 때문에 4개 프로바이더의 능력이 완전히
+자체 네이티브 표면이 다르기 때문에 5개 프로바이더의 능력이 완전히
 일치하지는 않습니다. 이 페이지는 어디서 무엇이 실제로 동작하는지,
 각 행의 단서 조건을 명시해서 나열합니다.
 
@@ -14,39 +14,39 @@ icon: TableProperties
 네이티브 표면 자체가 없다는 뜻입니다.
 
 > 마지막 검증 대상: Claude Code 1.x, Codex 0.x (`app-server`),
-> OpenCode 0.x (`serve`), Grok Build CLI 0.1.x.
+> OpenCode 0.x (`serve`), Grok Build CLI 0.1.x, Cursor CLI 2026.05.
 
 ## 런타임 특성
 
-| 능력 | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| 와이어 프로토콜 | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio |
-| `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ |
-| `supportsCwdPerThread` | 해당 없음 | ✓ | ✗ | 해당 없음 |
-| 공개 표준 프로토콜 | ✗ 벤더 | ✗ 벤더 | ✗ 벤더 | ✓ [ACP](https://agentclientprotocol.com) |
-| Cold-start 비용 | 호출당 약 1초 spawn | 데몬 약 2초 spawn, 재사용 | 데몬 약 3초 spawn, 재사용 | 세션당 약 2초 spawn |
+| 능력 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| 와이어 프로토콜 | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio | `agent acp` ACP JSON-RPC stdio |
+| `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ | ✗ |
+| `supportsCwdPerThread` | 해당 없음 | ✓ | ✗ | 해당 없음 | 해당 없음 |
+| 공개 표준 프로토콜 | ✗ 벤더 | ✗ 벤더 | ✗ 벤더 | ✓ [ACP](https://agentclientprotocol.com) | ✓ [ACP](https://agentclientprotocol.com) |
+| Cold-start 비용 | 호출당 약 1초 spawn | 데몬 약 2초 spawn, 재사용 | 데몬 약 3초 spawn, 재사용 | 세션당 약 2초 spawn | 세션당 약 2초 spawn |
 
-Claude Code와 Grok Build은 호출/세션 단위로 무상태입니다 — spawn마다
+Claude Code, Grok Build, Cursor는 호출/세션 단위 무상태입니다 — spawn마다
 새 자식 프로세스. Codex와 OpenCode는 `RuntimePool`을 통해 데몬을
 공유합니다. Codex 데몬만 `cwd`-비종속이라서, 단일 풀 데몬 위에서
 서로 다른 작업 디렉토리의 세션을 호스팅할 수 있는 유일한 프로바이더
-입니다.
+입니다. 두 ACP-스피킹 프로바이더(Grok Build, Cursor)는
+`core/providers/acp/base.ts`를 공유합니다.
 
 ## 세션 라이프사이클
 
-| 능력 | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `spawn(opts)` → AgentProcess | ✓ | ✓ | ✓ | ✓ |
-| 세션 중 `AgentEvent` 스트리밍 | ✓ | ✓ | ✓ | ✓ |
-| turn 중간 `interrupt()` | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) |
-| `kill()` / `closeThread()` | ✓ | ✓ (풀 refcount 인식) | ✓ (풀 refcount 인식) | ✓ |
-| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) |
-| `complete()` `onDelta` 스트리밍 | ✓ stream-json | ✓ `item/agentMessage/delta` | ✗ 현재 SDK 호출이 single-shot | ✓ streaming-json text 이벤트 |
-| `listModels()` | ✓ static + oMLX API | ✓ static catalog | ✓ `opencode` CLI 프로브 | ✓ static (`grok-build` 단일 항목) |
+| 능력 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `spawn(opts)` → AgentProcess | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 세션 중 `AgentEvent` 스트리밍 | ✓ | ✓ | ✓ | ✓ | ✓ |
+| turn 중간 `interrupt()` | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) | ✓ (ACP `session/cancel`) |
+| `kill()` / `closeThread()` | ✓ | ✓ (풀 refcount 인식) | ✓ (풀 refcount 인식) | ✓ | ✓ |
+| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) | ✓ (`agent -p`) |
+| `complete()` `onDelta` 스트리밍 | ✓ stream-json | ✓ `item/agentMessage/delta` | ✗ 현재 SDK 호출이 single-shot | ✓ streaming-json text 이벤트 | ✓ stream-json `assistant` 청크 (`model_call_id` 없음) |
+| `listModels()` | ✓ static + oMLX API | ✓ static catalog | ✓ `opencode` CLI 프로브 | ✓ static (`grok-build` 단일 항목) | ✓ `agent models` 텍스트 파싱 + static fallback |
 
 OpenCode는 스트리밍에서 예외입니다. 현재 SDK 헬퍼가 single-shot이라
 `complete()`에 `onDelta`를 넘기면 성공하지만 콜백은 발화하지 않습니다.
-`complete()` 반환값 자체는 정상입니다.
 
 ## 인플레이스 변경 (`applyPatch`)
 
@@ -54,61 +54,63 @@ OpenCode는 스트리밍에서 예외입니다. 현재 SDK 헬퍼가 single-shot
 적용할 수 있는지 선언합니다. "leftover"로 반환된 필드는 세션 매니저가
 kill 후 history replay와 함께 respawn해야 합니다.
 
-| 필드 | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `model` | ✓ control_request `set_model` | ✓ next-turn override | ✓ per-session override | ✗ leftover (respawn) |
-| `permissionMode` | ✓ control_request | ✓ next-turn sandbox 정책 | ✓ per-session override | ✗ leftover (respawn) |
-| `cwd` | ✗ leftover | ✓ next-turn override (유일하게 가능한 프로바이더) | ✗ leftover | ✗ leftover |
+| 필드 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `model` | ✓ control_request `set_model` | ✓ next-turn override | ✓ per-session override | ✗ leftover (respawn) | ✗ leftover (respawn) |
+| `permissionMode` | ✓ control_request | ✓ next-turn sandbox 정책 | ✓ per-session override | ✗ leftover (respawn) | ✗ leftover (respawn) |
+| `cwd` | ✗ leftover | ✓ next-turn override (유일하게 가능한 프로바이더) | ✗ leftover | ✗ leftover | ✗ leftover |
 
-Grok Build은 모든 필드를 leftover로 반환합니다. ACP에 런타임 변경
-메서드가 없고, 카탈로그에 모델이 하나뿐이라 `setModel`이 바꿔낼
-대상도 없기 때문입니다. 두 번째 모델이 추가되더라도 history replay
-respawn은 여전히 동작합니다.
+두 ACP-스피킹 프로바이더는 모든 필드를 leftover로 반환합니다. ACP에는
+런타임 변경 메서드가 없기 때문입니다. respawn-with-history-replay는
+변함없이 동작합니다.
 
 ## 권한 흐름
 
-| 능력 | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `permission_needed` AgentEvent emit | ✓ hook 브릿지 경유 | ✓ JSON-RPC server-request 경유 | ✓ HTTP webhook 경유 | ✓ ACP `session/request_permission` 경유 |
-| `respondToPermission(id, approved)` | ✗ 외부 hook 스크립트가 승인 처리 | ✓ JSON-RPC response | ✓ POST `/permissions/:id` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` |
-| 양방향 (프로바이더가 우리를 기다림) | ✗ hook 스크립트가 결정 | ✓ | ✓ | ✓ |
+| 능력 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `permission_needed` AgentEvent emit | ✓ hook 브릿지 경유 | ✓ JSON-RPC server-request 경유 | ✓ HTTP webhook 경유 | ✓ ACP `session/request_permission` 경유 | ✓ ACP `session/request_permission` 경유 |
+| `respondToPermission(id, approved)` | ✗ 외부 hook 스크립트가 승인 처리 | ✓ JSON-RPC response | ✓ POST `/permissions/:id` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` |
+| 양방향 (프로바이더가 우리를 기다림) | ✗ hook 스크립트가 결정 | ✓ | ✓ | ✓ | ✓ |
+| `bypassPermissions` 자동 승인 | ✓ hook 스크립트가 항상 허용 | ✓ next-turn override | ✓ per-session override | ✓ ACP base가 자동으로 `allow_*` 응답 | ✓ ACP base가 자동으로 `allow_*` 응답 |
 
 Claude Code의 권한 모델은 out-of-band입니다 — SNA가 hook 스크립트를
 써놓으면 CLI가 그것을 호출하고, 스크립트가 (permissionMode 및 allow/deny
 룰을 기준으로) 스스로 판단하며, CLI는 SNA 프로세스를 기다리지 않습니다.
-다른 세 프로바이더는 양방향입니다: 에이전트의 turn이 SNA의 권한 응답
-도착까지 일시정지합니다. Claude Code의 `respondToPermission`은 설계상
-no-op입니다.
+나머지 네 프로바이더는 양방향입니다.
 
 ## 설정 노브 (SpawnOptions)
 
-| 필드 | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start`의 `baseInstructions` | ✓ `appendSystemPrompt`와 결합 | ✓ `--system-prompt-override` |
-| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start`의 `developerInstructions` | ✓ `systemPrompt`와 결합 | ✓ `--rules` |
-| `allowedTools` | ✓ 네이티브 `--allowedTools` | ✓ PreToolUse hook (나머지 거부) | ⚠ best-effort (알려진 도구만 토글) | ✓ `--tools` 허용 목록 |
-| `disallowedTools` | ✓ 네이티브 `--disallowedTools` | ✓ PreToolUse hook | ✓ 나열된 도구 비활성 | ✓ `--disallowed-tools` |
-| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` 기록 | ✓ SDK 경유 | ⚠ `session/new`가 받지만 SNA에서 아직 와이어링 안 됨 |
-| `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 무시 | ✓ `toGrokEffort` → `--reasoning-effort` |
-| `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 대응 없음 | ✗ 대응 없음 (Grok Build은 `~/.grok` 고정) |
-| `resumeSessionId` | ✓ JSONL replay 파일 경유 | ✓ `thread/resume` API | ✓ 세션 id | ⚠ Grok Build 자체 세션 id로 resume은 동작하지만, 크로스 프로바이더 history는 아래 `resource` block 경로 사용 |
+| 필드 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start`의 `baseInstructions` | ✓ `appendSystemPrompt`와 결합 | ✓ `--system-prompt-override` | ⚠ CLI 플래그 없음. 사용자의 `AGENTS.md` 또는 첫 prompt에 fold (SNA에서 아직 와이어링 안 됨) |
+| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start`의 `developerInstructions` | ✓ `systemPrompt`와 결합 | ✓ `--rules` | ⚠ `systemPrompt`와 동일 |
+| `allowedTools` | ✓ 네이티브 `--allowedTools` | ✓ PreToolUse hook (나머지 거부) | ⚠ best-effort (알려진 도구만 토글) | ✓ `--tools` 허용 목록 | ⚠ `~/.cursor/cli-config.json`의 `permissions.allow` 경유 (user-global, SNA 관리 안 함) |
+| `disallowedTools` | ✓ 네이티브 `--disallowedTools` | ✓ PreToolUse hook | ✓ 나열된 도구 비활성 | ✓ `--disallowed-tools` | ⚠ `allowedTools`와 동일 (또는 `--mode plan`으로 세션 전체 read-only) |
+| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` 기록 | ✓ SDK 경유 | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ⚠ 사용자의 `~/.cursor/mcp.json`에 의존; per-session stdio MCP 주입은 follow-up |
+| `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 무시 | ✓ `toGrokEffort` → `--effort` | ✓ `applyCursorReasoning` → 모델 ID 접미사 (`gpt-5.3-codex` → `gpt-5.3-codex-high`) |
+| `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 대응 없음 | ✗ 대응 없음 (Grok Build은 `~/.grok` 고정) | ✗ 대응 없음 (Cursor는 `~/.cursor` 고정; `CURSOR_CONFIG_DIR`는 `cli-config.json`만 redirect, hook은 안 옮김) |
+| `resumeSessionId` | ✓ JSONL replay 파일 경유 | ✓ `thread/resume` API | ✓ 세션 id | ⚠ Grok Build chat id로 resume은 동작하지만, 크로스 프로바이더 history는 아래 `resource` block 경로 사용 | ⚠ Cursor `chatId`로 resume 동작 (`--resume <id>` / `session/load`), 크로스 프로바이더 history는 동일 경로 |
 
 ### `providerOptions` (프로바이더별 escape hatch)
 
-| 키 | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `settings` | ✓ `--settings` JSON에 병합 | ✓ 같은 hook shape | — | — |
-| `settingSources` | ✓ `--setting-sources` | — | — | — |
-| `strictMcpConfig` | ✓ `--strict-mcp-config` | — | — | — |
-| `maxTurns` | ✓ `--max-turns` | — | — | — |
-| `omlxBaseUrl` | ✓ `ANTHROPIC_BASE_URL` 라우팅 | — | — | — |
-| `serviceTier` | ✗ 잘못 과금됨 (`/fast`는 모델, tier가 아님) | ✓ `priority` / `flex` / `batch` | — | — |
-| `profile` | — | ✓ `config.toml` 프로파일 | — | — |
-| `config` (`-c key=value`) | — | ✓ `codex exec` 오버라이드 | — | — |
-| `serverUrl` | — | — | ✓ spawn 생략, 기존 데몬에 attach | — |
-| `modelProviderId` | — | — | ✓ `{providerID, modelID}`의 provider 절반 | — |
-| `agent` | — | — | ✓ build / plan / etc. | — |
-| `logLevel` | — | — | ✓ `opencode serve --log-level` | — |
+| 키 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `settings` | ✓ `--settings` JSON에 병합 | ✓ 같은 hook shape | — | — | — |
+| `settingSources` | ✓ `--setting-sources` | — | — | — | — |
+| `strictMcpConfig` | ✓ `--strict-mcp-config` | — | — | — | — |
+| `maxTurns` | ✓ `--max-turns` | — | — | — | — |
+| `omlxBaseUrl` | ✓ `ANTHROPIC_BASE_URL` 라우팅 | — | — | — | — |
+| `serviceTier` | ✗ 잘못 과금됨 (`/fast`는 모델, tier가 아님) | ✓ `priority` / `flex` / `batch` | — | — | — |
+| `profile` | — | ✓ `config.toml` 프로파일 | — | — | — |
+| `config` (`-c key=value`) | — | ✓ `codex exec` 오버라이드 | — | — | — |
+| `serverUrl` | — | — | ✓ spawn 생략, 기존 데몬에 attach | — | — |
+| `modelProviderId` | — | — | ✓ `{providerID, modelID}`의 provider 절반 | — | — |
+| `agent` | — | — | ✓ build / plan / etc. | — | — |
+| `logLevel` | — | — | ✓ `opencode serve --log-level` | — | — |
+
+Cursor는 현재 SNA-specific `providerOptions` 키가 없습니다 — CLI가
+받는 모든 노브(model, reasoning, mode)는 타입화된 `SpawnOptions` 필드에
+매핑됩니다. 미래에 Cursor가 새 플래그를 추가하면 여기에 등장합니다.
 
 ## 프로바이더 간 history replay
 
@@ -121,24 +123,29 @@ no-op입니다.
 | Claude Code | Anthropic 포맷 JSONL 작성 → `--resume <filepath>`로 경로 전달 | `history/claude-code.ts` |
 | Codex | `thread/resume(history=ResponseItems)` JSON-RPC | `history/codex.ts` |
 | OpenCode | SDK 경유 experimental `thread/resume(history=...)` | `history/opencode.ts` |
-| Grok Build | 첫 `session/prompt`에서 transcript를 단일 ACP `resource` content block으로 직렬화 | `core/providers/grok.ts` 인라인 (디자인 probe의 옵션 B) |
+| Grok Build / Cursor | 첫 `session/prompt`에서 transcript를 단일 ACP `resource` content block으로 직렬화 | `core/providers/acp/base.ts` 공유 (`serializeHistoryForAcp` + `buildHistoryPromptBlock`) |
 
-Grok Build 경로는 의도적으로 다릅니다: probing 결과 ACP `session/load`는
-UI 이벤트만 replay할 뿐 모델 컨텍스트를 복원하지 않고, 아래 깔린
-`chat_history.jsonl` 저장소는 xAI 내부 포맷이고 session load 시
-재생성되기 때문에 — 우리는 저장 계층을 아예 건드리지 않습니다. 대신
-첫 turn에 prior transcript를 인라인으로 embed하고, 그 컨텍스트는 같은
-세션의 후속 turn에서도 유지되므로 재주입은 불필요합니다.
+ACP 경로는 네이티브 resume 경로들과 의도적으로 다릅니다: probing 결과
+ACP `session/load`는 UI 이벤트만 replay할 뿐 모델 컨텍스트를 복원하지
+않고, 그 아래 깔린 세션 저장소는 벤더 내부 포맷(Grok은 xAI 내부, Cursor는
+`~/.cursor/chats/` 아래 SQLite)이고 session load 시 재생성됩니다 — 저장
+계층을 아예 건드리지 않는 방향. 대신 첫 turn에 prior transcript를
+인라인으로 embed하고, 그 컨텍스트는 같은 세션의 후속 turn에서도
+유지되므로 재주입은 불필요합니다.
 
 ## 아직 매트릭스에 없는 것
 
 - **런타임 plan mode 토글** (Claude Code `--permission-mode plan`,
-  Grok Build `--permission-mode plan`): CLI 플래그는 spawn 시점에 반영
-  되지만, 인플레이스 토글은 `permissionMode` patch 지원이 필요한데
-  Grok Build은 아직 지원하지 않습니다.
-- **Grok Build의 MCP 와이어링**: ACP `session/new`는 `mcpServers`
-  배열을 받지만 SNA가 현재 `[]`를 넘깁니다. SNA의 MCP 설정을 throughs로
-  전달하는 작업은 후속 과제입니다.
-- **프롬프트 이미지 입력**: 4개 프로바이더 모두 어떤 형태로든 이미지
+  Grok Build `--permission-mode plan`, Cursor `--mode plan`): CLI 플래그
+  는 spawn 시점에 반영되지만, 인플레이스 토글은 `permissionMode` patch
+  지원이 필요한데 ACP-스피킹 프로바이더들은 아직 지원하지 않습니다.
+- **Cursor MCP 와이어링**: Cursor의 ACP는 사용자의 `~/.cursor/mcp.json`을
+  startup에 읽습니다. Per-session stdio MCP 주입(Grok이 `.grok/config.toml`
+  + stdio→HTTP bridge로 처리하는 방식)은 후속 과제입니다.
+- **Cursor의 `systemPrompt` / `appendSystemPrompt`**: Cursor는 에이전트
+  시스템 프롬프트를 CLI로 override하는 방법이 없습니다. `AGENTS.md`
+  (프로젝트 단위, 침습적) 또는 첫 turn fold가 가능하지만 아직 와이어링
+  안 됨.
+- **프롬프트 이미지 입력**: 5개 프로바이더 모두 어떤 형태로든 이미지
   block을 받지만, 프로바이더별 첨부 인코딩이 아직 일관되지 않습니다 —
   현재 상태는 [세션 › 첨부](/ko/docs/introduction/sessions) 참조.

--- a/apps/docs/content/docs/introduction/feature-matrix.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.mdx
@@ -1,6 +1,6 @@
 ---
 title: Feature × provider matrix
-description: Which SNA features work with Claude Code, Codex, OpenCode, and Grok Build — with the caveats spelled out per row.
+description: Which SNA features work with Claude Code, Codex, OpenCode, Grok Build, and Cursor — with the caveats spelled out per row.
 icon: TableProperties
 ---
 
@@ -14,35 +14,37 @@ provider either ignores it, falls back to respawn, or has no equivalent
 native surface.
 
 > Last verified against: Claude Code 1.x, Codex 0.x (`app-server`),
-> OpenCode 0.x (`serve`), Grok Build CLI 0.1.x.
+> OpenCode 0.x (`serve`), Grok Build CLI 0.1.x, Cursor CLI 2026.05.
 
 ## Runtime characteristics
 
-| Capability | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| Wire protocol | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio |
-| `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ |
-| `supportsCwdPerThread` | n/a | ✓ | ✗ | n/a |
-| Public-standard protocol | ✗ vendor | ✗ vendor | ✗ vendor | ✓ [ACP](https://agentclientprotocol.com) |
-| Cold-start cost | ≈1s spawn per call | ≈2s daemon spawn, reused | ≈3s daemon spawn, reused | ≈2s spawn per session |
+| Capability | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| Wire protocol | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio | `agent acp` ACP JSON-RPC stdio |
+| `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ | ✗ |
+| `supportsCwdPerThread` | n/a | ✓ | ✗ | n/a | n/a |
+| Public-standard protocol | ✗ vendor | ✗ vendor | ✗ vendor | ✓ [ACP](https://agentclientprotocol.com) | ✓ [ACP](https://agentclientprotocol.com) |
+| Cold-start cost | ≈1s spawn per call | ≈2s daemon spawn, reused | ≈3s daemon spawn, reused | ≈2s spawn per session | ≈2s spawn per session |
 
-Claude Code and Grok Build are stateless per call/session — a fresh
-child process per spawn. Codex and OpenCode share daemons through
+Claude Code, Grok Build, and Cursor are stateless per call/session — a
+fresh child process per spawn. Codex and OpenCode share daemons through
 `RuntimePool`. Only Codex's daemon is `cwd`-agnostic, which is why it's
 the only provider that can host sessions for different working
-directories on a single pooled daemon.
+directories on a single pooled daemon. The two ACP-speaking providers
+(Grok Build and Cursor) share `core/providers/acp/base.ts` — see
+[Providers](/docs/introduction/providers) for the split.
 
 ## Session lifecycle
 
-| Capability | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `spawn(opts)` → AgentProcess | ✓ | ✓ | ✓ | ✓ |
-| Streaming `AgentEvent` during session | ✓ | ✓ | ✓ | ✓ |
-| `interrupt()` mid-turn | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) |
-| `kill()` / `closeThread()` | ✓ | ✓ (pool refcount aware) | ✓ (pool refcount aware) | ✓ |
-| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) |
-| `complete()` `onDelta` streaming | ✓ stream-json | ✓ `item/agentMessage/delta` | ✗ SDK call is single-shot today | ✓ streaming-json text events |
-| `listModels()` | ✓ static + oMLX API | ✓ static catalog | ✓ probes `opencode` CLI | ✓ static (single entry: `grok-build`) |
+| Capability | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `spawn(opts)` → AgentProcess | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Streaming `AgentEvent` during session | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `interrupt()` mid-turn | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) | ✓ (ACP `session/cancel`) |
+| `kill()` / `closeThread()` | ✓ | ✓ (pool refcount aware) | ✓ (pool refcount aware) | ✓ | ✓ |
+| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) | ✓ (`agent -p`) |
+| `complete()` `onDelta` streaming | ✓ stream-json | ✓ `item/agentMessage/delta` | ✗ SDK call is single-shot today | ✓ streaming-json text events | ✓ stream-json `assistant` chunks (no `model_call_id`) |
+| `listModels()` | ✓ static + oMLX API | ✓ static catalog | ✓ probes `opencode` CLI | ✓ static (single entry: `grok-build`) | ✓ parses `agent models` (plain text) + static fallback |
 
 OpenCode is the odd one out on streaming: its current SDK helper is
 single-shot, so passing `onDelta` to `complete()` succeeds but never
@@ -54,61 +56,66 @@ Each provider declares which `SessionPatch` fields can be applied in
 place without a respawn. Fields returned as "leftover" require the
 session manager to kill and re-spawn with history replay.
 
-| Field | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `model` | ✓ control_request `set_model` | ✓ next-turn override | ✓ per-session override | ✗ leftover (respawn) |
-| `permissionMode` | ✓ control_request | ✓ next-turn sandbox policy | ✓ per-session override | ✗ leftover (respawn) |
-| `cwd` | ✗ leftover | ✓ next-turn override (the only provider that can) | ✗ leftover | ✗ leftover |
+| Field | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `model` | ✓ control_request `set_model` | ✓ next-turn override | ✓ per-session override | ✗ leftover (respawn) | ✗ leftover (respawn) |
+| `permissionMode` | ✓ control_request | ✓ next-turn sandbox policy | ✓ per-session override | ✗ leftover (respawn) | ✗ leftover (respawn) |
+| `cwd` | ✗ leftover | ✓ next-turn override (the only provider that can) | ✗ leftover | ✗ leftover | ✗ leftover |
 
-Grok Build returns every field as leftover because ACP does not expose
-runtime mutation methods, and there is currently only one model in the
-catalog so `setModel` would have nothing to switch to anyway. If a
-second model appears, respawn-with-history-replay still works.
+Both ACP-speaking providers return every field as leftover because ACP
+does not expose runtime mutation methods. Respawn-with-history-replay
+keeps working as expected for the session manager.
 
 ## Permission flow
 
-| Capability | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `permission_needed` AgentEvent emit | ✓ via hook bridge | ✓ via JSON-RPC server-request | ✓ via HTTP webhook | ✓ via ACP `session/request_permission` |
-| `respondToPermission(id, approved)` | ✗ external hook script handles approval | ✓ JSON-RPC response | ✓ POST `/permissions/:id` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` |
-| Bidirectional (provider waits on us) | ✗ hook script makes the decision | ✓ | ✓ | ✓ |
+| Capability | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `permission_needed` AgentEvent emit | ✓ via hook bridge | ✓ via JSON-RPC server-request | ✓ via HTTP webhook | ✓ via ACP `session/request_permission` | ✓ via ACP `session/request_permission` |
+| `respondToPermission(id, approved)` | ✗ external hook script handles approval | ✓ JSON-RPC response | ✓ POST `/permissions/:id` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` | ✓ ACP `{outcome:{outcome:"selected",optionId}}` |
+| Bidirectional (provider waits on us) | ✗ hook script makes the decision | ✓ | ✓ | ✓ | ✓ |
+| `bypassPermissions` auto-approve | ✓ hook script always allows | ✓ next-turn override | ✓ per-session override | ✓ shared ACP base auto-replies `allow_*` | ✓ shared ACP base auto-replies `allow_*` |
 
 Claude Code's permission model is out-of-band — SNA writes a hook
 script the CLI calls, the script decides on its own (based on
 `permissionMode` and allow/deny rules), and the CLI never waits on
-the SNA process. The other three are bidirectional: the agent's turn
-suspends until SNA sends a permission response. `respondToPermission`
-is a no-op for Claude Code by design.
+the SNA process. The other four providers are bidirectional: the
+agent's turn suspends until SNA sends a permission response.
+`respondToPermission` is a no-op for Claude Code by design.
 
 ## Configuration knobs (SpawnOptions)
 
-| Field | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `systemPrompt` | ✓ `--system-prompt` | ✓ `baseInstructions` on `thread/start` | ✓ joined with `appendSystemPrompt` | ✓ `--system-prompt-override` |
-| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `developerInstructions` on `thread/start` | ✓ joined with `systemPrompt` | ✓ `--rules` |
-| `allowedTools` | ✓ native `--allowedTools` | ✓ via PreToolUse hook (deny-others) | ⚠ best-effort (toggles known tools) | ✓ `--tools` allow-list |
-| `disallowedTools` | ✓ native `--disallowedTools` | ✓ via PreToolUse hook | ✓ disables listed tools | ✓ `--disallowed-tools` |
-| `mcpServers` | ✓ `--mcp-config` JSON | ✓ written to `config.toml` `[mcp_servers.*]` | ✓ via SDK | ⚠ accepted by `session/new` but not yet wired from SNA |
-| `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ ignored | ✓ `toGrokEffort` → `--reasoning-effort` |
-| `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ no equivalent | ✗ no equivalent (Grok Build uses `~/.grok`) |
-| `resumeSessionId` | ✓ via JSONL replay file | ✓ `thread/resume` API | ✓ session id | ⚠ resume from a Grok Build session id works, but cross-provider history goes via the `resource` block path below |
+| Field | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `systemPrompt` | ✓ `--system-prompt` | ✓ `baseInstructions` on `thread/start` | ✓ joined with `appendSystemPrompt` | ✓ `--system-prompt-override` | ⚠ no CLI flag; use the user's `AGENTS.md` or fold into the first prompt (not yet wired by SNA) |
+| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `developerInstructions` on `thread/start` | ✓ joined with `systemPrompt` | ✓ `--rules` | ⚠ same as `systemPrompt` |
+| `allowedTools` | ✓ native `--allowedTools` | ✓ via PreToolUse hook (deny-others) | ⚠ best-effort (toggles known tools) | ✓ `--tools` allow-list | ⚠ via `~/.cursor/cli-config.json` `permissions.allow` (user-global, not yet managed by SNA) |
+| `disallowedTools` | ✓ native `--disallowedTools` | ✓ via PreToolUse hook | ✓ disables listed tools | ✓ `--disallowed-tools` | ⚠ same as `allowedTools` (or `--mode plan` to make the whole session read-only) |
+| `mcpServers` | ✓ `--mcp-config` JSON | ✓ written to `config.toml` `[mcp_servers.*]` | ✓ via SDK | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ⚠ relies on the user's `~/.cursor/mcp.json`; per-session injection of stdio MCP is a follow-up |
+| `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ ignored | ✓ `toGrokEffort` → `--effort` | ✓ `applyCursorReasoning` → model-id suffix (`gpt-5.3-codex` → `gpt-5.3-codex-high`) |
+| `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ no equivalent | ✗ no equivalent (Grok Build uses `~/.grok`) | ✗ no equivalent (Cursor uses `~/.cursor`; `CURSOR_CONFIG_DIR` only reroutes `cli-config.json`, not hooks) |
+| `resumeSessionId` | ✓ via JSONL replay file | ✓ `thread/resume` API | ✓ session id | ⚠ Grok Build chat id works, but cross-provider history goes via the `resource` block path below | ⚠ Cursor `chatId` works (`--resume <id>` / `session/load`), but cross-provider history goes via the same `resource` block path |
 
 ### `providerOptions` (per-provider escape hatches)
 
-| Key | Claude Code | Codex | OpenCode | Grok Build |
-|---|---|---|---|---|
-| `settings` | ✓ merged into `--settings` JSON | ✓ same hook shape | — | — |
-| `settingSources` | ✓ `--setting-sources` | — | — | — |
-| `strictMcpConfig` | ✓ `--strict-mcp-config` | — | — | — |
-| `maxTurns` | ✓ `--max-turns` | — | — | — |
-| `omlxBaseUrl` | ✓ routes `ANTHROPIC_BASE_URL` | — | — | — |
-| `serviceTier` | ✗ would mis-bill (`/fast` is a model, not a tier) | ✓ `priority` / `flex` / `batch` | — | — |
-| `profile` | — | ✓ `config.toml` profile | — | — |
-| `config` (`-c key=value`) | — | ✓ `codex exec` overrides | — | — |
-| `serverUrl` | — | — | ✓ skip spawn, attach to existing daemon | — |
-| `modelProviderId` | — | — | ✓ provider half of `{providerID, modelID}` | — |
-| `agent` | — | — | ✓ build / plan / etc. | — |
-| `logLevel` | — | — | ✓ `opencode serve --log-level` | — |
+| Key | Claude Code | Codex | OpenCode | Grok Build | Cursor |
+|---|---|---|---|---|---|
+| `settings` | ✓ merged into `--settings` JSON | ✓ same hook shape | — | — | — |
+| `settingSources` | ✓ `--setting-sources` | — | — | — | — |
+| `strictMcpConfig` | ✓ `--strict-mcp-config` | — | — | — | — |
+| `maxTurns` | ✓ `--max-turns` | — | — | — | — |
+| `omlxBaseUrl` | ✓ routes `ANTHROPIC_BASE_URL` | — | — | — | — |
+| `serviceTier` | ✗ would mis-bill (`/fast` is a model, not a tier) | ✓ `priority` / `flex` / `batch` | — | — | — |
+| `profile` | — | ✓ `config.toml` profile | — | — | — |
+| `config` (`-c key=value`) | — | ✓ `codex exec` overrides | — | — | — |
+| `serverUrl` | — | — | ✓ skip spawn, attach to existing daemon | — | — |
+| `modelProviderId` | — | — | ✓ provider half of `{providerID, modelID}` | — | — |
+| `agent` | — | — | ✓ build / plan / etc. | — | — |
+| `logLevel` | — | — | ✓ `opencode serve --log-level` | — | — |
+
+Cursor has no SNA-specific `providerOptions` keys today — every knob the
+CLI accepts (model, reasoning, mode) maps to a typed `SpawnOptions`
+field. New escape hatches will surface here if a future Cursor flag
+needs them.
 
 ## Cross-provider history replay
 
@@ -121,12 +128,13 @@ translated into the native shape at the adapter layer.
 | Claude Code | Write Anthropic-format JSONL, pass path to `--resume <filepath>` | `history/claude-code.ts` |
 | Codex | `thread/resume(history=ResponseItems)` JSON-RPC | `history/codex.ts` |
 | OpenCode | Experimental `thread/resume(history=...)` via SDK | `history/opencode.ts` |
-| Grok Build | Serialise transcript into a single ACP `resource` content block on the first `session/prompt` | inline in `core/providers/grok.ts` (option B from the design probe) |
+| Grok Build / Cursor | Serialise transcript into a single ACP `resource` content block on the first `session/prompt` | shared in `core/providers/acp/base.ts` (`serializeHistoryForAcp` + `buildHistoryPromptBlock`) |
 
-The Grok Build path is intentionally different: probing showed that
-ACP's `session/load` only replays UI events without restoring model
-context, and the underlying `chat_history.jsonl` storage is xAI-internal
-and gets regenerated on session load — so we avoid touching the storage
+The ACP path is intentionally different from the native-resume paths:
+probing showed that ACP's `session/load` only replays UI events without
+restoring model context, and the underlying session storage is
+vendor-internal (xAI for Grok, SQLite under `~/.cursor/chats/` for
+Cursor) and gets regenerated on load — so we avoid touching the storage
 layer entirely. Instead we embed the prior transcript inline on turn 1;
 the context persists across subsequent turns within the same session,
 so re-injection is not required.
@@ -134,13 +142,18 @@ so re-injection is not required.
 ## What's not in the matrix yet
 
 - **Plan mode toggling at runtime** (Claude Code `--permission-mode plan`,
-  Grok Build `--permission-mode plan`): the CLI flag is honored at spawn
-  but in-place toggling needs `permissionMode` patch support, which
-  Grok Build does not yet have.
-- **MCP wiring through Grok Build**: ACP `session/new` accepts an
-  `mcpServers` array but SNA passes `[]` today. Threading SNA's MCP
-  config through is a follow-up.
-- **Image input in prompts**: all four providers accept image blocks
+  Grok Build `--permission-mode plan`, Cursor `--mode plan`): the CLI
+  flag is honored at spawn but in-place toggling needs `permissionMode`
+  patch support, which the ACP-speaking providers do not yet have.
+- **MCP wiring through Cursor**: Cursor's ACP reads from the user's
+  `~/.cursor/mcp.json` at startup. Per-session injection of stdio MCP
+  (the way Grok handles it via `.grok/config.toml` + the stdio→HTTP
+  bridge) is a follow-up.
+- **`systemPrompt` / `appendSystemPrompt` for Cursor**: Cursor has no
+  CLI override for the agent system prompt. Routes via `AGENTS.md`
+  (project-scoped, intrusive) or first-turn folding are possible but
+  not yet wired.
+- **Image input in prompts**: all five providers accept image blocks
   in some form, but the per-provider attachment encoding is still
   inconsistent — see [Sessions › Attachments](/docs/introduction/sessions)
   for the current state.

--- a/apps/docs/content/docs/introduction/providers.ja.mdx
+++ b/apps/docs/content/docs/introduction/providers.ja.mdx
@@ -5,7 +5,9 @@ icon: Boxes
 ---
 
 各ランタイムは共通の `AgentProvider` インタフェースの背後にクラスと
-して実装されています。アダプタは `core/providers/{claude-code,codex,opencode,grok}.ts` です。
+して実装されています。アダプタは `core/providers/{claude-code,codex,opencode,grok,cursor}.ts`、
+ACP を話すプロバイダ (Grok Build と Cursor) は `core/providers/acp/base.ts`
+を共有します。
 
 ## AgentProvider
 
@@ -42,26 +44,40 @@ interface AgentProcess {
 | **codex** | `codex app-server` デーモン、stdio 上の JSON-RPC | 永続デーモン、マルチスレッド | はい |
 | **opencode** | `opencode serve` デーモン + SDK HTTP | 永続デーモン、single-cwd | はい |
 | **grok** | `grok agent stdio` (stdio 上の Agent Client Protocol — Grok Build CLI) | セッションごとに stateless | いいえ |
+| **cursor** | `agent acp` (stdio 上の Agent Client Protocol — Cursor CLI) | セッションごとに stateless | いいえ |
 
 Codex と OpenCode プロバイダは `RuntimePool` 経由でデーモンを共有
 します。セッションを開くとき、プールが `(provider, cwd, config)` で
 照会され、互換のデーモンがあれば再利用してコールドスタートコスト
 を節約します(Codex 約 2 秒、OpenCode 約 3 秒)。
 
-Grok Build は SNA で初めてワイヤプロトコルに公開標準
-([ACP](https://agentclientprotocol.com))を採用したプロバイダです。
-そのためアダプタの大部分は ACP の `session/update` 通知を SNA の
-正規化された `AgentEvent` ストリームへ変換する薄いブリッジに留まり
-ます。`core/providers/grok.ts` の Grok Build 固有部分(CLI パス探索、
-`--effort` フラグマッピング、`_x.ai/*` 拡張通知のフィルタリング)は
-分離してあるので、2 番目の ACP-スピーキングエージェントが登場した
-ときには共通基底に抽出しやすい形に保っています。
+Grok Build が SNA で初めてワイヤプロトコルに公開標準
+([ACP](https://agentclientprotocol.com))を採用したプロバイダでした。
+2 番目の ACP-スピーキングプロバイダとして Cursor が加わったことで、
+共有ロジックは `core/providers/acp/base.ts` に抽出されました — JSON-RPC
+pump、`initialize`/`session/new` ハンドシェイク、`session/update` →
+`AgentEvent` 変換、双方向 `session/request_permission`
+(+`bypassPermissions` 自動承認)、プロバイダ間 `resource` block history
+インジェクションまで。各サブクラスは本当に違う部分だけを保持します:
+CLI パス探索、spawn 引数、任意の認証ステップ (Cursor の
+`authenticate({methodId:"cursor_login"})`)、ベンダ拡張通知の prefix
+(`_x.ai/*` Grok、`cursor/*` Cursor)、プロバイダ固有の tool-call unwrap。
 
-プロバイダ間の history replay は、Grok Build セッションの最初の
+プロバイダ間の history replay は、ACP セッションの最初の
 `session/prompt` に正規化された会話履歴を 1 個の ACP `resource`
 content block として埋め込む方式で扱います — 機能マトリクスページの
 [プロバイダ間 history replay](/ja/docs/introduction/feature-matrix#cross-provider-history-replay)
 を参照してください。
+
+Cursor はユーザがすでに済ませた `agent login` をそのまま使います
+(macOS Keychain の `cursor-access-token` / `cursor-refresh-token` →
+Cursor サブスクリプションを利用)。`CURSOR_API_KEY` を別途発行する必要は
+ありません。SNA は spawn の環境変数をそのまま通過させ、子プロセスは
+ユーザがインタラクティブに使うときと同じ資格情報を拾います。Reasoning
+level はモデル ID 自体にエンコードされます (`gpt-5.3-codex` →
+level 4 なら `gpt-5.3-codex-high` に変換)。`reasoning-level.ts` の
+`applyCursorReasoning` がその変換を行い、effort family に属さないモデル
+(`composer-*`、`auto` など) はそのまま通過します。
 
 ## RuntimePool
 
@@ -88,8 +104,9 @@ SNA が ACP だけをプロバイダ層にせず、高忠実度のネイティ�
 - **`reasoningLevel: 0..5`**: プロバイダ非依存、最軽量から最重量
   まで。[reasoning-level.ts](https://github.com/neuradex/sna/blob/main/packages/core/src/core/providers/reasoning-level.ts)
   が Claude Code の `--effort`、Codex の `model_reasoning_effort`、
-  Grok Build の `--reasoning-effort` に翻訳します。OpenCode はこの
-  フィールドを無視します。
+  Grok Build の `--effort`、Cursor のモデル ID サフィックス
+  (`gpt-5.3-codex-high` 等) に翻訳します。OpenCode はこのフィールドを
+  無視します。
 - **`providerOptions.serviceTier`**: Codex 専用。Codex の `/fast`
   スラッシュコマンドをミラーする (値: `"priority"`, `"flex"`,
   `"batch"`)。Claude Code には意図的に自動マッピングしません。

--- a/apps/docs/content/docs/introduction/providers.ko.mdx
+++ b/apps/docs/content/docs/introduction/providers.ko.mdx
@@ -5,7 +5,9 @@ icon: Boxes
 ---
 
 각 런타임은 공통 `AgentProvider` 인터페이스 뒤에 클래스로 구현됩니다.
-어댑터는 `core/providers/{claude-code,codex,opencode,grok}.ts`.
+어댑터는 `core/providers/{claude-code,codex,opencode,grok,cursor}.ts`이며,
+ACP로 말하는 프로바이더(Grok Build, Cursor)는 `core/providers/acp/base.ts`를
+공유합니다.
 
 ## AgentProvider
 
@@ -42,25 +44,38 @@ respawn-with-history-replay가 필요한지 결정합니다.
 | **codex** | `codex app-server` 데몬, stdio 위 JSON-RPC | 영구 데몬, 멀티 스레드 | 예 |
 | **opencode** | `opencode serve` 데몬 + SDK HTTP | 영구 데몬, single-cwd | 예 |
 | **grok** | `grok agent stdio` (stdio 위 Agent Client Protocol — Grok Build CLI) | 세션 단위 무상태 | 아니오 |
+| **cursor** | `agent acp` (stdio 위 Agent Client Protocol — Cursor CLI) | 세션 단위 무상태 | 아니오 |
 
 Codex와 OpenCode 프로바이더는 `RuntimePool`을 통해 데몬을 공유합니다.
 세션이 열릴 때 `(provider, cwd, config)` 키로 풀이 조회되고, 호환되는
 기존 데몬이 있으면 재사용해서 cold-start 비용을 줄입니다(Codex 약 2초,
 OpenCode 약 3초).
 
-Grok Build은 SNA에서 처음으로 공개 표준 ([ACP](https://agentclientprotocol.com))을
-와이어 프로토콜로 쓰는 프로바이더입니다. 그래서 어댑터 대부분은 ACP
-`session/update` 알림을 SNA의 정규화된 `AgentEvent` 스트림으로 옮기는
-얇은 변환기 수준입니다. `core/providers/grok.ts`의 Grok Build 고유 부분(CLI
-경로 탐색, `--effort` 플래그 매핑, `_x.ai/*` 확장 알림 필터링)은 따로
-분리해 두었고, 두 번째 ACP-스피킹 에이전트가 등장하면 base를 추출해
-공유하기 쉬운 모양으로 유지하고 있습니다.
+Grok Build이 SNA에서 처음으로 공개 표준 ([ACP](https://agentclientprotocol.com))을
+와이어 프로토콜로 쓰는 프로바이더였습니다. Cursor가 두 번째 ACP-스피킹
+프로바이더로 합류하면서, 공유 로직은 `core/providers/acp/base.ts`로
+추출됐습니다 — JSON-RPC pump, `initialize`/`session/new` 핸드셰이크,
+`session/update` → `AgentEvent` 변환, 양방향 `session/request_permission`
+(+`bypassPermissions` 자동승인), 프로바이더 간 `resource` block history
+주입까지. 각 서브클래스는 진짜로 다른 것들만 남깁니다: CLI 경로 탐색,
+spawn 인자, 선택적 인증 단계(Cursor의 `authenticate({methodId:"cursor_login"})`),
+벤더 확장 알림 prefix(`_x.ai/*` for Grok, `cursor/*` for Cursor),
+프로바이더 고유 tool-call unwrap.
 
-프로바이더 간 history replay는 Grok Build 세션의 첫 `session/prompt`에
-정규화된 대화 이력을 단일 ACP `resource` content block으로 담아 보내는
-식으로 처리합니다 — 기능 매트릭스 페이지의
+프로바이더 간 history replay는 ACP 세션의 첫 `session/prompt`에 정규화된
+대화 이력을 단일 ACP `resource` content block으로 담아 보내는 식으로
+처리합니다 — 기능 매트릭스 페이지의
 [프로바이더 간 history replay](/ko/docs/introduction/feature-matrix#cross-provider-history-replay)
 항목 참고.
+
+Cursor는 사용자가 이미 끝낸 `agent login`을 그대로 씁니다(macOS Keychain의
+`cursor-access-token` / `cursor-refresh-token` 항목 → Cursor 구독 사용).
+`CURSOR_API_KEY` 같은 추가 발급이 필요 없습니다. SNA는 spawn 환경변수를
+그대로 통과시키고, 자식 프로세스는 사용자가 인터랙티브하게 쓸 때와 동일한
+자격증명을 픽업합니다. Reasoning level은 모델 ID 자체에 인코딩됩니다
+(`gpt-5.3-codex` → level 4면 `gpt-5.3-codex-high`로 변환). `reasoning-level.ts`의
+`applyCursorReasoning`이 이 변환을 처리하고, effort family에 속하지 않는
+모델(`composer-*`, `auto` 등)은 그대로 통과합니다.
 
 ## RuntimePool
 
@@ -82,7 +97,7 @@ SNA가 ACP만을 프로바이더 계층으로 삼지 않고 고충실도 네이�
 
 - **`reasoningLevel: 0..5`**: 프로바이더 비종속, 가장 가벼움부터 가장
   무거움까지. Claude Code의 `--effort`, Codex의 `model_reasoning_effort`,
-  Grok Build의 `--reasoning-effort`를
+  Grok Build의 `--effort`, Cursor의 모델 ID 접미사(`gpt-5.3-codex-high` 등)로
   [reasoning-level.ts](https://github.com/neuradex/sna/blob/main/packages/core/src/core/providers/reasoning-level.ts)가 번역합니다.
   OpenCode는 이 필드를 무시합니다.
 - **`providerOptions.serviceTier`**: Codex 전용. Codex의 `/fast`

--- a/apps/docs/content/docs/introduction/providers.mdx
+++ b/apps/docs/content/docs/introduction/providers.mdx
@@ -6,7 +6,8 @@ icon: Boxes
 
 Each runtime is implemented as a class behind a common
 `AgentProvider` interface. Adapters live in
-`core/providers/{claude-code,codex,opencode,grok}.ts`.
+`core/providers/{claude-code,codex,opencode,grok,cursor}.ts`.
+ACP-speaking providers (Grok Build, Cursor) share `core/providers/acp/base.ts`.
 
 ## AgentProvider
 
@@ -43,24 +44,39 @@ apply in-place vs which require a respawn-with-history-replay.
 | **codex** | `codex app-server` daemon, JSON-RPC over stdio | persistent daemon, multi-thread | yes |
 | **opencode** | `opencode serve` daemon plus SDK HTTP | persistent daemon, single-cwd | yes |
 | **grok** | `grok agent stdio` (Agent Client Protocol over stdio — Grok Build CLI) | stateless per session | no |
+| **cursor** | `agent acp` (Agent Client Protocol over stdio — Cursor CLI) | stateless per session | no |
 
 The Codex and OpenCode providers share daemons through `RuntimePool`.
 When a session opens, the pool is queried by `(provider, cwd, config)`
 and an existing daemon is reused if compatible, sparing the cold-start
 cost (≈2s for Codex, ≈3s for OpenCode).
 
-Grok Build is the first SNA provider whose wire protocol is a public
-standard ([ACP](https://agentclientprotocol.com)), so the adapter is
-mostly a thin translator between ACP `session/update` notifications and
-SNA's normalized `AgentEvent` stream. The bulk of `core/providers/grok.ts`
-is ACP-standard; the Grok Build-specific pieces (CLI discovery,
-`--effort` flag mapping, `_x.ai/*` extension filtering) are kept
-separable so a second ACP-speaking agent could share the same foundation
-with modest effort. Resume across providers is handled by serialising the
-canonical history into a single ACP `resource` content block on the first
-`session/prompt` of a Grok Build session — see
+Grok Build was the first SNA provider whose wire protocol is a public
+standard ([ACP](https://agentclientprotocol.com)). With Cursor added as
+the second ACP-speaking provider, the shared logic now lives in
+`core/providers/acp/base.ts` — a JSON-RPC pump, the
+`initialize`/`session/new` handshake, the `session/update` →
+`AgentEvent` translation, bidirectional `session/request_permission`
+(with `bypassPermissions` auto-approve), and the cross-provider
+`resource`-block history injection. Each subclass keeps only what
+genuinely differs: CLI path resolution, spawn args, optional auth step
+(Cursor's `authenticate({methodId:"cursor_login"})`), vendor extension
+notification prefixes (`_x.ai/*` for Grok, `cursor/*` for Cursor), and
+provider-specific tool-call unwraps. Cross-provider resume serialises
+SNA's canonical history into a single ACP `resource` block on the first
+`session/prompt` — see
 [Cross-provider history replay](/docs/introduction/feature-matrix#cross-provider-history-replay)
 on the feature matrix page.
+
+Cursor uses the user's existing `agent login` (macOS Keychain entries
+`cursor-access-token` / `cursor-refresh-token`) — and therefore the
+Cursor subscription. No `CURSOR_API_KEY` is required; SNA passes the
+spawn's environment through unchanged, and the child process picks up
+the same credentials the user would use interactively. Reasoning level
+is encoded into the model id itself (`gpt-5.3-codex` → `gpt-5.3-codex-high`
+for level 4); `applyCursorReasoning` in `reasoning-level.ts` does that
+rewrite, and models outside the effort family (`composer-*`, `auto`, etc.)
+are left unchanged.
 
 ## RuntimePool
 
@@ -82,7 +98,8 @@ Two latency knobs flow through every provider:
 
 - **`reasoningLevel: 0..5`**: provider-agnostic, lightest to heaviest.
   Translates to Claude Code's `--effort`, Codex's `model_reasoning_effort`,
-  and Grok Build's `--reasoning-effort` via
+  Grok Build's `--effort`, and Cursor's model-id suffix (e.g.
+  `gpt-5.3-codex-high`) via
   [reasoning-level.ts](https://github.com/neuradex/sna/blob/main/packages/core/src/core/providers/reasoning-level.ts).
   OpenCode currently ignores this field.
 - **`providerOptions.serviceTier`**: Codex-only. Mirrors Codex's

--- a/packages/core/src/core/providers/acp/base.ts
+++ b/packages/core/src/core/providers/acp/base.ts
@@ -1,0 +1,866 @@
+/**
+ * AcpStdioProcess — shared ACP-over-stdio adapter base.
+ *
+ * Both Grok Build and Cursor expose Agent Client Protocol (ACP,
+ * https://agentclientprotocol.com) servers over stdio. The wire shapes are
+ * nearly identical, so this class extracts the common JSON-RPC pump,
+ * handshake, event translation, and permission flow. Per-vendor subclasses
+ * (`GrokProcess`, `CursorProcess`) override the small set of hooks that
+ * differ — spawn args, optional auth step, vendor notification prefix,
+ * tool-call wrapper unwrap, and any pre/post-handshake setup.
+ *
+ * Design decisions captured here (validated end-to-end against grok 0.1.212
+ * during the GrokProcess work; verified compatible with `agent acp` 2026.05
+ * during the Cursor work):
+ *
+ * 1. NO daemon pooling. Each `AcpStdioProcess` owns its own child agent
+ *    process, mirroring Claude Code's stateless model.
+ *
+ * 2. Cross-provider history is injected as a single ACP `resource` content
+ *    block on the first `session/prompt`. The model treats the embedded
+ *    text as prior context; subsequent turns retain it via the agent's
+ *    own session storage, so re-injection is not required. (Capabilities
+ *    sometimes advertise `embeddedContext: false` but both providers
+ *    accept the block in practice — we send it unconditionally.)
+ *
+ * 3. Permission flow is the Codex bidirectional pattern: ACP's
+ *    `session/request_permission` is a server-request whose response shape
+ *    is `{outcome:{outcome:"selected",optionId}}` (note the doubled
+ *    `outcome` discriminator — `{type:"selected"}` is silently rejected).
+ *    When the session is in `bypassPermissions` mode, we auto-reply with
+ *    an `allow_*` option and never surface the prompt to SNA's permission
+ *    queue. Subclasses can extend `respondToPermission()` semantics by
+ *    overriding the option-id selection.
+ *
+ * 4. Vendor extension notifications (`_x.ai/*` for Grok, `cursor/*` for
+ *    Cursor) are dropped on the floor. They're useful for native IDE
+ *    clients but irrelevant to SNA's normalized event model. The prefix
+ *    each subclass wants to drop is supplied via `vendorNotificationPrefix`.
+ *
+ * 5. ACP has no terminal "agent message complete" notification — the turn
+ *    ends implicitly when `session/prompt` resolves. SNA's persistence
+ *    layer only writes assistant rows for the `assistant` event (the full
+ *    message), not the streaming `assistant_delta` chunks. So we
+ *    accumulate chunks per turn and flush them as a synthetic `assistant`
+ *    event right before `complete`, otherwise reload-the-chat wipes every
+ *    streamed reply.
+ *
+ * Subclasses only need to implement `resolveSpawn()` and `name`. The
+ * remaining hooks (`authenticate`, `preHandshake`, `onExit`,
+ * `unwrapToolCall`, `translateVendorUpdate`, `vendorNotificationPrefix`)
+ * have sensible no-op defaults — override only what differs.
+ */
+
+import { spawn, type ChildProcess } from "child_process";
+import { EventEmitter } from "events";
+import readline from "readline";
+import type {
+  AgentProcess,
+  AgentEvent,
+  SpawnOptions,
+  SessionPatch,
+  ContentBlock,
+} from "../types.js";
+import type { CanonicalBlock } from "../../../history/types.js";
+import { logger } from "../../../lib/logger.js";
+
+// ── JSON-RPC types ──────────────────────────────────────────────────────────
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
+
+// ── ACP shapes we actually consume ──────────────────────────────────────────
+
+export interface AcpSessionUpdate {
+  sessionUpdate:
+    | "user_message_chunk"
+    | "agent_message_chunk"
+    | "agent_thought_chunk"
+    | "tool_call"
+    | "tool_call_update"
+    | "available_commands_update"
+    | "plan"
+    | string;
+  content?: { type: "text"; text?: string } | unknown;
+  /** Present on tool_call / tool_call_update */
+  toolCallId?: string;
+  kind?: string;
+  title?: string;
+  rawInput?: unknown;
+  /** Present on tool_call_update result variant. */
+  rawOutput?: unknown;
+  /** File/path locations the tool touched — surfaces for tool_call_update. */
+  locations?: unknown;
+  status?: string;
+}
+
+export interface AcpPermissionOption {
+  optionId: string;
+  name?: string;
+  kind: "allow_always" | "allow_once" | "reject_once" | "reject_always";
+}
+
+export interface AcpPermissionRequest {
+  sessionId: string;
+  toolCall: {
+    toolCallId: string;
+    kind?: string;
+    title?: string;
+    rawInput?: unknown;
+  };
+  options: AcpPermissionOption[];
+}
+
+/** Result of unwrapping a tool_call / tool_call_update. */
+export interface UnwrappedToolCall {
+  /** Canonical tool name consumers match on. */
+  toolName: string;
+  /** Arguments the tool will actually receive. */
+  input: unknown;
+  /** Extra fields to merge into the AgentEvent's `data` (e.g. vendor display title). */
+  extra?: Record<string, unknown>;
+}
+
+// ── Shared history serializer ───────────────────────────────────────────────
+
+/**
+ * Default cross-provider history serializer. Each agent treats this as a
+ * plain-text transcript embedded in the prompt context. Tool round-trips
+ * are summarized inline — we don't attempt to recreate provider-specific
+ * tool_use / tool_result blocks across vendors.
+ */
+export function serializeHistoryForAcp(history: CanonicalBlock[]): string {
+  const lines: string[] = [];
+  for (const block of history) {
+    const actor = block.actor.toUpperCase();
+    switch (block.kind) {
+      case "text":
+        lines.push(`${actor}: ${block.content}`);
+        break;
+      case "thinking":
+        // Skip internal reasoning from prior providers — adds noise without
+        // useful context for the next agent.
+        break;
+      case "tool_use": {
+        const name = (block.meta as { name?: string } | undefined)?.name ?? "tool";
+        lines.push(`${actor} (calling ${name}): ${block.content}`);
+        break;
+      }
+      case "tool_result":
+        lines.push(`TOOL_RESULT: ${block.content}`);
+        break;
+      case "status":
+      case "error":
+        // Status/error metadata is not useful as prior conversation context.
+        break;
+    }
+  }
+  return lines.join("\n");
+}
+
+// ── Spawn descriptor returned by subclasses ─────────────────────────────────
+
+export interface AcpSpawnDescriptor {
+  /** Absolute path or bare command for the agent binary. */
+  command: string;
+  /** Args including any subcommand (e.g. `["agent","stdio"]` or `["acp"]`). */
+  args: string[];
+  /** Optional env overrides merged into `process.env`. */
+  env?: Record<string, string | undefined>;
+}
+
+// ── Base class ──────────────────────────────────────────────────────────────
+
+export abstract class AcpStdioProcess extends EventEmitter implements AgentProcess {
+  // Definite-assignment: populated inside initialize() before the handshake
+  // resolves. Consumers always await this.ready before touching state.
+  protected proc!: ChildProcess;
+  protected rl!: readline.Interface;
+  protected _sessionId: string | null = null;
+  protected _alive = true;
+
+  protected rpcIdCounter = 0;
+  /** Resolvers for outgoing requests, keyed by our own request id. */
+  protected readonly pendingRequests = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (err: Error) => void; method: string }
+  >();
+  /**
+   * Open permission requests from the agent. Maps SNA's externally-visible
+   * requestId (which we expose via the permission_needed AgentEvent) to
+   * the agent's JSON-RPC request id, so respondToPermission() can route back.
+   */
+  protected readonly pendingPermissions = new Map<string, number>();
+
+  /** Cached history transcript for first-turn injection. */
+  protected readonly historyTranscript: string | null;
+  protected firstPromptSent = false;
+  /**
+   * Per-turn accumulator for `agent_message_chunk` text. See design
+   * decision (5) in the file header.
+   */
+  protected assistantTurnBuffer = "";
+  /** Captured permission mode — see design decision (3). */
+  protected readonly permissionMode: string | undefined;
+  /** Set true after initialize + (optional authenticate) + session/new succeed. */
+  protected ready: Promise<void>;
+
+  // ──── Subclass hooks ────
+
+  /**
+   * Logger label used in `${name} stderr:` messages and similar.
+   * Match the provider's registry key (e.g. "grok", "cursor").
+   */
+  protected abstract get name(): string;
+
+  /**
+   * The binary + args + env to spawn. Called once per process construction;
+   * subclasses can inspect SpawnOptions to compose flags.
+   */
+  protected abstract resolveSpawn(options: SpawnOptions): AcpSpawnDescriptor;
+
+  /**
+   * Notification methods whose `method` starts with this string are dropped.
+   * Use the empty string to disable filtering. Examples: `"_x.ai/"` (Grok),
+   * `"cursor/"` (Cursor).
+   */
+  protected get vendorNotificationPrefix(): string {
+    return "";
+  }
+
+  /**
+   * Optional second handshake step after `initialize`. Cursor uses this to
+   * call `authenticate({methodId: "cursor_login"})`; Grok skips it.
+   */
+  protected async authenticate(_options: SpawnOptions, _initResult: unknown): Promise<void> {
+    // default no-op
+  }
+
+  /**
+   * Hook run before the agent process spawns. Subclasses can perform setup
+   * that must be visible to the agent at startup — typically MCP bridge
+   * setup + writing provider-specific config files. Throwing aborts spawn;
+   * `onPreSpawnCleanup()` will run.
+   */
+  protected async preHandshake(_options: SpawnOptions): Promise<void> {
+    // default no-op
+  }
+
+  /**
+   * Called when the spawned process exits. Subclasses dispose any per-session
+   * resources (MCP bridges, restored config files, etc.).
+   */
+  protected onExit(_code: number | null): void {
+    // default no-op
+  }
+
+  /**
+   * Called when `kill()` runs before the agent process was spawned (e.g.
+   * initialize() failed during preHandshake). Default delegates to onExit.
+   */
+  protected onPreSpawnCleanup(): void {
+    this.onExit(null);
+  }
+
+  /**
+   * Translate a `tool_call` / input-refresh `tool_call_update` payload into
+   * the canonical (name, input, extra) triple. Default unwraps no vendor
+   * dispatch wrapper — subclasses can intercept (e.g. Grok's `use_tool`
+   * dispatch wraps the real tool name in `rawInput.tool_name`).
+   */
+  protected unwrapToolCall(update: AcpSessionUpdate): UnwrappedToolCall {
+    return {
+      toolName: update.title ?? "tool",
+      input: update.rawInput,
+    };
+  }
+
+  /**
+   * Handle vendor-specific `session/update` sub-types not in the standard
+   * ACP set. Return null to drop, an AgentEvent to emit, or undefined to
+   * use the base class fallthrough (which drops unknown sub-types).
+   */
+  protected translateVendorUpdate(_update: AcpSessionUpdate): AgentEvent | null | undefined {
+    return undefined;
+  }
+
+  /**
+   * Permission option ID to use when responding to a `session/request_permission`.
+   * Subclasses can override if the agent's option-id namespace differs.
+   * Defaults to the canonical ACP option ids used by both Grok and Cursor:
+   * `allow-once` / `reject-once`.
+   */
+  protected pickPermissionOptionId(approved: boolean, _options: AcpPermissionOption[]): string {
+    return approved ? "allow-once" : "reject-once";
+  }
+
+  /**
+   * Override the resource block prepended to the first `session/prompt`.
+   * Default builds an ACP `resource` block; subclasses can swap shapes if
+   * a future agent advertises a different embedded-context format.
+   */
+  protected buildHistoryPromptBlock(transcript: string): unknown {
+    return {
+      type: "resource",
+      resource: {
+        uri: "sna://prior-conversation.txt",
+        mimeType: "text/plain",
+        text:
+          "The following is our prior conversation, carried over from " +
+          "another agent. Continue from where it leaves off.\n\n" +
+          transcript,
+      },
+    };
+  }
+
+  /**
+   * `clientCapabilities` advertised in the initialize request. Subclasses
+   * can override — Grok declares fs/terminal=false; Cursor matches that.
+   */
+  protected initializeClientCapabilities(): Record<string, unknown> {
+    return {
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+    };
+  }
+
+  /**
+   * `session/new` params builder. Default declares an empty `mcpServers`
+   * array because both Grok and Cursor today route MCP via on-disk config
+   * files, not the ACP field. Subclasses can override if a provider ever
+   * starts accepting it via the wire.
+   */
+  protected sessionNewParams(options: SpawnOptions): Record<string, unknown> {
+    return {
+      cwd: options.cwd,
+      mcpServers: [],
+    };
+  }
+
+  // ──── Constructor + initialize ────
+
+  constructor(options: SpawnOptions) {
+    super();
+    this.permissionMode = options.permissionMode;
+    this.historyTranscript =
+      options.history && options.history.length > 0
+        ? this.serializeHistory(options.history)
+        : null;
+
+    this.ready = this.initialize(options);
+    this.ready.catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emitEvent({ type: "error", message, timestamp: Date.now() });
+    });
+  }
+
+  /**
+   * Override to customize history transcript format. Default uses the
+   * shared cross-provider serializer.
+   */
+  protected serializeHistory(history: CanonicalBlock[]): string {
+    return serializeHistoryForAcp(history);
+  }
+
+  /**
+   * One-shot async setup chain:
+   *   1. Subclass `preHandshake` (e.g. MCP bridge setup + config write)
+   *   2. Spawn agent and wire stdio
+   *   3. ACP `initialize` + optional `authenticate` + `session/new`
+   */
+  private async initialize(options: SpawnOptions): Promise<void> {
+    try {
+      await this.preHandshake(options);
+      this.spawnAgent(options);
+      await this.runHandshake(options);
+    } catch (err) {
+      // Any failure between preHandshake and a live handshake leaves
+      // orphaned subclass resources. Trigger cleanup hook before bubbling.
+      this.onPreSpawnCleanup();
+      throw err;
+    }
+  }
+
+  private spawnAgent(options: SpawnOptions): void {
+    const desc = this.resolveSpawn(options);
+
+    logger.log("agent", `${this.name}: spawning ${desc.command} ${desc.args.join(" ")} (cwd=${options.cwd})`);
+
+    const env: Record<string, string> = { ...process.env } as Record<string, string>;
+    if (options.env) Object.assign(env, options.env);
+    if (desc.env) {
+      for (const [k, v] of Object.entries(desc.env)) {
+        if (v !== undefined) env[k] = v;
+      }
+    }
+
+    this.proc = spawn(desc.command, desc.args, {
+      cwd: options.cwd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    this.rl = readline.createInterface({ input: this.proc.stdout! });
+    this.rl.on("line", (line) => this.handleLine(line));
+
+    this.proc.stderr!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      // Surface any line containing "error" (case-insensitive) — catches
+      // both vendor tracing "ERROR" chatter and clap-style "error:" parse
+      // failures. Cap the snippet so a panic dump doesn't fill the log.
+      if (/error/i.test(text)) {
+        logger.log("agent", `${this.name} stderr: ${text.trim().slice(0, 400)}`);
+      }
+    });
+
+    this.proc.on("exit", (code) => {
+      this._alive = false;
+      for (const { reject, method } of this.pendingRequests.values()) {
+        reject(new Error(`${this.name} process exited (code=${code}) while waiting for ${method}`));
+      }
+      this.pendingRequests.clear();
+      this.onExit(code);
+      this.emit("exit", code);
+    });
+
+    this.proc.on("error", (err) => {
+      this._alive = false;
+      this.emit("error", err);
+    });
+  }
+
+  private async runHandshake(options: SpawnOptions): Promise<void> {
+    const initResult = await this.request("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: this.initializeClientCapabilities(),
+    });
+
+    await this.authenticate(options, initResult);
+
+    const sessionResp = (await this.request(
+      "session/new",
+      this.sessionNewParams(options),
+    )) as { sessionId?: string } | undefined;
+
+    const sessionId = sessionResp?.sessionId ?? null;
+    if (!sessionId) {
+      throw new Error(`${this.name}: session/new returned no sessionId`);
+    }
+    this._sessionId = sessionId;
+    this.emitEvent({
+      type: "init",
+      message: `${this.name} session ready`,
+      data: { sessionId },
+      timestamp: Date.now(),
+    });
+  }
+
+  // ──── JSON-RPC primitives ────
+
+  protected write(msg: JsonRpcMessage): void {
+    if (!this.proc?.stdin || this.proc.stdin.destroyed) {
+      throw new Error(`${this.name} stdin closed`);
+    }
+    this.proc.stdin.write(JSON.stringify(msg) + "\n");
+  }
+
+  protected request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    const id = ++this.rpcIdCounter;
+    return new Promise<T>((resolve, reject) => {
+      this.pendingRequests.set(id, {
+        resolve: (v) => resolve(v as T),
+        reject,
+        method,
+      });
+      try {
+        this.write({ jsonrpc: "2.0", id, method, params });
+      } catch (err) {
+        this.pendingRequests.delete(id);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  // ──── Stream handling ────
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(trimmed) as JsonRpcMessage;
+    } catch {
+      logger.log("agent", `${this.name}: non-JSON line dropped: ${trimmed.slice(0, 200)}`);
+      return;
+    }
+
+    // Response to one of our outgoing requests
+    if ("id" in msg && msg.id != null && !("method" in msg)) {
+      const pending = this.pendingRequests.get(msg.id);
+      if (!pending) return;
+      this.pendingRequests.delete(msg.id);
+      const resp = msg as JsonRpcResponse;
+      if (resp.error) {
+        pending.reject(new Error(`${this.name} ${pending.method} failed: ${resp.error.message}`));
+      } else {
+        pending.resolve(resp.result);
+      }
+      return;
+    }
+
+    // Server-initiated request (agent asking us for something)
+    if ("method" in msg && "id" in msg && msg.id != null) {
+      this.handleServerRequest(msg as JsonRpcRequest);
+      return;
+    }
+
+    // Notification
+    if ("method" in msg) {
+      this.handleNotification(msg as JsonRpcNotification);
+      return;
+    }
+  }
+
+  private handleServerRequest(req: JsonRpcRequest): void {
+    if (req.method === "session/request_permission") {
+      const params = req.params as AcpPermissionRequest;
+      const requestId = params.toolCall.toolCallId;
+
+      // Bypass-mode shortcut: pick whichever option carries an "allow"
+      // intent (or fall back to the first option) and reply immediately,
+      // skipping the SessionManager round-trip + UI dialog entirely. This
+      // mirrors the contract of `permissionMode: "bypassPermissions"`,
+      // which other providers implement by never asking in the first place.
+      if (this.permissionMode === "bypassPermissions") {
+        const allowOpt =
+          params.options.find((o) => o.kind === "allow_always") ??
+          params.options.find((o) => o.kind === "allow_once") ??
+          params.options[0];
+        if (allowOpt) {
+          this.write({
+            jsonrpc: "2.0",
+            id: req.id,
+            result: { outcome: { outcome: "selected", optionId: allowOpt.optionId } },
+          });
+          return;
+        }
+      }
+
+      this.pendingPermissions.set(requestId, req.id);
+      this.emitEvent({
+        type: "permission_needed",
+        message: params.toolCall.title,
+        data: {
+          requestId,
+          toolCall: params.toolCall,
+          options: params.options,
+        },
+        timestamp: Date.now(),
+      });
+      return;
+    }
+
+    // We don't speak the rest of the ACP server-request surface (fs reads,
+    // terminal control, etc.). Reply with a method-not-found error so the
+    // agent doesn't hang waiting on us.
+    this.write({
+      jsonrpc: "2.0",
+      id: req.id,
+      error: { code: -32601, message: `Method not implemented in SNA: ${req.method}` },
+    });
+  }
+
+  private handleNotification(notif: JsonRpcNotification): void {
+    const prefix = this.vendorNotificationPrefix;
+    if (prefix && notif.method.startsWith(prefix)) {
+      // Vendor extension notification — drop on the floor.
+      return;
+    }
+    if (notif.method === "session/update") {
+      const params = notif.params as { sessionId?: string; update?: AcpSessionUpdate };
+      if (!params?.update) return;
+      const event = this.dispatchSessionUpdate(params.update);
+      if (event) this.emitEvent(event);
+      return;
+    }
+    // Unknown notifications: log and ignore.
+    logger.log("agent", `${this.name}: ignored notification ${notif.method}`);
+  }
+
+  private dispatchSessionUpdate(update: AcpSessionUpdate): AgentEvent | null {
+    // Subclass first — lets vendor-specific sub-types short-circuit the
+    // default ACP set without monkeying with switch statements.
+    const vendor = this.translateVendorUpdate(update);
+    if (vendor !== undefined) return vendor;
+
+    const now = Date.now();
+    const text = (update.content as { text?: string } | undefined)?.text ?? "";
+    switch (update.sessionUpdate) {
+      case "agent_thought_chunk":
+        return { type: "thinking_delta", delta: text, timestamp: now };
+      case "agent_message_chunk":
+        // Accumulate so the final `assistant` event (flushed when
+        // session/prompt resolves) carries the full message text for the DB.
+        this.assistantTurnBuffer += text;
+        return { type: "assistant_delta", delta: text, timestamp: now };
+      case "user_message_chunk":
+        return { type: "user_message", message: text, timestamp: now };
+      case "tool_call":
+        return this.buildToolUseEvent(update, now, false);
+      case "tool_call_update": {
+        // ACP overloads `tool_call_update` for two distinct purposes:
+        //   (a) Input refresh — rawInput grows or finalizes between the
+        //       initial `tool_call` and execution. No status, no rawOutput.
+        //       We emit `tool_use` again with the same id so the persistence
+        //       layer merges by id.
+        //   (b) Result update — has status (in_progress/completed/failed)
+        //       and/or rawOutput. We emit `tool_result` with everything.
+        const hasResultSignal = !!update.status || update.rawOutput !== undefined;
+        if (!hasResultSignal && update.rawInput !== undefined) {
+          return this.buildToolUseEvent(update, now, true);
+        }
+        return {
+          type: "tool_result",
+          data: {
+            id: update.toolCallId,
+            status: update.status,
+            content: update.content,
+            rawOutput: update.rawOutput,
+            locations: update.locations,
+            kind: update.kind,
+            title: update.title || undefined,
+          },
+          timestamp: now,
+        };
+      }
+      case "available_commands_update":
+      case "plan":
+        // Slash-command list refresh / plan-mode pane updates aren't part
+        // of SNA's event vocabulary; ignore.
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  private buildToolUseEvent(update: AcpSessionUpdate, now: number, fromUpdate: boolean): AgentEvent {
+    const { toolName, input, extra } = this.unwrapToolCall(update);
+    return {
+      type: "tool_use",
+      message: toolName,
+      data: {
+        id: update.toolCallId,
+        toolName,
+        kind: update.kind,
+        input,
+        ...(extra ?? {}),
+        ...(fromUpdate ? { fromUpdate: true } : {}),
+      },
+      timestamp: now,
+    };
+  }
+
+  protected emitEvent(event: AgentEvent): void {
+    this.emit("event", event);
+  }
+
+  // ──── AgentProcess surface ────
+
+  send(input: string | ContentBlock[]): void {
+    void this.ready
+      .then(() => this.sendPrompt(input))
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        this.emitEvent({ type: "error", message, timestamp: Date.now() });
+      });
+  }
+
+  private async sendPrompt(input: string | ContentBlock[]): Promise<void> {
+    if (!this._sessionId) {
+      throw new Error(`${this.name}: send() called before session is ready`);
+    }
+
+    const promptBlocks: unknown[] = [];
+
+    // First turn: prepend the history transcript so the model reads it as
+    // prior context. Subsequent turns rely on the agent's own session state.
+    if (!this.firstPromptSent && this.historyTranscript) {
+      promptBlocks.push(this.buildHistoryPromptBlock(this.historyTranscript));
+    }
+
+    if (typeof input === "string") {
+      promptBlocks.push({ type: "text", text: input });
+      this.emitEvent({ type: "user_message", message: input, timestamp: Date.now() });
+    } else {
+      for (const block of input) {
+        if (block.type === "text") {
+          promptBlocks.push({ type: "text", text: block.text });
+        } else if (block.type === "image") {
+          // ACP's image block expects { type: "image", data, mimeType }.
+          // Translate SNA's Anthropic-style {source:{type,media_type,data}}
+          // shape into that.
+          promptBlocks.push({
+            type: "image",
+            data: block.source.data,
+            mimeType: block.source.media_type,
+          });
+        }
+      }
+      this.emitEvent({
+        type: "user_message",
+        data: { blocks: input },
+        timestamp: Date.now(),
+      });
+    }
+
+    this.firstPromptSent = true;
+
+    try {
+      const result = (await this.request("session/prompt", {
+        sessionId: this._sessionId,
+        prompt: promptBlocks,
+      })) as { stopReason?: string } | undefined;
+      this.flushAssistantTurn();
+      this.emitEvent({
+        type: "complete",
+        data: { stopReason: result?.stopReason ?? null },
+        timestamp: Date.now(),
+      });
+    } catch (err) {
+      // Flush whatever text streamed before the failure so a partial turn
+      // still lands in chat_messages and the user sees it after reload.
+      this.flushAssistantTurn();
+      const message = err instanceof Error ? err.message : String(err);
+      this.emitEvent({ type: "error", message, timestamp: Date.now() });
+    }
+  }
+
+  /**
+   * Emit the accumulated `agent_message_chunk` text as a single terminal
+   * `assistant` event so SNA's persistence layer writes a row to
+   * chat_messages, then clear the buffer for the next turn. No-op when
+   * nothing streamed.
+   */
+  protected flushAssistantTurn(): void {
+    const text = this.assistantTurnBuffer;
+    this.assistantTurnBuffer = "";
+    if (!text) return;
+    this.emitEvent({
+      type: "assistant",
+      message: text,
+      timestamp: Date.now(),
+    });
+  }
+
+  interrupt(): void {
+    if (!this._sessionId || !this._alive) return;
+    // ACP's `session/cancel` is a notification, not a request — the
+    // current session/prompt request resolves with stopReason="cancelled"
+    // once the agent stops the turn.
+    try {
+      this.write({
+        jsonrpc: "2.0",
+        method: "session/cancel",
+        params: { sessionId: this._sessionId },
+      });
+      this.emitEvent({ type: "interrupted", timestamp: Date.now() });
+    } catch (err) {
+      logger.log("agent", `${this.name}: interrupt failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  setModel(_model: string): void {
+    // ACP does not expose a runtime model swap. Subclasses can override if
+    // the underlying CLI grows the surface; the only path today is respawn
+    // (returned as leftover from applyPatch).
+  }
+
+  setPermissionMode(_mode: string): void {
+    // ACP permissionMode is fixed at process startup. Runtime change
+    // requires respawn — returned as leftover from applyPatch.
+  }
+
+  applyPatch(patch: SessionPatch): SessionPatch {
+    // No in-place patching supported in the base implementation — every
+    // mutable field requires a respawn. Return the patch unchanged so
+    // session-manager handles it.
+    return { ...patch };
+  }
+
+  respondToPermission(requestId: string, approved: boolean): void {
+    const rpcId = this.pendingPermissions.get(requestId);
+    if (rpcId == null) {
+      logger.log("agent", `${this.name}: respondToPermission called for unknown requestId=${requestId}`);
+      return;
+    }
+    this.pendingPermissions.delete(requestId);
+    // ACP RequestPermissionResponse shape: { outcome: <Outcome> }, where the
+    // outcome itself uses `outcome` as its discriminator (not `type`).
+    //   { outcome: { outcome: "selected", optionId: "allow-once" } }
+    //   { outcome: { outcome: "cancelled" } }
+    // Sending {type:"selected"} is silently rejected with -32603.
+    const optionId = this.pickPermissionOptionId(approved, []);
+    try {
+      this.write({
+        jsonrpc: "2.0",
+        id: rpcId,
+        result: { outcome: { outcome: "selected", optionId } },
+      });
+    } catch (err) {
+      logger.log("agent", `${this.name}: permission response failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  kill(): void {
+    if (!this._alive) return;
+    this._alive = false;
+    // kill() may race with initialize() — proc isn't assigned until
+    // spawnAgent() runs. If we beat that, run the pre-spawn cleanup and
+    // bail; initialize() will see _alive=false and unwind on its own.
+    if (!this.proc) {
+      this.onPreSpawnCleanup();
+      return;
+    }
+    try {
+      this.proc.kill("SIGTERM");
+    } catch {
+      // already dead
+    }
+    // Hard fallback if the agent doesn't exit cleanly within 2s.
+    setTimeout(() => {
+      try {
+        if (this.proc.exitCode == null) this.proc.kill("SIGKILL");
+      } catch {
+        // ignore
+      }
+    }, 2000).unref();
+  }
+
+  closeThread(): void {
+    // Not pooled — same as kill.
+    this.kill();
+  }
+
+  get alive(): boolean { return this._alive; }
+  get pid(): number | null { return this.proc?.pid ?? null; }
+  get sessionId(): string | null { return this._sessionId; }
+}

--- a/packages/core/src/core/providers/cursor.ts
+++ b/packages/core/src/core/providers/cursor.ts
@@ -1,0 +1,474 @@
+/**
+ * Cursor provider — ACP-over-stdio adapter, second provider on the shared
+ * `AcpStdioProcess` base.
+ *
+ * Backed by Cursor's `agent acp` subcommand (the headless CLI shipped at
+ * `~/.local/bin/agent` on macOS/Linux). The wire protocol is the standard
+ * Agent Client Protocol (https://agentclientprotocol.com), so the bulk of
+ * the work lives in `acp/base.ts` shared with Grok Build. This file is
+ * the Cursor-specific subclass + provider entry: CLI path resolution,
+ * the `authenticate({methodId: "cursor_login"})` step between `initialize`
+ * and `session/new`, the `cursor/*` and `session_info_update` extension
+ * drop, the `tool_call.<kind>ToolCall` wrapper unwrap (Cursor nests every
+ * tool call under a per-tool variant key like `shellToolCall` /
+ * `writeToolCall` / `readToolCall` / `createPlanToolCall`), and the
+ * headless `agent -p` path used by `complete()`.
+ *
+ * Design decisions specific to Cursor (the shared ACP decisions live at
+ * the top of `acp/base.ts`):
+ *
+ *   • Authentication relies on the user's existing `agent login` —
+ *     credentials live in the macOS Keychain (`cursor-access-token` /
+ *     `cursor-refresh-token` under account `cursor-user`) and the
+ *     Cursor subscription billing is used. We never touch
+ *     `CURSOR_API_KEY` (token-billed, would bypass subscription) or
+ *     override `HOME` (which detaches Keychain lookup).
+ *
+ *   • Reasoning level is encoded into the model id itself (Cursor has
+ *     no `--effort` flag). `gpt-5.3-codex` → `gpt-5.3-codex-high` when
+ *     the caller passes `reasoningLevel: 4`. See `applyCursorReasoning`
+ *     in `reasoning-level.ts`.
+ *
+ *   • `tool_call.<kind>ToolCall` unwrap. Cursor wraps every tool
+ *     invocation under a per-tool variant key. We surface the variant
+ *     name (`shell`, `write`, `read`, `createPlan`, future additions) as
+ *     the canonical tool name and unpack `args` / `result` payloads.
+ *     `result` is preserved under `data.toolCallResult` so consumers
+ *     wanting the structured success/rejected shape have it.
+ *
+ *   • MCP wiring is left to the user's existing `~/.cursor/mcp.json` for
+ *     now. Cursor's ACP server reads it at startup. Per-session injection
+ *     of stdio MCP servers (the way Grok handles it via `.grok/config.toml`
+ *     + the stdio→HTTP bridge) is a follow-up — Cursor's ACP currently
+ *     accepts only what's already declared in the user-level mcp.json.
+ */
+
+import { spawn, execSync } from "child_process";
+import type {
+  AgentProvider,
+  AgentProcess,
+  AgentEvent,
+  SpawnOptions,
+  CompleteOptions,
+  CompletionResult,
+  ListModelsConfig,
+  ListModelsResult,
+  RuntimeModelInfo,
+} from "./types.js";
+import { logger } from "../../lib/logger.js";
+import { applyCursorReasoning } from "./reasoning-level.js";
+import {
+  AcpStdioProcess,
+  type AcpSpawnDescriptor,
+  type AcpSessionUpdate,
+  type UnwrappedToolCall,
+} from "./acp/base.js";
+
+// ── CLI discovery ────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the path to the `agent` CLI (Cursor's headless binary).
+ * Env override → static common locations → PATH lookup.
+ */
+export function resolveCursorPath(_cwd: string = process.cwd()): string {
+  if (process.env.SNA_CURSOR_COMMAND) return process.env.SNA_CURSOR_COMMAND;
+  const home = process.env.HOME ?? "";
+  const candidates = [
+    `${home}/.local/bin/agent`,
+    "/usr/local/bin/agent",
+    "/opt/homebrew/bin/agent",
+  ];
+  for (const p of candidates) {
+    try {
+      execSync(`test -x "${p}"`, { stdio: "pipe" });
+      return p;
+    } catch {
+      // try next
+    }
+  }
+  return "agent";
+}
+
+// ── Cursor tool_call wrapper variants ───────────────────────────────────────
+
+/**
+ * Cursor nests every tool invocation under a per-tool variant key inside
+ * `tool_call.rawInput` (e.g. `{shellToolCall: {args: {...}, result?: {...}}}`).
+ * We surface the variant name (without the trailing "ToolCall") as the
+ * canonical tool name and the inner `args` as the input. The `result`
+ * (success/rejected) — when present on a `tool_call_update` — is preserved
+ * under `data.toolCallResult` so consumers wanting the structured shape
+ * can read it without re-parsing.
+ */
+function unwrapCursorVariant(rawInput: unknown): { variant: string; args: unknown; result?: unknown } | null {
+  if (!rawInput || typeof rawInput !== "object") return null;
+  const obj = rawInput as Record<string, unknown>;
+  for (const [key, value] of Object.entries(obj)) {
+    if (!key.endsWith("ToolCall") || !value || typeof value !== "object") continue;
+    const variant = key.slice(0, -"ToolCall".length);
+    const inner = value as { args?: unknown; result?: unknown };
+    return { variant, args: inner.args, result: inner.result };
+  }
+  return null;
+}
+
+// ── Process ─────────────────────────────────────────────────────────────────
+
+export class CursorProcess extends AcpStdioProcess {
+  protected get name(): string { return "cursor"; }
+
+  /**
+   * Drop `cursor/*` extension notifications (`cursor/ask_question`,
+   * `cursor/create_plan`, `cursor/update_todos`, `cursor/task`,
+   * `cursor/generate_image`). They're useful for native IDE clients
+   * (Zed, JetBrains) but aren't part of SNA's normalized event model.
+   */
+  protected get vendorNotificationPrefix(): string { return "cursor/"; }
+
+  protected resolveSpawn(options: SpawnOptions): AcpSpawnDescriptor {
+    // `agent acp` is the only subcommand for ACP mode. Unlike Grok, Cursor
+    // doesn't accept top-level model/effort/permission flags on this path —
+    // reasoning is encoded into the model id itself (composed by the
+    // caller via applyCursorReasoning), and permissions are negotiated
+    // through ACP `session/request_permission` regardless of CLI flags.
+    const args = ["acp"];
+    return { command: resolveCursorPath(options.cwd), args };
+  }
+
+  /**
+   * Cursor requires an explicit `authenticate({methodId: "cursor_login"})`
+   * step between `initialize` and `session/new`. The actual credential
+   * comes from the macOS Keychain (populated by `agent login`); we never
+   * pass it inline — that would force per-token billing rather than the
+   * user's Cursor subscription.
+   */
+  protected async authenticate(_options: SpawnOptions, _initResult: unknown): Promise<void> {
+    try {
+      await this.request("authenticate", { methodId: "cursor_login" });
+    } catch (err) {
+      // If the user is already authenticated, Cursor returns an error like
+      // "already authenticated". That's not fatal — session/new will work.
+      // Anything else, surface as a real failure so the consumer knows
+      // they need to run `agent login`.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/already authenticated|already logged in/i.test(msg)) {
+        throw err;
+      }
+    }
+  }
+
+  /**
+   * Translate Cursor's `cursor/`-prefixed `session/update` sub-types and
+   * the proprietary `session_info_update` notification. Returns
+   * `undefined` to fall through to base behavior for anything we don't
+   * recognise, `null` to silently drop, or an AgentEvent to emit.
+   */
+  protected translateVendorUpdate(update: AcpSessionUpdate): AgentEvent | null | undefined {
+    switch (update.sessionUpdate) {
+      case "session_info_update":
+        // Cursor-specific session metadata refresh (model name, capability
+        // changes, etc.). Not part of SNA's event vocabulary; drop.
+        return null;
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * Canonical tool name for a Cursor ACP `tool_call` / `tool_call_update`.
+   *
+   * Cursor's ACP wire format flattens what its stream-json output expresses
+   * as `{<kind>ToolCall: {args, result}}` — over ACP, you get a top-level
+   * `update.kind` (e.g. "execute", "read", "edit") plus `update.rawInput`
+   * carrying the inner args directly. So we use `kind` as the canonical
+   * tool name, and surface `update.title` (the user-visible call
+   * description, often the literal shell command in backticks) as
+   * `data.cursorTitle` for debug overlays.
+   *
+   * If a future Cursor version starts shipping the wrapped variant in ACP
+   * rawInput, `unwrapCursorVariant` catches it and uses the variant name
+   * instead — same path, just slightly nicer name.
+   */
+  protected unwrapToolCall(update: AcpSessionUpdate): UnwrappedToolCall {
+    const wrapped = unwrapCursorVariant(update.rawInput);
+    if (wrapped) {
+      return {
+        toolName: wrapped.variant,
+        input: wrapped.args,
+        extra: {
+          ...(update.title ? { cursorTitle: update.title } : {}),
+          ...(wrapped.result !== undefined ? { toolCallResult: wrapped.result } : {}),
+        },
+      };
+    }
+    // Flattened ACP shape: prefer `kind` over the title (which often
+    // contains the literal command text and isn't a stable tool name).
+    const toolName = update.kind || update.title || "tool";
+    return {
+      toolName,
+      input: update.rawInput,
+      extra: update.title && update.title !== toolName ? { cursorTitle: update.title } : undefined,
+    };
+  }
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+export class CursorProvider implements AgentProvider {
+  readonly name = "cursor";
+  readonly supportsRuntimePooling = false;
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const p = resolveCursorPath(process.cwd());
+      execSync(`"${p}" --version`, { stdio: "pipe", timeout: 5000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  spawn(options: SpawnOptions): AgentProcess {
+    const effectiveModel = applyCursorReasoning(options.model, options.reasoningLevel);
+    logger.log(
+      "agent",
+      `cursor: spawn cwd=${options.cwd} model=${effectiveModel ?? "default"}`,
+    );
+    // Replace the model id on the way through so CursorProcess sees the
+    // effort-resolved variant. We don't mutate the caller's options.
+    return new CursorProcess({ ...options, model: effectiveModel });
+  }
+
+  async complete(options: CompleteOptions): Promise<CompletionResult> {
+    // One-shot path uses `agent -p` headless mode (stream-json or json),
+    // not ACP. The wire format is Anthropic-shape so we mostly mirror
+    // Claude Code's complete() — including the streaming-json delta
+    // shape (`{type:"assistant",message:{content:[{type:"text",text}]}}`).
+    const cursorPath = resolveCursorPath(options.cwd);
+    const cwd = options.cwd ?? process.cwd();
+
+    const streaming = typeof options.onDelta === "function";
+    const args: string[] = [
+      "-p",
+      ...(streaming ? ["--output-format", "stream-json", "--stream-partial-output"] : ["--output-format", "json"]),
+      "--trust",
+      "--force",
+    ];
+    const baseModel = options.model;
+    const effectiveModel = applyCursorReasoning(baseModel, options.reasoningLevel) ?? baseModel;
+    if (effectiveModel) args.push("--model", effectiveModel);
+    if (options.extraArgs) args.push(...options.extraArgs);
+    args.push(options.prompt);
+
+    const timeout = options.timeout ?? 60_000;
+    const reportedModel = effectiveModel ?? "auto";
+
+    logger.log(
+      "agent",
+      `complete: provider=cursor model=${reportedModel} prompt="${options.prompt.slice(0, 60)}..."`,
+    );
+
+    return new Promise<CompletionResult>((resolve, reject) => {
+      const start = Date.now();
+      const proc = spawn(cursorPath, args, {
+        cwd,
+        env: { ...process.env, ...(options.env ?? {}) },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let streamBuf = "";
+      // Track which assistant message ids have already streamed their text
+      // so we don't fire onDelta twice when Cursor sends both an incremental
+      // chunk (without model_call_id) and a final aggregated message.
+      const seenAssistantText = new Set<string>();
+
+      const timer = setTimeout(() => {
+        proc.kill("SIGTERM");
+        reject(new Error(`cursor complete timed out after ${timeout}ms`));
+      }, timeout);
+
+      proc.stdout!.on("data", (chunk: Buffer) => {
+        const text = chunk.toString();
+        stdout += text;
+        if (!streaming) return;
+        streamBuf += text;
+        const lines = streamBuf.split("\n");
+        streamBuf = lines.pop() ?? "";
+        for (const line of lines) {
+          const t = line.trim();
+          if (!t) continue;
+          try {
+            const evt = JSON.parse(t) as {
+              type?: string;
+              message?: { content?: Array<{ type?: string; text?: string }> };
+              timestamp_ms?: number;
+              model_call_id?: string;
+            };
+            if (
+              evt.type === "assistant" &&
+              typeof evt.timestamp_ms === "number" &&
+              !evt.model_call_id &&
+              options.onDelta
+            ) {
+              const blocks = evt.message?.content ?? [];
+              for (const block of blocks) {
+                if (block?.type === "text" && typeof block.text === "string") {
+                  try {
+                    options.onDelta(block.text);
+                  } catch (cbErr) {
+                    clearTimeout(timer);
+                    proc.kill();
+                    reject(cbErr instanceof Error ? cbErr : new Error(String(cbErr)));
+                    return;
+                  }
+                }
+              }
+            } else if (evt.type === "assistant" && evt.model_call_id) {
+              seenAssistantText.add(evt.model_call_id);
+            }
+          } catch {
+            // ignore malformed lines
+          }
+        }
+      });
+
+      proc.stderr!.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      proc.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+
+      proc.on("exit", (code) => {
+        clearTimeout(timer);
+        const durationMs = Date.now() - start;
+        if (code !== 0) {
+          const stderrTail = stderr.trim().split("\n").slice(-3).join(" | ");
+          reject(new Error(`cursor exited with code ${code}: ${stderrTail || "(no stderr)"}`));
+          return;
+        }
+
+        let resultText = "";
+        let usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
+        try {
+          if (streaming) {
+            // Find the terminal `result` event — it carries the final
+            // aggregated text + usage.
+            const lines = stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+            for (const line of lines) {
+              const evt = JSON.parse(line) as {
+                type?: string;
+                subtype?: string;
+                result?: string;
+                usage?: {
+                  inputTokens?: number;
+                  outputTokens?: number;
+                  cacheReadTokens?: number;
+                  cacheWriteTokens?: number;
+                };
+              };
+              if (evt.type === "result" && evt.subtype === "success") {
+                resultText = evt.result ?? "";
+                usage = {
+                  inputTokens: evt.usage?.inputTokens ?? 0,
+                  outputTokens: evt.usage?.outputTokens ?? 0,
+                  cacheReadTokens: evt.usage?.cacheReadTokens ?? 0,
+                  cacheCreationTokens: evt.usage?.cacheWriteTokens ?? 0,
+                };
+                break;
+              }
+            }
+          } else {
+            const parsed = JSON.parse(stdout) as {
+              result?: string;
+              usage?: {
+                inputTokens?: number;
+                outputTokens?: number;
+                cacheReadTokens?: number;
+                cacheWriteTokens?: number;
+              };
+            };
+            resultText = parsed.result ?? "";
+            usage = {
+              inputTokens: parsed.usage?.inputTokens ?? 0,
+              outputTokens: parsed.usage?.outputTokens ?? 0,
+              cacheReadTokens: parsed.usage?.cacheReadTokens ?? 0,
+              cacheCreationTokens: parsed.usage?.cacheWriteTokens ?? 0,
+            };
+          }
+        } catch (err) {
+          reject(new Error(`cursor complete: failed to parse stdout: ${err instanceof Error ? err.message : String(err)}`));
+          return;
+        }
+
+        resolve({
+          text: resultText,
+          usage,
+          costUsd: 0,
+          durationMs,
+          durationApiMs: durationMs,
+          model: reportedModel,
+        });
+      });
+    });
+  }
+
+  async listModels(_config?: ListModelsConfig): Promise<ListModelsResult> {
+    // Cursor's `agent models` prints a human-readable list (`<id> - <label>`,
+    // newline-separated). No `--json` flag exists today, so we parse the
+    // text. On failure, fall back to a hard-coded subset of widely-available
+    // ids observed at the time of writing.
+    try {
+      const cursorPath = resolveCursorPath(process.cwd());
+      const raw = execSync(`"${cursorPath}" models`, { encoding: "utf-8", timeout: 5000 });
+      const models: RuntimeModelInfo[] = [];
+      for (const line of raw.split("\n")) {
+        const m = line.match(/^([a-z0-9.-]+)\s+-\s+(.+)$/i);
+        if (!m) continue;
+        const id = m[1]!;
+        const label = m[2]!;
+        models.push({
+          id,
+          label,
+          provider: providerForCursorModel(id),
+          source: "cli",
+        });
+      }
+      if (models.length === 0) throw new Error("agent models returned no parseable entries");
+      return { models, source: "cli", fetchedAt: Date.now() };
+    } catch (err) {
+      logger.log(
+        "agent",
+        `cursor listModels: falling back to static catalog (${err instanceof Error ? err.message : String(err)})`,
+      );
+      const fallback: RuntimeModelInfo[] = [
+        { id: "auto", label: "Auto", provider: "cursor", source: "static" },
+        { id: "composer-2.5", label: "Composer 2.5", provider: "cursor", source: "static" },
+        { id: "gpt-5.3-codex", label: "Codex 5.3", provider: "openai", source: "static" },
+        { id: "claude-sonnet-4.5", label: "Claude Sonnet 4.5", provider: "anthropic", source: "static" },
+      ];
+      return {
+        models: fallback,
+        source: "static",
+        fetchedAt: Date.now(),
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+}
+
+/**
+ * Map a Cursor model id to its inference backend family for attribution
+ * purposes (matches the convention used by other providers' RuntimeModelInfo).
+ */
+function providerForCursorModel(id: string): string {
+  if (id.startsWith("gpt-") || id.includes("codex")) return "openai";
+  if (id.startsWith("claude-") || id.startsWith("sonnet-") || id.startsWith("opus-") || id.startsWith("haiku-")) return "anthropic";
+  if (id.startsWith("gemini-")) return "google";
+  if (id.startsWith("grok-")) return "xai";
+  return "cursor";
+}

--- a/packages/core/src/core/providers/grok.ts
+++ b/packages/core/src/core/providers/grok.ts
@@ -3,68 +3,65 @@
  *
  * Backed by the Grok Build CLI's `grok agent stdio` subcommand, which
  * implements the Agent Client Protocol (ACP, https://agentclientprotocol.com)
- * as a JSON-RPC 2.0 stream over stdin/stdout. This is the only provider in
- * SNA whose wire protocol is a public standard rather than a vendor-specific
- * schema — which means the adapter is mostly a thin translator between ACP
- * `session/update` notifications and SNA's normalized `AgentEvent`.
+ * as a JSON-RPC 2.0 stream over stdin/stdout.
+ *
+ * The bulk of the wire handling lives in `acp/base.ts` (shared with Cursor).
+ * This file is the Grok Build-specific subclass + provider entry: CLI path
+ * resolution, top-level flag composition, MCP bridge setup via
+ * `<cwd>/.grok/config.toml`, `_x.ai/*` extension drop, and the `use_tool`
+ * dispatch unwrap that surfaces the real MCP tool name behind grok's
+ * generic dispatcher.
  *
  * Note on product naming: throughout this file, `grok` (lowercase) refers
  * to the CLI binary / registry key only. The xAI product itself is "Grok
  * Build" — that's what user-facing documentation should call it, just as
  * "Claude Code" is the product name behind the `claude` binary.
  *
- * Design decisions (validated against Grok Build CLI 0.1.212):
+ * Design decisions specific to Grok Build (the shared ACP decisions are
+ * captured at the top of `acp/base.ts`):
  *
- * 1. NO daemon pooling. `grok agent stdio` is spawned fresh per session,
- *    mirroring Claude Code's stateless model. xAI's storage layer
- *    (chat_history.jsonl + 6 other files in ~/.grok/sessions/) is treated
- *    as a black box; we never read or write it directly.
+ *   • MCP via `<cwd>/.grok/config.toml`. Grok advertises only `{http,sse}`
+ *     in `initialize.mcpCapabilities` and rejects every non-empty shape
+ *     passed to `session/new.mcpServers`. Stdio MCP servers (Loom's
+ *     workflow today) are bridged to HTTP via `stdio-http-bridge.ts`
+ *     and written into a project-scoped TOML the daemon reads at startup.
+ *     The original config (if any) is restored on exit.
  *
- * 2. History injection via ACP `resource` blocks (option B). Probing showed
- *    that `session/load` only replays UI events and does NOT restore model
- *    context — the real context lives in xAI-internal chat_history.jsonl
- *    which is regenerated on load. We instead serialise SNA's canonical
- *    history into a single `resource` content block on the first
- *    `session/prompt`, and the embedded context persists across subsequent
- *    turns within the same grok session (verified: turn-2 still remembered
- *    facts injected on turn-1 without re-injection).
+ *   • `_x.ai/*` extension notifications are dropped on the floor.
  *
- * 3. Permission flow reuses the Codex bidirectional pattern. ACP's
- *    `session/request_permission` is a server-request (has `id`, expects
- *    a response) with an `options[]` array — structurally identical to
- *    Codex's pattern. We map it to SNA's `permission_needed` event and
- *    accept `respondToPermission()` callbacks the same way.
+ *   • `use_tool` unwrap. Grok dispatches every external MCP call through
+ *     its internal `use_tool` tool with the real tool name + arguments
+ *     nested as `rawInput.tool_name` and `rawInput.tool_input`. We
+ *     surface the canonical name directly so downstream
+ *     `isToolName(name, "board_item_add")` checks behave the same way
+ *     they do for claude / codex / opencode.
  *
- * 4. `_x.ai/*` extension notifications (fs_notify, mcp/init_progress,
- *    session_notification, etc.) are dropped on the floor. They're useful
- *    for native IDE clients but irrelevant to SNA's normalized event model.
- *
- * 5. Reasoning level uses the same 5-step table as Claude Code (low / low /
- *    medium / high / xhigh / max).
+ *   • Reasoning level uses the same 5-step table as Claude Code (low / low
+ *     / medium / high / xhigh / max).
  */
 
-import { spawn, execSync, type ChildProcess } from "child_process";
-import { EventEmitter } from "events";
+import { spawn, execSync } from "child_process";
 import fs from "node:fs";
 import path from "node:path";
-import readline from "readline";
 import { bridgeStdioMcpToHttp, type BridgeHandle } from "../mcp/stdio-http-bridge.js";
 import type {
   AgentProvider,
   AgentProcess,
-  AgentEvent,
   SpawnOptions,
-  SessionPatch,
   CompleteOptions,
   CompletionResult,
-  ContentBlock,
   ListModelsConfig,
   ListModelsResult,
   RuntimeModelInfo,
 } from "./types.js";
-import type { CanonicalBlock } from "../../history/types.js";
 import { logger } from "../../lib/logger.js";
 import { toGrokEffort } from "./reasoning-level.js";
+import {
+  AcpStdioProcess,
+  type AcpSpawnDescriptor,
+  type AcpSessionUpdate,
+  type UnwrappedToolCall,
+} from "./acp/base.js";
 
 // ── CLI discovery ────────────────────────────────────────────────────────────
 
@@ -87,171 +84,12 @@ export function resolveGrokPath(_cwd: string = process.cwd()): string {
   return "grok";
 }
 
-// ── JSON-RPC types ──────────────────────────────────────────────────────────
-
-interface JsonRpcRequest {
-  jsonrpc: "2.0";
-  id: number;
-  method: string;
-  params?: unknown;
-}
-
-interface JsonRpcNotification {
-  jsonrpc: "2.0";
-  method: string;
-  params?: unknown;
-}
-
-interface JsonRpcResponse {
-  jsonrpc: "2.0";
-  id: number;
-  result?: unknown;
-  error?: { code: number; message: string; data?: unknown };
-}
-
-type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
-
-// ── ACP shapes we actually consume ───────────────────────────────────────────
-
-interface AcpSessionUpdate {
-  sessionUpdate:
-    | "user_message_chunk"
-    | "agent_message_chunk"
-    | "agent_thought_chunk"
-    | "tool_call"
-    | "tool_call_update"
-    | "available_commands_update"
-    | "plan"
-    | string;
-  content?: { type: "text"; text?: string } | unknown;
-  /** Present on tool_call / tool_call_update */
-  toolCallId?: string;
-  kind?: string;
-  title?: string;
-  rawInput?: unknown;
-  /** Present on tool_call_update result variant. */
-  rawOutput?: unknown;
-  /** File/path locations the tool touched — surfaces for tool_call_update. */
-  locations?: unknown;
-  status?: string;
-}
-
-interface AcpPermissionOption {
-  optionId: string;
-  name?: string;
-  kind: "allow_always" | "allow_once" | "reject_once" | "reject_always";
-}
-
-interface AcpPermissionRequest {
-  sessionId: string;
-  toolCall: {
-    toolCallId: string;
-    kind?: string;
-    title?: string;
-    rawInput?: unknown;
-  };
-  options: AcpPermissionOption[];
-}
-
-// ── History → resource transcript ────────────────────────────────────────────
-
-/**
- * Serialize SNA's canonical history into a plain-text transcript that fits
- * inside one ACP `resource` content block. The grok model treats the
- * content as part of its prompt context — see option-B probe results.
- *
- * Format is intentionally human-readable; the model parses it well enough
- * to extract user-stated facts and prior assistant outputs. Tool calls and
- * results are summarized inline; we do not attempt to round-trip them as
- * structured tool_use blocks (grok would have no use for unfinished tool
- * state from a different provider's session).
- */
-/**
- * Translate a `tool_call` or input-refresh `tool_call_update` notification
- * into a normalized `tool_use` AgentEvent. Centralizes the `use_tool`
- * unwrap so both code paths land on the same shape:
- *
- *   • `data.toolName` is the canonical tool name consumers match on
- *     (`pinboard_patch`, `board_item_add`, vendor MCP names, etc.). Grok
- *     wraps every external MCP call in its internal `use_tool` dispatch
- *     with the real tool name nested in `rawInput.tool_name` — we surface
- *     it directly so downstream `isToolName(...)` checks behave the same
- *     way they do for claude / codex / opencode.
- *   • `data.input` is what the *tool* sees: the unwrapped `tool_input`
- *     for use_tool dispatches, or the raw input for grok's native tools
- *     (`search_tool`, `run_terminal_command`, `write`, …).
- *   • `data.grokTitle` preserves grok's human-readable dispatch title
- *     ("Write `/tmp/big.html`", "Execute `wc -c /tmp/big.html`") for
- *     debug overlays / tooltips without confusing the canonical name.
- *   • `data.fromUpdate` flags refresh events so consumers can choose to
- *     skip work that already ran on the initial tool_call. Optional —
- *     idempotent-by-id consumers ignore it.
- */
-function toolUseFromUpdate(
-  update: AcpSessionUpdate,
-  now: number,
-  opts: { fromUpdate?: boolean } = {},
-): AgentEvent {
-  const raw = update.rawInput as { tool_name?: string; tool_input?: unknown } | undefined;
-  const isUseTool = !!(raw && typeof raw.tool_name === "string");
-  const toolName = isUseTool ? raw!.tool_name! : (update.title ?? "tool");
-  const input = isUseTool ? raw!.tool_input : update.rawInput;
-  return {
-    type: "tool_use",
-    message: toolName,
-    data: {
-      id: update.toolCallId,
-      toolName,
-      kind: update.kind,
-      input,
-      grokTitle: update.title,
-      ...(opts.fromUpdate ? { fromUpdate: true } : {}),
-    },
-    timestamp: now,
-  };
-}
-
-export function serializeHistoryForGrok(history: CanonicalBlock[]): string {
-  const lines: string[] = [];
-  for (const block of history) {
-    const actor = block.actor.toUpperCase();
-    switch (block.kind) {
-      case "text":
-        lines.push(`${actor}: ${block.content}`);
-        break;
-      case "thinking":
-        // Skip internal reasoning from prior providers — adds noise without
-        // useful context for grok.
-        break;
-      case "tool_use": {
-        const name = (block.meta as { name?: string } | undefined)?.name ?? "tool";
-        lines.push(`${actor} (calling ${name}): ${block.content}`);
-        break;
-      }
-      case "tool_result":
-        lines.push(`TOOL_RESULT: ${block.content}`);
-        break;
-      case "status":
-      case "error":
-        // Status/error metadata is not useful as prior conversation context.
-        break;
-    }
-  }
-  return lines.join("\n");
-}
-
 // ── Process ─────────────────────────────────────────────────────────────────
 
-export class GrokProcess extends EventEmitter implements AgentProcess {
-  // Definite-assignment: populated inside initialize() before the handshake
-  // resolves. Consumers always await this.ready before touching state.
-  private proc!: ChildProcess;
-  private rl!: readline.Interface;
-  private _sessionId: string | null = null;
-  private _alive = true;
+export class GrokProcess extends AcpStdioProcess {
   /**
    * stdio→HTTP MCP bridges spun up for this session. Each one owns its
-   * own child process + listener; dispose them on grok exit so we don't
+   * own child process + listener; disposed on grok exit so we don't
    * leak sockets between sessions.
    */
   private mcpBridges: BridgeHandle[] = [];
@@ -263,93 +101,11 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
    */
   private grokConfigRestore: { path: string; original: string | null } | null = null;
 
-  private rpcIdCounter = 0;
-  /** Resolvers for outgoing requests, keyed by our own request id. */
-  private readonly pendingRequests = new Map<
-    number,
-    { resolve: (value: unknown) => void; reject: (err: Error) => void; method: string }
-  >();
-  /**
-   * Open permission requests from grok. Maps SNA's externally-visible
-   * requestId (which we expose via the permission_needed AgentEvent) to
-   * grok's JSON-RPC request id, so respondToPermission() can route back.
-   */
-  private readonly pendingPermissions = new Map<string, number>();
+  protected get name(): string { return "grok"; }
 
-  /** Cached history transcript for first-turn injection (option B). */
-  private readonly historyTranscript: string | null;
-  private firstPromptSent = false;
-  /**
-   * Per-turn accumulator for `agent_message_chunk` text. ACP has no terminal
-   * "final assistant message" notification — the turn ends implicitly when
-   * `session/prompt` resolves with a `stopReason`. SNA's persistence layer,
-   * however, only writes assistant rows for the `assistant` event (which
-   * carries the full message text), not for the streaming `assistant_delta`
-   * chunks. So we accumulate chunks here and flush them as a single
-   * `assistant` event right before `complete` — otherwise the assistant turn
-   * never lands in chat_messages and reload-the-chat wipes the reply.
-   */
-  private assistantTurnBuffer = "";
-  /**
-   * Captured permission mode for the duration of this session. Grok's CLI
-   * `--always-approve` flag covers built-in tool prompts but does NOT skip
-   * the ACP `session/request_permission` round-trip for MCP tool calls —
-   * grok always asks the client even in bypass mode. SNA's SessionManager
-   * doesn't auto-resolve permissions either (it expects the renderer to do
-   * that via a dialog). So a `bypassPermissions` session would hang on
-   * every MCP tool call. We handle the auto-approve here in the provider
-   * instead, replying `allow-once` to permission requests before they ever
-   * leave SNA.
-   */
-  private readonly permissionMode: string | undefined;
-  /** Set true after initialize + session/new succeed. */
-  private ready: Promise<void>;
+  protected get vendorNotificationPrefix(): string { return "_x.ai/"; }
 
-  constructor(options: SpawnOptions) {
-    super();
-    this.permissionMode = options.permissionMode;
-    this.historyTranscript =
-      options.history && options.history.length > 0
-        ? serializeHistoryForGrok(options.history)
-        : null;
-
-    // Bridge setup is async (needs a free port), so we cannot spawn grok
-    // synchronously in the constructor — config.toml must already be written
-    // before `grok agent stdio` starts reading it. Drive everything through
-    // an async initialize chain. Consumers always await this.ready first.
-    this.ready = this.initialize(options);
-    this.ready.catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
-      this.emitEvent({ type: "error", message, timestamp: Date.now() });
-    });
-  }
-
-  /**
-   * One-shot async setup chain:
-   *   1. Bridge any stdio MCP entries to HTTP and write their URLs into
-   *      `<cwd>/.grok/config.toml` so grok picks them up at startup. ACP's
-   *      `session/new.mcpServers` is rejected by grok 0.1.212 for any
-   *      non-empty shape, so config.toml is the only working channel today.
-   *   2. Spawn `grok agent stdio` and wire stdout/stderr/exit listeners.
-   *   3. Run the ACP handshake (initialize + session/new).
-   */
-  private async initialize(options: SpawnOptions): Promise<void> {
-    try {
-      await this.setupMcpBridges(options);
-      this.spawnGrok(options);
-      await this.runHandshake(options);
-    } catch (err) {
-      // Any failure between bridge setup and a live grok process leaves
-      // orphaned bridges + a config.toml we wrote. The proc.exit handler
-      // hasn't been registered yet (or won't fire if grok never spawned),
-      // so clean up here. Idempotent — fine to also run from exit later.
-      this.disposeMcpBridges();
-      throw err;
-    }
-  }
-
-  private spawnGrok(options: SpawnOptions): void {
-    const grokPath = resolveGrokPath(options.cwd);
+  protected resolveSpawn(options: SpawnOptions): AcpSpawnDescriptor {
     // grok's top-level flags (`--model`, `--effort`, `--always-approve`) must
     // come BEFORE the `agent stdio` subcommand — the subcommand itself takes
     // no options other than `--help`. Putting them after silently fails with
@@ -366,47 +122,37 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
       args.push("--always-approve");
     }
     args.push("agent", "stdio");
+    return { command: resolveGrokPath(options.cwd), args };
+  }
 
-    logger.log("agent", `grok: spawning ${grokPath} ${args.join(" ")} (cwd=${options.cwd})`);
+  protected async preHandshake(options: SpawnOptions): Promise<void> {
+    await this.setupMcpBridges(options);
+  }
 
-    this.proc = spawn(grokPath, args, {
-      cwd: options.cwd,
-      env: { ...process.env, ...(options.env ?? {}) },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+  protected onExit(_code: number | null): void {
+    this.disposeMcpBridges();
+  }
 
-    this.rl = readline.createInterface({ input: this.proc.stdout! });
-    this.rl.on("line", (line) => this.handleLine(line));
+  protected onPreSpawnCleanup(): void {
+    this.disposeMcpBridges();
+  }
 
-    this.proc.stderr!.on("data", (chunk: Buffer) => {
-      const text = chunk.toString();
-      // grok's stderr emits two distinct shapes:
-      //   1. Structured tracing — `"2026-05-20T... ERROR ..."` (uppercase) —
-      //      mostly background-worker chatter (telemetry, memory).
-      //   2. Clap arg-parse failures — `"error: unexpected argument '--foo'"`
-      //      (lowercase) — fatal, immediate exit.
-      // Surface both. Matching case-insensitively also catches "Error:" from
-      // panics or auth failures that the CLI prints at startup.
-      if (/error/i.test(text)) {
-        logger.log("agent", `grok stderr: ${text.trim().slice(0, 400)}`);
-      }
-    });
-
-    this.proc.on("exit", (code) => {
-      this._alive = false;
-      // Reject any inflight requests so callers don't hang.
-      for (const { reject, method } of this.pendingRequests.values()) {
-        reject(new Error(`grok process exited (code=${code}) while waiting for ${method}`));
-      }
-      this.pendingRequests.clear();
-      this.disposeMcpBridges();
-      this.emit("exit", code);
-    });
-
-    this.proc.on("error", (err) => {
-      this._alive = false;
-      this.emit("error", err);
-    });
+  /**
+   * Grok wraps every external MCP call in its internal `use_tool` dispatch
+   * with the real tool name nested in `rawInput.tool_name`. Unwrap so
+   * downstream consumers see the canonical name.
+   */
+  protected unwrapToolCall(update: AcpSessionUpdate): UnwrappedToolCall {
+    const raw = update.rawInput as { tool_name?: string; tool_input?: unknown } | undefined;
+    const isUseTool = !!(raw && typeof raw.tool_name === "string");
+    const toolName = isUseTool ? raw!.tool_name! : (update.title ?? "tool");
+    const input = isUseTool ? raw!.tool_input : update.rawInput;
+    return {
+      toolName,
+      input,
+      // Preserve grok's human-readable dispatch title for debug overlays/tooltips.
+      extra: update.title ? { grokTitle: update.title } : undefined,
+    };
   }
 
   /**
@@ -493,442 +239,6 @@ export class GrokProcess extends EventEmitter implements AgentProcess {
       logger.log("agent", `grok: failed to restore ${restore.path}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
-
-  // ── JSON-RPC primitives ───────────────────────────────────────────────────
-
-  private write(msg: JsonRpcMessage): void {
-    if (!this.proc.stdin || this.proc.stdin.destroyed) {
-      throw new Error("grok stdin closed");
-    }
-    this.proc.stdin.write(JSON.stringify(msg) + "\n");
-  }
-
-  private request<T = unknown>(method: string, params?: unknown): Promise<T> {
-    const id = ++this.rpcIdCounter;
-    return new Promise<T>((resolve, reject) => {
-      this.pendingRequests.set(id, {
-        resolve: (v) => resolve(v as T),
-        reject,
-        method,
-      });
-      try {
-        this.write({ jsonrpc: "2.0", id, method, params });
-      } catch (err) {
-        this.pendingRequests.delete(id);
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
-    });
-  }
-
-  // ── Stream handling ───────────────────────────────────────────────────────
-
-  private handleLine(line: string): void {
-    const trimmed = line.trim();
-    if (!trimmed) return;
-    let msg: JsonRpcMessage;
-    try {
-      msg = JSON.parse(trimmed) as JsonRpcMessage;
-    } catch {
-      logger.log("agent", `grok: non-JSON line dropped: ${trimmed.slice(0, 200)}`);
-      return;
-    }
-
-    // Response to one of our outgoing requests
-    if ("id" in msg && msg.id != null && !("method" in msg)) {
-      const pending = this.pendingRequests.get(msg.id);
-      if (!pending) return;
-      this.pendingRequests.delete(msg.id);
-      const resp = msg as JsonRpcResponse;
-      if (resp.error) {
-        pending.reject(new Error(`grok ${pending.method} failed: ${resp.error.message}`));
-      } else {
-        pending.resolve(resp.result);
-      }
-      return;
-    }
-
-    // Server-initiated request (grok asking us for something)
-    if ("method" in msg && "id" in msg && msg.id != null) {
-      this.handleServerRequest(msg as JsonRpcRequest);
-      return;
-    }
-
-    // Notification
-    if ("method" in msg) {
-      this.handleNotification(msg as JsonRpcNotification);
-      return;
-    }
-  }
-
-  private handleServerRequest(req: JsonRpcRequest): void {
-    if (req.method === "session/request_permission") {
-      const params = req.params as AcpPermissionRequest;
-      const requestId = params.toolCall.toolCallId;
-
-      // Bypass-mode shortcut: pick whichever option carries an "allow"
-      // intent (or fall back to the first option) and reply immediately,
-      // skipping the SessionManager round-trip + UI dialog entirely. This
-      // mirrors the contract of `permissionMode: "bypassPermissions"`,
-      // which other providers implement by never asking in the first place.
-      if (this.permissionMode === "bypassPermissions") {
-        const allowOpt =
-          params.options.find((o) => o.kind === "allow_always") ??
-          params.options.find((o) => o.kind === "allow_once") ??
-          params.options[0];
-        if (allowOpt) {
-          this.write({
-            jsonrpc: "2.0",
-            id: req.id,
-            result: { outcome: { outcome: "selected", optionId: allowOpt.optionId } },
-          });
-          return;
-        }
-      }
-
-      // Externally we expose the toolCallId as the requestId — it's stable
-      // across the tool's lifecycle and lets callers correlate with the
-      // tool_use AgentEvent that triggered the prompt.
-      this.pendingPermissions.set(requestId, req.id);
-      this.emitEvent({
-        type: "permission_needed",
-        message: params.toolCall.title,
-        data: {
-          requestId,
-          toolCall: params.toolCall,
-          options: params.options,
-        },
-        timestamp: Date.now(),
-      });
-      return;
-    }
-
-    // We don't speak the rest of the ACP server-request surface (fs reads,
-    // terminal control, etc.). Reply with a method-not-found error so grok
-    // doesn't hang waiting on us.
-    this.write({
-      jsonrpc: "2.0",
-      id: req.id,
-      error: { code: -32601, message: `Method not implemented in SNA: ${req.method}` },
-    });
-  }
-
-  private handleNotification(notif: JsonRpcNotification): void {
-    if (notif.method.startsWith("_x.ai/")) {
-      // Vendor extension notifications (fs_notify, mcp/init_progress,
-      // session_notification, etc.) — design decision (4): drop.
-      return;
-    }
-    if (notif.method === "session/update") {
-      const params = notif.params as { sessionId?: string; update?: AcpSessionUpdate };
-      if (!params?.update) return;
-      const event = this.translateSessionUpdate(params.update);
-      if (event) this.emitEvent(event);
-      return;
-    }
-    // Unknown notifications: log and ignore.
-    logger.log("agent", `grok: ignored notification ${notif.method}`);
-  }
-
-  private translateSessionUpdate(update: AcpSessionUpdate): AgentEvent | null {
-    const now = Date.now();
-    const text = (update.content as { text?: string } | undefined)?.text ?? "";
-    switch (update.sessionUpdate) {
-      case "agent_thought_chunk":
-        return { type: "thinking_delta", delta: text, timestamp: now };
-      case "agent_message_chunk":
-        // Accumulate so the final `assistant` event (flushed when
-        // session/prompt resolves) carries the full message text for the DB.
-        this.assistantTurnBuffer += text;
-        return { type: "assistant_delta", delta: text, timestamp: now };
-      case "user_message_chunk":
-        // Emitted by grok when replaying loaded sessions or echoing our own
-        // prompts back. SNA's user_message AgentEvent has the same shape.
-        return { type: "user_message", message: text, timestamp: now };
-      case "tool_call":
-        return toolUseFromUpdate(update, now);
-      case "tool_call_update": {
-        // `tool_call_update` is overloaded in ACP — grok uses the same
-        // notification for two distinct kinds of update:
-        //   (a) Input refresh — rawInput grows or finalizes between the
-        //       initial `tool_call` and execution. Carries rawInput + kind +
-        //       title + (textual) content, NO status. We emit `tool_use`
-        //       again with the same id; SNA's persistence + Loom's
-        //       message store merge by id so the existing bubble refreshes
-        //       in place. xAI's API itself doesn't expose token-level
-        //       streaming for tool arguments (it returns the call "in
-        //       whole in a single chunk" per their docs), so the
-        //       differences between (a) and the original tool_call are
-        //       small finalization patches — but we still pass them
-        //       through so future grok/ACP additions slot in cleanly.
-        //   (b) Result update — has status (in_progress/completed/failed)
-        //       and content/rawOutput. We emit `tool_result` with all
-        //       fields preserved so consumers see locations, raw output
-        //       (parsed), and the textual content side-by-side.
-        const hasResultSignal = !!update.status || update.rawOutput !== undefined;
-        if (!hasResultSignal && update.rawInput !== undefined) {
-          return toolUseFromUpdate(update, now, { fromUpdate: true });
-        }
-        return {
-          type: "tool_result",
-          data: {
-            id: update.toolCallId,
-            status: update.status,
-            content: update.content,
-            rawOutput: update.rawOutput,
-            locations: update.locations,
-            kind: update.kind,
-            title: update.title || undefined,
-          },
-          timestamp: now,
-        };
-      }
-      case "available_commands_update":
-      case "plan":
-        // Slash-command list refresh / plan-mode pane updates aren't part
-        // of SNA's event vocabulary; ignore.
-        return null;
-      default:
-        return null;
-    }
-  }
-
-  private emitEvent(event: AgentEvent): void {
-    this.emit("event", event);
-  }
-
-  // ── Lifecycle ─────────────────────────────────────────────────────────────
-
-  private async runHandshake(options: SpawnOptions): Promise<void> {
-    await this.request("initialize", {
-      protocolVersion: 1,
-      clientCapabilities: {
-        // We accept fs/terminal capability declarations but don't actually
-        // implement those server-request methods (we reject them in
-        // handleServerRequest). Declaring true here would invite grok to
-        // call us; declare false to keep traffic minimal.
-        fs: { readTextFile: false, writeTextFile: false },
-        terminal: false,
-      },
-    });
-
-    // MCP server registration goes through `<cwd>/.grok/config.toml`, not
-    // session/new — setupMcpBridges() already wrote that file before this
-    // handshake runs. ACP's `session/new.mcpServers` field rejects any
-    // non-empty shape on grok 0.1.212 (`Invalid params`), even structurally
-    // valid http entries, so we keep it empty and let grok read tools off
-    // its own config-load path.
-    const sessionResp = (await this.request("session/new", {
-      cwd: options.cwd,
-      mcpServers: [],
-    })) as { sessionId?: string } | undefined;
-
-    const sessionId = sessionResp?.sessionId ?? null;
-    if (!sessionId) {
-      throw new Error("grok session/new returned no sessionId");
-    }
-    this._sessionId = sessionId;
-    this.emitEvent({
-      type: "init",
-      message: "grok session ready",
-      data: { sessionId },
-      timestamp: Date.now(),
-    });
-  }
-
-  // ── AgentProcess surface ──────────────────────────────────────────────────
-
-  send(input: string | ContentBlock[]): void {
-    void this.ready
-      .then(() => this.sendPrompt(input))
-      .catch((err) => {
-        const message = err instanceof Error ? err.message : String(err);
-        this.emitEvent({ type: "error", message, timestamp: Date.now() });
-      });
-  }
-
-  private async sendPrompt(input: string | ContentBlock[]): Promise<void> {
-    if (!this._sessionId) {
-      throw new Error("grok: send() called before session is ready");
-    }
-
-    // Build ACP prompt blocks. Order matters: on the first turn, the
-    // history `resource` block precedes the user's actual text so the
-    // transcript reads as prior context, not a follow-up.
-    const promptBlocks: unknown[] = [];
-
-    if (!this.firstPromptSent && this.historyTranscript) {
-      promptBlocks.push({
-        type: "resource",
-        resource: {
-          uri: "sna://prior-conversation.txt",
-          mimeType: "text/plain",
-          text:
-            "The following is our prior conversation, carried over from " +
-            "another agent. Continue from where it leaves off.\n\n" +
-            this.historyTranscript,
-        },
-      });
-    }
-
-    if (typeof input === "string") {
-      promptBlocks.push({ type: "text", text: input });
-      this.emitEvent({ type: "user_message", message: input, timestamp: Date.now() });
-    } else {
-      for (const block of input) {
-        if (block.type === "text") {
-          promptBlocks.push({ type: "text", text: block.text });
-        } else if (block.type === "image") {
-          // ACP's image block expects { type: "image", data, mimeType }.
-          // Translate SNA's Anthropic-style {source:{type,media_type,data}}
-          // shape into that.
-          promptBlocks.push({
-            type: "image",
-            data: block.source.data,
-            mimeType: block.source.media_type,
-          });
-        }
-      }
-      this.emitEvent({
-        type: "user_message",
-        data: { blocks: input },
-        timestamp: Date.now(),
-      });
-    }
-
-    this.firstPromptSent = true;
-
-    try {
-      const result = (await this.request("session/prompt", {
-        sessionId: this._sessionId,
-        prompt: promptBlocks,
-      })) as { stopReason?: string } | undefined;
-      this.flushAssistantTurn();
-      this.emitEvent({
-        type: "complete",
-        data: { stopReason: result?.stopReason ?? null },
-        timestamp: Date.now(),
-      });
-    } catch (err) {
-      // Flush whatever text streamed before the failure so a partial turn
-      // still lands in chat_messages and the user sees it after reload.
-      this.flushAssistantTurn();
-      const message = err instanceof Error ? err.message : String(err);
-      this.emitEvent({ type: "error", message, timestamp: Date.now() });
-    }
-  }
-
-  /**
-   * Emit the accumulated `agent_message_chunk` text as a single terminal
-   * `assistant` event so SNA's persistence layer writes a row to
-   * chat_messages, then clear the buffer for the next turn. No-op when
-   * nothing streamed (tool-only turns, interruptions before any text).
-   */
-  private flushAssistantTurn(): void {
-    const text = this.assistantTurnBuffer;
-    this.assistantTurnBuffer = "";
-    if (!text) return;
-    this.emitEvent({
-      type: "assistant",
-      message: text,
-      timestamp: Date.now(),
-    });
-  }
-
-  interrupt(): void {
-    if (!this._sessionId || !this._alive) return;
-    // ACP's `session/cancel` is a notification, not a request — the
-    // current session/prompt request resolves with stopReason="cancelled"
-    // once grok stops the turn.
-    try {
-      this.write({
-        jsonrpc: "2.0",
-        method: "session/cancel",
-        params: { sessionId: this._sessionId },
-      });
-      this.emitEvent({ type: "interrupted", timestamp: Date.now() });
-    } catch (err) {
-      logger.log("agent", `grok: interrupt failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-
-  setModel(_model: string): void {
-    // ACP does not expose a runtime model swap. grok currently advertises
-    // a single model ("grok-build"), so this is effectively no-op for now.
-    // If multiple models appear later, the only path is respawn — exposed
-    // via applyPatch().
-  }
-
-  setPermissionMode(_mode: string): void {
-    // ACP permissionMode is fixed at process startup. Runtime change
-    // requires respawn — returned as leftover from applyPatch.
-  }
-
-  applyPatch(patch: SessionPatch): SessionPatch {
-    // No in-place patching is supported yet — every mutable field requires
-    // a respawn. Return the patch unchanged so session-manager handles it.
-    return { ...patch };
-  }
-
-  respondToPermission(requestId: string, approved: boolean): void {
-    const rpcId = this.pendingPermissions.get(requestId);
-    if (rpcId == null) {
-      logger.log("agent", `grok: respondToPermission called for unknown requestId=${requestId}`);
-      return;
-    }
-    this.pendingPermissions.delete(requestId);
-    // Match the option kinds observed in the probe: "allow-once" /
-    // "reject-once". (grok also offers "always" variants — exposing those
-    // later would require richer respondToPermission semantics.)
-    const optionId = approved ? "allow-once" : "reject-once";
-    try {
-      // ACP RequestPermissionResponse shape: { outcome: <Outcome> }, where the
-      // outcome itself uses `outcome` as its discriminator (not `type`).
-      //   { outcome: { outcome: "selected", optionId: "allow-once" } }
-      //   { outcome: { outcome: "cancelled" } }
-      // grok rejects {type:"selected"} with -32603 "failed to deserialize response".
-      this.write({
-        jsonrpc: "2.0",
-        id: rpcId,
-        result: { outcome: { outcome: "selected", optionId } },
-      });
-    } catch (err) {
-      logger.log("agent", `grok: permission response failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-
-  kill(): void {
-    if (!this._alive) return;
-    this._alive = false;
-    // kill() may race with initialize() — proc isn't assigned until
-    // spawnGrok() runs. If we beat that, just dispose bridges and bail;
-    // initialize() will see _alive=false and unwind on its own.
-    if (!this.proc) {
-      this.disposeMcpBridges();
-      return;
-    }
-    try {
-      this.proc.kill("SIGTERM");
-    } catch {
-      // already dead
-    }
-    // Hard fallback if grok doesn't exit cleanly within 2s.
-    setTimeout(() => {
-      try {
-        if (this.proc.exitCode == null) this.proc.kill("SIGKILL");
-      } catch {
-        // ignore
-      }
-    }, 2000).unref();
-  }
-
-  closeThread(): void {
-    // Not pooled — same as kill.
-    this.kill();
-  }
-
-  get alive(): boolean { return this._alive; }
-  get pid(): number | null { return this.proc.pid ?? null; }
-  get sessionId(): string | null { return this._sessionId; }
 }
 
 // ── Provider ────────────────────────────────────────────────────────────────
@@ -1114,3 +424,11 @@ export class GrokProvider implements AgentProvider {
     return { models: [model], source: "static", fetchedAt: Date.now() };
   }
 }
+
+/**
+ * Backwards-compat export for the history serializer used inside the
+ * original GrokProcess. The base now provides `serializeHistoryForAcp()`
+ * (functionally identical); this thin re-export keeps the public symbol
+ * stable for any external callers that imported it from this module.
+ */
+export { serializeHistoryForAcp as serializeHistoryForGrok } from "./acp/base.js";

--- a/packages/core/src/core/providers/index.ts
+++ b/packages/core/src/core/providers/index.ts
@@ -19,6 +19,7 @@ export { ClaudeCodeProvider } from "./claude-code.js";
 export { CodexProvider } from "./codex.js";
 export { OpenCodeProvider } from "./opencode.js";
 export { GrokProvider } from "./grok.js";
+export { CursorProvider } from "./cursor.js";
 export { spawnWithPool } from "./spawn-helper.js";
 
 import type { AgentProvider } from "./types.js";
@@ -26,6 +27,7 @@ import { ClaudeCodeProvider } from "./claude-code.js";
 import { CodexProvider } from "./codex.js";
 import { OpenCodeProvider } from "./opencode.js";
 import { GrokProvider } from "./grok.js";
+import { CursorProvider } from "./cursor.js";
 
 const providers: Record<string, AgentProvider> = {
   "claude-code": new ClaudeCodeProvider(),
@@ -33,6 +35,7 @@ const providers: Record<string, AgentProvider> = {
   "opencode": new OpenCodeProvider(),
   "omlx": new ClaudeCodeProvider(),
   "grok": new GrokProvider(),
+  "cursor": new CursorProvider(),
 };
 
 /**

--- a/packages/core/src/core/providers/reasoning-level.ts
+++ b/packages/core/src/core/providers/reasoning-level.ts
@@ -17,6 +17,13 @@
  *
  * OpenCode currently has no equivalent knob exposed in its provider —
  * `reasoningLevel` is silently ignored there.
+ *
+ * Cursor is different: it has no `--effort` flag at all. Instead the
+ * effort is baked into the model id itself — `gpt-5.3-codex` (default)
+ * vs `gpt-5.3-codex-low`, `…-high`, `…-xhigh`. See `applyCursorReasoning`
+ * below; it transforms a base model id by appending the matching suffix.
+ * Models without an effort family (e.g. `composer-2.5`, `auto`) are
+ * returned unchanged.
  */
 
 export type ReasoningLevel = 0 | 1 | 2 | 3 | 4 | 5;
@@ -24,10 +31,15 @@ export type ReasoningLevel = 0 | 1 | 2 | 3 | 4 | 5;
 const CLAUDE_TABLE = ["low", "low", "medium", "high", "xhigh", "max"] as const;
 const CODEX_TABLE = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
 const GROK_TABLE = ["low", "low", "medium", "high", "xhigh", "max"] as const;
+// Cursor effort suffixes attached to model ids. Index 0 collapses to no
+// suffix (default model behavior) since Cursor doesn't expose a "below
+// default" effort.
+const CURSOR_SUFFIX_TABLE = ["", "-low", "-low", "", "-high", "-xhigh"] as const;
 
 export type ClaudeEffort = (typeof CLAUDE_TABLE)[number];
 export type CodexEffort = (typeof CODEX_TABLE)[number];
 export type GrokEffort = (typeof GROK_TABLE)[number];
+export type CursorEffortSuffix = (typeof CURSOR_SUFFIX_TABLE)[number];
 
 /** Translate a level to Claude Code's `--effort` argument value. */
 export function toClaudeEffort(level: ReasoningLevel): ClaudeEffort {
@@ -42,4 +54,58 @@ export function toCodexEffort(level: ReasoningLevel): CodexEffort {
 /** Translate a level to Grok's `--effort` argument value. */
 export function toGrokEffort(level: ReasoningLevel): GrokEffort {
   return GROK_TABLE[level];
+}
+
+/**
+ * Translate a level to a Cursor model-id suffix (`""`, `"-low"`,
+ * `"-high"`, `"-xhigh"`). Use {@link applyCursorReasoning} to append it
+ * to a model id only when the base model belongs to an effort family.
+ */
+export function toCursorEffortSuffix(level: ReasoningLevel): CursorEffortSuffix {
+  return CURSOR_SUFFIX_TABLE[level];
+}
+
+/**
+ * Set of Cursor model id prefixes (without an effort suffix) that support
+ * the `-low` / `-high` / `-xhigh` variant family. Only these get rewritten
+ * by {@link applyCursorReasoning}. All other models (`composer-*`,
+ * `claude-*`, `auto`, …) are returned verbatim.
+ */
+const CURSOR_EFFORT_FAMILIES = [
+  "gpt-5.3-codex",
+  "gpt-5.2-codex",
+  "gpt-5.1-codex",
+  "gpt-5-codex",
+];
+
+/**
+ * Combine a base Cursor model id with a SNA reasoning level by appending
+ * the matching effort suffix when the base model belongs to a known
+ * effort family. The base id may already include an effort or `-fast`
+ * suffix — we strip those first so the same model can be re-tuned by a
+ * subsequent reasoning-level patch without accumulating suffixes.
+ *
+ *   applyCursorReasoning("gpt-5.3-codex", 4)            → "gpt-5.3-codex-high"
+ *   applyCursorReasoning("gpt-5.3-codex-low", 4)        → "gpt-5.3-codex-high"
+ *   applyCursorReasoning("gpt-5.3-codex-low-fast", 4)   → "gpt-5.3-codex-high"
+ *   applyCursorReasoning("composer-2.5", 4)             → "composer-2.5" (no family match)
+ *   applyCursorReasoning("gpt-5.3-codex", undefined)    → "gpt-5.3-codex"
+ */
+export function applyCursorReasoning(modelId: string | undefined, level: ReasoningLevel | undefined): string | undefined {
+  if (!modelId) return modelId;
+  // Strip a trailing `-fast` (orthogonal to effort) — we'll preserve it
+  // separately if the original carried one. Today we drop it, since SNA
+  // doesn't expose a fast knob; consumers wanting `*-fast` should pass the
+  // explicit model id.
+  const base = modelId.replace(/-fast$/, "");
+  // Find a family the model belongs to, and strip any existing effort.
+  for (const family of CURSOR_EFFORT_FAMILIES) {
+    if (base === family || base.startsWith(`${family}-`)) {
+      const trimmed = family; // ignore any existing suffix
+      if (level === undefined) return trimmed;
+      return `${trimmed}${toCursorEffortSuffix(level)}`;
+    }
+  }
+  // No effort family match — return the (de-fast'd) base id; level is ignored.
+  return base;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,13 @@ export type { Session, SessionInfo, SessionManagerOptions, SessionState } from "
 // Consumers building their own latency-tuning layers can introspect or
 // reuse the same translation tables that codex.ts / claude-code.ts use.
 export type { ReasoningLevel } from "./core/providers/reasoning-level.js";
-export { toClaudeEffort, toCodexEffort, toGrokEffort } from "./core/providers/reasoning-level.js";
+export {
+  toClaudeEffort,
+  toCodexEffort,
+  toGrokEffort,
+  toCursorEffortSuffix,
+  applyCursorReasoning,
+} from "./core/providers/reasoning-level.js";
 
 // Runtime pool — exposed so consumer apps can pre-warm daemons (warmup
 // `prepare()` once at startup so subsequent completion()/spawn() calls hit


### PR DESCRIPTION
## Summary

Adds **Cursor** as SNA's fifth provider, alongside extracting an
`AcpStdioProcess` base class now that we have two ACP-speaking
providers (Grok Build + Cursor). The base sits at
\`core/providers/acp/base.ts\` and absorbs the JSON-RPC pump, ACP
handshake, event translation, bidirectional permission flow
(including \`bypassPermissions\` auto-approve), tool_call_update
routing, per-turn assistant-flush, and history \`resource\` block
injection. Both Grok and Cursor are now thin subclasses.

The Cursor adapter is backed by the \`agent acp\` subcommand. Uses
the user's existing \`agent login\` (macOS Keychain) — so the user's
Cursor subscription is what bills, not \`CURSOR_API_KEY\`. No global
files touched; no setup beyond \`agent login\` (which most users have
already done).

## Commits

1. \`6663173\` **refactor(core/acp)**: extract \`AcpStdioProcess\`
   base, port Grok onto it.
   - Grok grok.ts goes 1116 → 435 lines (681-line drop into the base).
   - No behavior change for Grok — regression-verified live with the
     spawn → init → send → delta stream → complete round-trip.

2. \`07102c4\` **feat(core)**: add Cursor provider.
   - \`core/providers/cursor.ts\` (~380 lines): \`CursorProcess\`
     extending \`AcpStdioProcess\` + \`CursorProvider\`.
   - Override hooks: \`authenticate({methodId:\"cursor_login\"})\`
     between initialize and session/new, \`agent acp\` spawn args,
     \`cursor/*\` + \`session_info_update\` extension drop,
     \`<kind>ToolCall\` unwrap (uses \`update.kind\` since Cursor's
     ACP wire flattens what its stream-json calls \`shellToolCall\`).
   - \`applyCursorReasoning\` in reasoning-level.ts encodes effort
     into the model id (\`gpt-5.3-codex\` → \`gpt-5.3-codex-high\`).
   - \`complete()\` headless via \`agent -p --output-format stream-json
     --stream-partial-output --force --trust\`.
   - \`listModels\` parses \`agent models\` text + static fallback.
   - Docs: providers.{mdx,ko,ja} + feature-matrix.{mdx,ko,ja} all
     pick up the Cursor column.

## Validation

Live-tested against Cursor CLI 2026.05 (6/6 smoke tests pass):

| Test | Result |
|---|---|
| spawn / initialize / authenticate / session/new | ✅ |
| send → \`agent_message_chunk\` stream → \`assistant\` flush → complete | ✅ |
| tool_use + bidirectional \`session/request_permission\` | ✅ (\`toolName=\"execute\"\`, allow-once, output appears) |
| Cross-provider history via \`resource\` block | ✅ (\"BLUEFOX-CURSOR\" recalled) |
| Multi-turn context retention | ✅ (turn-1 \"7777\" → turn-2 \"7777\") |
| \`complete()\` headless (\`agent -p\`) | ✅ \"PONG\" 11s |
| \`getProvider(\"cursor\")\` registry | ✅ |

Grok regression-tested after the refactor — same Grok smoke output as
on \`main\`, same timings.

## What's intentionally deferred

- **\`systemPrompt\` / \`appendSystemPrompt\`** for Cursor — no CLI
  override exists. Routes via \`AGENTS.md\` (project-scoped, intrusive)
  or first-turn folding are possible; not yet wired. ⚠ in feature
  matrix.
- **Per-session stdio MCP injection** — Cursor's ACP reads from
  user's \`~/.cursor/mcp.json\` at startup. Bridging stdio entries the
  way Grok handles it via \`.grok/config.toml\` + the stdio→HTTP bridge
  is a follow-up.
- **\`applyPatch\` in-place mutation** — every field is leftover for
  now; respawn-with-history-replay covers it.
- **Image input** — accepted in the prompt shape but not exercised
  end-to-end yet.

## Test plan

- [ ] \`pnpm install && pnpm --filter @sna/core build\` — expect green
- [ ] \`pnpm --filter @sna/docs build\` — expect green
- [ ] (Optional) Reviewer with a logged-in \`agent\` CLI runs the
      cursor smoke suite in \`/tmp/cursor-smoke.mjs\` (not committed —
      can share on request).
- [ ] (Optional) Reviewer with a logged-in \`grok\` CLI runs a Grok
      smoke session to confirm the refactor didn't regress.
- [ ] (Optional) Reviewer wires up a session via SessionManager with
      \`config.provider = \"cursor\"\` and watches the event stream
      end-to-end.