### PR TITLE
feat(acp): wire allowedTools/disallowedTools + image input verification

### DIFF
--- a/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
@@ -84,11 +84,11 @@ allow/deny ルールに基づいて) 自分で判断し、CLI は SNA プロセ�
 
 | フィールド | Claude Code | Codex | OpenCode | Grok Build | Cursor |
 |---|---|---|---|---|---|
-| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start` の `baseInstructions` | ✓ `appendSystemPrompt` と結合 | ✓ `--system-prompt-override` | ⚠ CLI フラグ無し。ユーザの `AGENTS.md` か最初のプロンプトに fold (SNA からはまだ配線していない) |
-| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start` の `developerInstructions` | ✓ `systemPrompt` と結合 | ✓ `--rules` | ⚠ `systemPrompt` と同様 |
+| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start` の `baseInstructions` | ✓ `appendSystemPrompt` と結合 | ✓ ACP base 最初の turn の `resource` block (ヘッドレス `complete()` 経路は `--system-prompt-override` もサポート) | ✓ ACP base 最初の turn の `resource` block (CLI フラグ自体が無い。fold が共有 base に乗る) |
+| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start` の `developerInstructions` | ✓ `systemPrompt` と結合 | ✓ 同じ最初の turn の block で `systemPrompt` と結合 (complete 経路は `--rules` もサポート) | ✓ 同じ最初の turn の block で `systemPrompt` と結合 |
 | `allowedTools` | ✓ ネイティブ `--allowedTools` | ✓ PreToolUse hook (他を deny) | ⚠ best-effort (既知のツールのみトグル) | ✓ `--tools` 許可リスト | ⚠ `~/.cursor/cli-config.json` の `permissions.allow` 経由 (user-global、SNA は管理しない) |
 | `disallowedTools` | ✓ ネイティブ `--disallowedTools` | ✓ PreToolUse hook | ✓ 列挙されたツールを無効化 | ✓ `--disallowed-tools` | ⚠ `allowedTools` と同様 (または `--mode plan` でセッション全体 read-only) |
-| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` に書き出し | ✓ SDK 経由 | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ⚠ ユーザの `~/.cursor/mcp.json` に依存; per-session stdio MCP 注入は後続タスク |
+| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` に書き出し | ✓ SDK 経由 | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ✓ stdio→HTTP bridge + `<cwd>/.cursor/mcp.json` (既存 user entries とマージ、exit で復元) |
 | `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 無視 | ✓ `toGrokEffort` → `--effort` | ✓ `applyCursorReasoning` → モデル ID サフィックス (`gpt-5.3-codex` → `gpt-5.3-codex-high`) |
 | `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 対応なし | ✗ 対応なし (Grok Build は `~/.grok` 固定) | ✗ 対応なし (Cursor は `~/.cursor` 固定; `CURSOR_CONFIG_DIR` は `cli-config.json` だけリルート、hook はリルートしない) |
 | `resumeSessionId` | ✓ JSONL replay ファイル経由 | ✓ `thread/resume` API | ✓ session id | ⚠ Grok Build chat id で resume は動くが、クロスプロバイダ history は下記 `resource` block 経路 | ⚠ Cursor `chatId` で resume 動作 (`--resume <id>` / `session/load`)、クロスプロバイダ history は同じ経路 |
@@ -143,13 +143,9 @@ xAI 内部、Cursor は `~/.cursor/chats/` 下の SQLite) で session load 時
   Cursor `--mode plan`): CLI フラグは spawn 時に反映されますが、
   インプレース切り替えには `permissionMode` patch サポートが必要で、
   ACP-スピーキングプロバイダはまだ持っていません。
-- **Cursor の MCP 配線**: Cursor の ACP は起動時にユーザの
-  `~/.cursor/mcp.json` を読みます。Per-session stdio MCP 注入 (Grok が
-  `.grok/config.toml` + stdio→HTTP bridge で扱う方式) は後続タスク。
-- **Cursor の `systemPrompt` / `appendSystemPrompt`**: Cursor には
-  エージェントのシステムプロンプトを CLI で override する手段が
-  ありません。`AGENTS.md` (プロジェクト単位、侵襲的) や最初の turn
-  への fold は可能ですが、まだ配線していません。
+- **Cursor の `allowedTools` / `disallowedTools`**: Cursor の per-tool
+  権限は user-global な `~/.cursor/cli-config.json` にあり、per-session
+  での shaping は後続タスク。
 - **プロンプトへの画像入力**: 5 つのプロバイダはすべて何らかの形で
   画像 block を受け付けますが、プロバイダごとの添付エンコーディング
   はまだ揃っていません — 現状は

--- a/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
@@ -86,8 +86,8 @@ allow/deny ルールに基づいて) 自分で判断し、CLI は SNA プロセ�
 |---|---|---|---|---|---|
 | `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start` の `baseInstructions` | ✓ `appendSystemPrompt` と結合 | ✓ ACP base 最初の turn の `resource` block (ヘッドレス `complete()` 経路は `--system-prompt-override` もサポート) | ✓ ACP base 最初の turn の `resource` block (CLI フラグ自体が無い。fold が共有 base に乗る) |
 | `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start` の `developerInstructions` | ✓ `systemPrompt` と結合 | ✓ 同じ最初の turn の block で `systemPrompt` と結合 (complete 経路は `--rules` もサポート) | ✓ 同じ最初の turn の block で `systemPrompt` と結合 |
-| `allowedTools` | ✓ ネイティブ `--allowedTools` | ✓ PreToolUse hook (他を deny) | ⚠ best-effort (既知のツールのみトグル) | ✓ `--tools` 許可リスト | ⚠ `~/.cursor/cli-config.json` の `permissions.allow` 経由 (user-global、SNA は管理しない) |
-| `disallowedTools` | ✓ ネイティブ `--disallowedTools` | ✓ PreToolUse hook | ✓ 列挙されたツールを無効化 | ✓ `--disallowed-tools` | ⚠ `allowedTools` と同様 (または `--mode plan` でセッション全体 read-only) |
+| `allowedTools` | ✓ ネイティブ `--allowedTools` | ✓ PreToolUse hook (他を deny) | ⚠ best-effort (既知のツールのみトグル) | ✓ ACP base が `session/request_permission` 境界で非リストツールを自動 deny | ✓ ACP base が `session/request_permission` 境界で非リストツールを自動 deny |
+| `disallowedTools` | ✓ ネイティブ `--disallowedTools` | ✓ PreToolUse hook | ✓ 列挙されたツールを無効化 | ✓ ACP base が permission 境界で列挙されたツールを自動 deny | ✓ ACP base が permission 境界で列挙されたツールを自動 deny |
 | `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` に書き出し | ✓ SDK 経由 | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ✓ stdio→HTTP bridge + `<cwd>/.cursor/mcp.json` (既存 user entries とマージ、exit で復元) |
 | `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 無視 | ✓ `toGrokEffort` → `--effort` | ✓ `applyCursorReasoning` → モデル ID サフィックス (`gpt-5.3-codex` → `gpt-5.3-codex-high`) |
 | `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 対応なし | ✗ 対応なし (Grok Build は `~/.grok` 固定) | ✗ 対応なし (Cursor は `~/.cursor` 固定; `CURSOR_CONFIG_DIR` は `cli-config.json` だけリルート、hook はリルートしない) |
@@ -141,12 +141,15 @@ xAI 内部、Cursor は `~/.cursor/chats/` 下の SQLite) で session load 時
 - **plan mode のランタイム切り替え** (Claude Code
   `--permission-mode plan`、Grok Build `--permission-mode plan`、
   Cursor `--mode plan`): CLI フラグは spawn 時に反映されますが、
-  インプレース切り替えには `permissionMode` patch サポートが必要で、
-  ACP-スピーキングプロバイダはまだ持っていません。
-- **Cursor の `allowedTools` / `disallowedTools`**: Cursor の per-tool
-  権限は user-global な `~/.cursor/cli-config.json` にあり、per-session
-  での shaping は後続タスク。
-- **プロンプトへの画像入力**: 5 つのプロバイダはすべて何らかの形で
-  画像 block を受け付けますが、プロバイダごとの添付エンコーディング
-  はまだ揃っていません — 現状は
-  [セッション › 添付](/ja/docs/introduction/sessions) を参照。
+  インプレース切り替えは ACP がワイヤメソッドとして公開しません —
+  ACP applyPatch はすべてのフィールドを leftover として返し、セッション
+  マネージャが respawn-with-history-replay で処理します。
+- **ACP プロバイダの `allowedTools` / `disallowedTools` glob/パターン
+  マッチ**: 現在の auto-deny intercept はツール名を文字列完全一致のみ
+  比較。実ワークロードで必要になれば glob パターン (例: `"shell.*"`)
+  が自然な後続。
+- **画像入力の最小サイズ**: Grok Build は 8×8 未満、合計 512px 未満
+  の画像を拒否 (正方形なら 23×23 以上が必要); Cursor は 16×16 から
+  受け付けます。両方ともサーバサイドで検証するため、SNA は image
+  block をそのまま渡します。サムネイル等を扱うコンシューマは
+  Grok 互換のため 32×32 以上にアップスケールが必要。

--- a/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
@@ -82,11 +82,11 @@ Claude Code의 권한 모델은 out-of-band입니다 — SNA가 hook 스크립�
 
 | 필드 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
 |---|---|---|---|---|---|
-| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start`의 `baseInstructions` | ✓ `appendSystemPrompt`와 결합 | ✓ `--system-prompt-override` | ⚠ CLI 플래그 없음. 사용자의 `AGENTS.md` 또는 첫 prompt에 fold (SNA에서 아직 와이어링 안 됨) |
-| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start`의 `developerInstructions` | ✓ `systemPrompt`와 결합 | ✓ `--rules` | ⚠ `systemPrompt`와 동일 |
+| `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start`의 `baseInstructions` | ✓ `appendSystemPrompt`와 결합 | ✓ ACP base 첫-turn `resource` block (헤드리스 `complete()` 경로는 `--system-prompt-override`도 지원) | ✓ ACP base 첫-turn `resource` block (CLI flag 자체가 없음. fold가 공유 base를 타고 들어감) |
+| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start`의 `developerInstructions` | ✓ `systemPrompt`와 결합 | ✓ 같은 첫-turn block에 `systemPrompt`와 결합 (complete 경로는 `--rules`도 지원) | ✓ 같은 첫-turn block에 `systemPrompt`와 결합 |
 | `allowedTools` | ✓ 네이티브 `--allowedTools` | ✓ PreToolUse hook (나머지 거부) | ⚠ best-effort (알려진 도구만 토글) | ✓ `--tools` 허용 목록 | ⚠ `~/.cursor/cli-config.json`의 `permissions.allow` 경유 (user-global, SNA 관리 안 함) |
 | `disallowedTools` | ✓ 네이티브 `--disallowedTools` | ✓ PreToolUse hook | ✓ 나열된 도구 비활성 | ✓ `--disallowed-tools` | ⚠ `allowedTools`와 동일 (또는 `--mode plan`으로 세션 전체 read-only) |
-| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` 기록 | ✓ SDK 경유 | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ⚠ 사용자의 `~/.cursor/mcp.json`에 의존; per-session stdio MCP 주입은 follow-up |
+| `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` 기록 | ✓ SDK 경유 | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ✓ stdio→HTTP bridge + `<cwd>/.cursor/mcp.json` (기존 user entries와 머지, exit에 원복) |
 | `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 무시 | ✓ `toGrokEffort` → `--effort` | ✓ `applyCursorReasoning` → 모델 ID 접미사 (`gpt-5.3-codex` → `gpt-5.3-codex-high`) |
 | `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 대응 없음 | ✗ 대응 없음 (Grok Build은 `~/.grok` 고정) | ✗ 대응 없음 (Cursor는 `~/.cursor` 고정; `CURSOR_CONFIG_DIR`는 `cli-config.json`만 redirect, hook은 안 옮김) |
 | `resumeSessionId` | ✓ JSONL replay 파일 경유 | ✓ `thread/resume` API | ✓ 세션 id | ⚠ Grok Build chat id로 resume은 동작하지만, 크로스 프로바이더 history는 아래 `resource` block 경로 사용 | ⚠ Cursor `chatId`로 resume 동작 (`--resume <id>` / `session/load`), 크로스 프로바이더 history는 동일 경로 |
@@ -139,13 +139,9 @@ ACP `session/load`는 UI 이벤트만 replay할 뿐 모델 컨텍스트를 복�
   Grok Build `--permission-mode plan`, Cursor `--mode plan`): CLI 플래그
   는 spawn 시점에 반영되지만, 인플레이스 토글은 `permissionMode` patch
   지원이 필요한데 ACP-스피킹 프로바이더들은 아직 지원하지 않습니다.
-- **Cursor MCP 와이어링**: Cursor의 ACP는 사용자의 `~/.cursor/mcp.json`을
-  startup에 읽습니다. Per-session stdio MCP 주입(Grok이 `.grok/config.toml`
-  + stdio→HTTP bridge로 처리하는 방식)은 후속 과제입니다.
-- **Cursor의 `systemPrompt` / `appendSystemPrompt`**: Cursor는 에이전트
-  시스템 프롬프트를 CLI로 override하는 방법이 없습니다. `AGENTS.md`
-  (프로젝트 단위, 침습적) 또는 첫 turn fold가 가능하지만 아직 와이어링
-  안 됨.
+- **Cursor `allowedTools` / `disallowedTools`**: Cursor의 per-tool
+  권한은 user-global `~/.cursor/cli-config.json`에 있어서, per-session
+  shape이 아직 follow-up.
 - **프롬프트 이미지 입력**: 5개 프로바이더 모두 어떤 형태로든 이미지
   block을 받지만, 프로바이더별 첨부 인코딩이 아직 일관되지 않습니다 —
   현재 상태는 [세션 › 첨부](/ko/docs/introduction/sessions) 참조.

--- a/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
@@ -84,8 +84,8 @@ Claude Code의 권한 모델은 out-of-band입니다 — SNA가 hook 스크립�
 |---|---|---|---|---|---|
 | `systemPrompt` | ✓ `--system-prompt` | ✓ `thread/start`의 `baseInstructions` | ✓ `appendSystemPrompt`와 결합 | ✓ ACP base 첫-turn `resource` block (헤드리스 `complete()` 경로는 `--system-prompt-override`도 지원) | ✓ ACP base 첫-turn `resource` block (CLI flag 자체가 없음. fold가 공유 base를 타고 들어감) |
 | `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `thread/start`의 `developerInstructions` | ✓ `systemPrompt`와 결합 | ✓ 같은 첫-turn block에 `systemPrompt`와 결합 (complete 경로는 `--rules`도 지원) | ✓ 같은 첫-turn block에 `systemPrompt`와 결합 |
-| `allowedTools` | ✓ 네이티브 `--allowedTools` | ✓ PreToolUse hook (나머지 거부) | ⚠ best-effort (알려진 도구만 토글) | ✓ `--tools` 허용 목록 | ⚠ `~/.cursor/cli-config.json`의 `permissions.allow` 경유 (user-global, SNA 관리 안 함) |
-| `disallowedTools` | ✓ 네이티브 `--disallowedTools` | ✓ PreToolUse hook | ✓ 나열된 도구 비활성 | ✓ `--disallowed-tools` | ⚠ `allowedTools`와 동일 (또는 `--mode plan`으로 세션 전체 read-only) |
+| `allowedTools` | ✓ 네이티브 `--allowedTools` | ✓ PreToolUse hook (나머지 거부) | ⚠ best-effort (알려진 도구만 토글) | ✓ ACP base가 `session/request_permission` 경계에서 미허용 도구 자동 deny | ✓ ACP base가 `session/request_permission` 경계에서 미허용 도구 자동 deny |
+| `disallowedTools` | ✓ 네이티브 `--disallowedTools` | ✓ PreToolUse hook | ✓ 나열된 도구 비활성 | ✓ ACP base가 permission 경계에서 나열된 도구 자동 deny | ✓ ACP base가 permission 경계에서 나열된 도구 자동 deny |
 | `mcpServers` | ✓ `--mcp-config` JSON | ✓ `config.toml` `[mcp_servers.*]` 기록 | ✓ SDK 경유 | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ✓ stdio→HTTP bridge + `<cwd>/.cursor/mcp.json` (기존 user entries와 머지, exit에 원복) |
 | `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ 무시 | ✓ `toGrokEffort` → `--effort` | ✓ `applyCursorReasoning` → 모델 ID 접미사 (`gpt-5.3-codex` → `gpt-5.3-codex-high`) |
 | `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ 대응 없음 | ✗ 대응 없음 (Grok Build은 `~/.grok` 고정) | ✗ 대응 없음 (Cursor는 `~/.cursor` 고정; `CURSOR_CONFIG_DIR`는 `cli-config.json`만 redirect, hook은 안 옮김) |
@@ -137,11 +137,15 @@ ACP `session/load`는 UI 이벤트만 replay할 뿐 모델 컨텍스트를 복�
 
 - **런타임 plan mode 토글** (Claude Code `--permission-mode plan`,
   Grok Build `--permission-mode plan`, Cursor `--mode plan`): CLI 플래그
-  는 spawn 시점에 반영되지만, 인플레이스 토글은 `permissionMode` patch
-  지원이 필요한데 ACP-스피킹 프로바이더들은 아직 지원하지 않습니다.
-- **Cursor `allowedTools` / `disallowedTools`**: Cursor의 per-tool
-  권한은 user-global `~/.cursor/cli-config.json`에 있어서, per-session
-  shape이 아직 follow-up.
-- **프롬프트 이미지 입력**: 5개 프로바이더 모두 어떤 형태로든 이미지
-  block을 받지만, 프로바이더별 첨부 인코딩이 아직 일관되지 않습니다 —
-  현재 상태는 [세션 › 첨부](/ko/docs/introduction/sessions) 참조.
+  는 spawn 시점에 반영되지만, 인플레이스 토글은 ACP가 wire 메서드로
+  노출하지 않습니다 — ACP applyPatch는 모든 필드를 leftover로
+  반환하고 세션 매니저가 respawn-with-history-replay로 처리합니다.
+- **ACP 프로바이더의 `allowedTools` / `disallowedTools` glob/패턴 매칭**:
+  현재 auto-deny intercept는 도구 이름을 정확 문자열 동등성으로만
+  매치. 실제 워크로드에서 필요해지면 glob 패턴(예: `"shell.*"`)이
+  자연스러운 follow-up.
+- **이미지 입력 최소 크기**: Grok Build는 8×8 미만, 총 512px 미만
+  이미지 거부(정사각형은 23×23 이상 필요); Cursor는 16×16부터 허용.
+  둘 다 서버 측에서 검증하므로 SNA는 image block을 그대로 전달.
+  썸네일 같은 작은 이미지 다루는 컨슈머는 Grok 호환을 위해 32×32
+  이상으로 upscale 필요.

--- a/apps/docs/content/docs/introduction/feature-matrix.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.mdx
@@ -86,11 +86,11 @@ agent's turn suspends until SNA sends a permission response.
 
 | Field | Claude Code | Codex | OpenCode | Grok Build | Cursor |
 |---|---|---|---|---|---|
-| `systemPrompt` | ✓ `--system-prompt` | ✓ `baseInstructions` on `thread/start` | ✓ joined with `appendSystemPrompt` | ✓ `--system-prompt-override` | ⚠ no CLI flag; use the user's `AGENTS.md` or fold into the first prompt (not yet wired by SNA) |
-| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `developerInstructions` on `thread/start` | ✓ joined with `systemPrompt` | ✓ `--rules` | ⚠ same as `systemPrompt` |
+| `systemPrompt` | ✓ `--system-prompt` | ✓ `baseInstructions` on `thread/start` | ✓ joined with `appendSystemPrompt` | ✓ ACP base first-turn `resource` block (the headless `complete()` path also supports `--system-prompt-override`) | ✓ ACP base first-turn `resource` block (no CLI flag exists; the fold rides on the shared base) |
+| `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `developerInstructions` on `thread/start` | ✓ joined with `systemPrompt` | ✓ joined with `systemPrompt` in the same first-turn block (complete-path also supports `--rules`) | ✓ joined with `systemPrompt` in the same first-turn block |
 | `allowedTools` | ✓ native `--allowedTools` | ✓ via PreToolUse hook (deny-others) | ⚠ best-effort (toggles known tools) | ✓ `--tools` allow-list | ⚠ via `~/.cursor/cli-config.json` `permissions.allow` (user-global, not yet managed by SNA) |
 | `disallowedTools` | ✓ native `--disallowedTools` | ✓ via PreToolUse hook | ✓ disables listed tools | ✓ `--disallowed-tools` | ⚠ same as `allowedTools` (or `--mode plan` to make the whole session read-only) |
-| `mcpServers` | ✓ `--mcp-config` JSON | ✓ written to `config.toml` `[mcp_servers.*]` | ✓ via SDK | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ⚠ relies on the user's `~/.cursor/mcp.json`; per-session injection of stdio MCP is a follow-up |
+| `mcpServers` | ✓ `--mcp-config` JSON | ✓ written to `config.toml` `[mcp_servers.*]` | ✓ via SDK | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ✓ stdio→HTTP bridge + `<cwd>/.cursor/mcp.json` (merges with existing user entries, restores on exit) |
 | `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ ignored | ✓ `toGrokEffort` → `--effort` | ✓ `applyCursorReasoning` → model-id suffix (`gpt-5.3-codex` → `gpt-5.3-codex-high`) |
 | `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ no equivalent | ✗ no equivalent (Grok Build uses `~/.grok`) | ✗ no equivalent (Cursor uses `~/.cursor`; `CURSOR_CONFIG_DIR` only reroutes `cli-config.json`, not hooks) |
 | `resumeSessionId` | ✓ via JSONL replay file | ✓ `thread/resume` API | ✓ session id | ⚠ Grok Build chat id works, but cross-provider history goes via the `resource` block path below | ⚠ Cursor `chatId` works (`--resume <id>` / `session/load`), but cross-provider history goes via the same `resource` block path |
@@ -145,14 +145,9 @@ so re-injection is not required.
   Grok Build `--permission-mode plan`, Cursor `--mode plan`): the CLI
   flag is honored at spawn but in-place toggling needs `permissionMode`
   patch support, which the ACP-speaking providers do not yet have.
-- **MCP wiring through Cursor**: Cursor's ACP reads from the user's
-  `~/.cursor/mcp.json` at startup. Per-session injection of stdio MCP
-  (the way Grok handles it via `.grok/config.toml` + the stdio→HTTP
-  bridge) is a follow-up.
-- **`systemPrompt` / `appendSystemPrompt` for Cursor**: Cursor has no
-  CLI override for the agent system prompt. Routes via `AGENTS.md`
-  (project-scoped, intrusive) or first-turn folding are possible but
-  not yet wired.
+- **Cursor `allowedTools` / `disallowedTools`**: Cursor's per-tool
+  permission lives in the user-global `~/.cursor/cli-config.json`;
+  per-session shaping is a follow-up.
 - **Image input in prompts**: all five providers accept image blocks
   in some form, but the per-provider attachment encoding is still
   inconsistent — see [Sessions › Attachments](/docs/introduction/sessions)

--- a/apps/docs/content/docs/introduction/feature-matrix.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.mdx
@@ -88,8 +88,8 @@ agent's turn suspends until SNA sends a permission response.
 |---|---|---|---|---|---|
 | `systemPrompt` | ✓ `--system-prompt` | ✓ `baseInstructions` on `thread/start` | ✓ joined with `appendSystemPrompt` | ✓ ACP base first-turn `resource` block (the headless `complete()` path also supports `--system-prompt-override`) | ✓ ACP base first-turn `resource` block (no CLI flag exists; the fold rides on the shared base) |
 | `appendSystemPrompt` | ✓ `--append-system-prompt` | ✓ `developerInstructions` on `thread/start` | ✓ joined with `systemPrompt` | ✓ joined with `systemPrompt` in the same first-turn block (complete-path also supports `--rules`) | ✓ joined with `systemPrompt` in the same first-turn block |
-| `allowedTools` | ✓ native `--allowedTools` | ✓ via PreToolUse hook (deny-others) | ⚠ best-effort (toggles known tools) | ✓ `--tools` allow-list | ⚠ via `~/.cursor/cli-config.json` `permissions.allow` (user-global, not yet managed by SNA) |
-| `disallowedTools` | ✓ native `--disallowedTools` | ✓ via PreToolUse hook | ✓ disables listed tools | ✓ `--disallowed-tools` | ⚠ same as `allowedTools` (or `--mode plan` to make the whole session read-only) |
+| `allowedTools` | ✓ native `--allowedTools` | ✓ via PreToolUse hook (deny-others) | ⚠ best-effort (toggles known tools) | ✓ ACP base auto-denies non-listed tools at the `session/request_permission` boundary | ✓ ACP base auto-denies non-listed tools at the `session/request_permission` boundary |
+| `disallowedTools` | ✓ native `--disallowedTools` | ✓ via PreToolUse hook | ✓ disables listed tools | ✓ ACP base auto-denies listed tools at the permission boundary | ✓ ACP base auto-denies listed tools at the permission boundary |
 | `mcpServers` | ✓ `--mcp-config` JSON | ✓ written to `config.toml` `[mcp_servers.*]` | ✓ via SDK | ✓ stdio→HTTP bridge + `<cwd>/.grok/config.toml` | ✓ stdio→HTTP bridge + `<cwd>/.cursor/mcp.json` (merges with existing user entries, restores on exit) |
 | `reasoningLevel` (0..5) | ✓ `toClaudeEffort` → `--effort` | ✓ `toCodexEffort` → `model_reasoning_effort` | ✗ ignored | ✓ `toGrokEffort` → `--effort` | ✓ `applyCursorReasoning` → model-id suffix (`gpt-5.3-codex` → `gpt-5.3-codex-high`) |
 | `configDir` | ✓ `CLAUDE_CONFIG_DIR` | ✓ `CODEX_HOME` | ✗ no equivalent | ✗ no equivalent (Grok Build uses `~/.grok`) | ✗ no equivalent (Cursor uses `~/.cursor`; `CURSOR_CONFIG_DIR` only reroutes `cli-config.json`, not hooks) |
@@ -144,11 +144,16 @@ so re-injection is not required.
 - **Plan mode toggling at runtime** (Claude Code `--permission-mode plan`,
   Grok Build `--permission-mode plan`, Cursor `--mode plan`): the CLI
   flag is honored at spawn but in-place toggling needs `permissionMode`
-  patch support, which the ACP-speaking providers do not yet have.
-- **Cursor `allowedTools` / `disallowedTools`**: Cursor's per-tool
-  permission lives in the user-global `~/.cursor/cli-config.json`;
-  per-session shaping is a follow-up.
-- **Image input in prompts**: all five providers accept image blocks
-  in some form, but the per-provider attachment encoding is still
-  inconsistent — see [Sessions › Attachments](/docs/introduction/sessions)
-  for the current state.
+  patch support, which ACP does not expose as a wire method — every
+  field on the ACP `applyPatch` surface is returned as leftover, and
+  the session manager handles the change via respawn-with-history-replay.
+- **Glob/pattern matching in `allowedTools` / `disallowedTools`** for
+  the ACP providers — today the auto-deny intercept matches tool names
+  by exact string equality. Glob patterns (e.g. `"shell.*"`) are a
+  natural follow-up if real workloads need them.
+- **Image input minimum dimensions** — Grok Build rejects images
+  smaller than 8×8 pixels and below 512 total pixels (1024 effective
+  minimum for square images); Cursor accepts as small as 16×16. Both
+  validate server-side, so SNA passes the image block through
+  unchanged. Consumers feeding tiny thumbnails should upscale to at
+  least 32×32 to satisfy Grok.

--- a/packages/core/src/core/providers/acp/base.ts
+++ b/packages/core/src/core/providers/acp/base.ts
@@ -177,6 +177,22 @@ export function serializeHistoryForAcp(history: CanonicalBlock[]): string {
   return lines.join("\n");
 }
 
+/**
+ * Compose a single system-prompt string from the two SpawnOptions fields.
+ * `systemPrompt` and `appendSystemPrompt` are treated as concatenation
+ * candidates — the override and the append are joined by a blank line.
+ * Returns `null` when neither was supplied.
+ */
+export function buildSystemPromptText(
+  systemPrompt: string | undefined,
+  appendSystemPrompt: string | undefined,
+): string | null {
+  const parts: string[] = [];
+  if (systemPrompt && systemPrompt.trim().length > 0) parts.push(systemPrompt);
+  if (appendSystemPrompt && appendSystemPrompt.trim().length > 0) parts.push(appendSystemPrompt);
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
 // ── Spawn descriptor returned by subclasses ─────────────────────────────────
 
 export interface AcpSpawnDescriptor {
@@ -213,6 +229,20 @@ export abstract class AcpStdioProcess extends EventEmitter implements AgentProce
 
   /** Cached history transcript for first-turn injection. */
   protected readonly historyTranscript: string | null;
+  /**
+   * Cached system-prompt text for first-turn injection. ACP doesn't have a
+   * server-side `--system-prompt` flag for either Grok Build's
+   * `agent stdio` or Cursor's `agent acp`, so we fold the instruction
+   * into the first `session/prompt` as a high-priority resource block
+   * (placed before the optional history block and the user's actual
+   * message). Subsequent turns inherit it via the agent's own session
+   * state — same persistence model as `historyTranscript`.
+   *
+   * Combines `SpawnOptions.systemPrompt` (replaces) and
+   * `appendSystemPrompt` (additive) into one string. `null` when neither
+   * was supplied.
+   */
+  protected readonly systemPromptText: string | null;
   protected firstPromptSent = false;
   /**
    * Per-turn accumulator for `agent_message_chunk` text. See design
@@ -333,6 +363,32 @@ export abstract class AcpStdioProcess extends EventEmitter implements AgentProce
   }
 
   /**
+   * Override the resource block prepended to the first `session/prompt`
+   * for `systemPrompt` / `appendSystemPrompt`. Placed BEFORE the history
+   * block so the model reads it as the highest-priority instruction.
+   *
+   * Both Grok and Cursor accept ACP `resource` blocks in the prompt
+   * (verified live during the option-B probe), even when their
+   * `promptCapabilities.embeddedContext` flag advertises `false`. The
+   * model treats the text as additional context layered on top of the
+   * agent's own system prompt — it can shape behavior strongly but
+   * cannot literally REPLACE the vendor's base instructions. Authors
+   * that need an authoritative override should phrase it that way
+   * ("You are NOT X. You are Y. …") rather than relying on
+   * cooperative-tone phrasing.
+   */
+  protected buildSystemPromptBlock(text: string): unknown {
+    return {
+      type: "resource",
+      resource: {
+        uri: "sna://system-prompt.txt",
+        mimeType: "text/plain",
+        text,
+      },
+    };
+  }
+
+  /**
    * `clientCapabilities` advertised in the initialize request. Subclasses
    * can override — Grok declares fs/terminal=false; Cursor matches that.
    */
@@ -365,6 +421,10 @@ export abstract class AcpStdioProcess extends EventEmitter implements AgentProce
       options.history && options.history.length > 0
         ? this.serializeHistory(options.history)
         : null;
+    this.systemPromptText = buildSystemPromptText(
+      options.systemPrompt,
+      options.appendSystemPrompt,
+    );
 
     this.ready = this.initialize(options);
     this.ready.catch((err) => {
@@ -701,10 +761,23 @@ export abstract class AcpStdioProcess extends EventEmitter implements AgentProce
 
     const promptBlocks: unknown[] = [];
 
-    // First turn: prepend the history transcript so the model reads it as
-    // prior context. Subsequent turns rely on the agent's own session state.
-    if (!this.firstPromptSent && this.historyTranscript) {
-      promptBlocks.push(this.buildHistoryPromptBlock(this.historyTranscript));
+    // First-turn injection. Order matters — the model reads top-down,
+    // so authority decreases as we go:
+    //
+    //   1. System prompt    (highest authority — sets identity/policy)
+    //   2. History transcript (prior context for cross-provider resume)
+    //   3. User text        (the current question)
+    //
+    // Subsequent turns rely on the agent's own session state — both
+    // blocks land in the agent's internal history after turn 1, so
+    // re-injection is wasted tokens.
+    if (!this.firstPromptSent) {
+      if (this.systemPromptText) {
+        promptBlocks.push(this.buildSystemPromptBlock(this.systemPromptText));
+      }
+      if (this.historyTranscript) {
+        promptBlocks.push(this.buildHistoryPromptBlock(this.historyTranscript));
+      }
     }
 
     if (typeof input === "string") {

--- a/packages/core/src/core/providers/acp/base.ts
+++ b/packages/core/src/core/providers/acp/base.ts
@@ -251,6 +251,21 @@ export abstract class AcpStdioProcess extends EventEmitter implements AgentProce
   protected assistantTurnBuffer = "";
   /** Captured permission mode — see design decision (3). */
   protected readonly permissionMode: string | undefined;
+  /**
+   * Optional allow-list of tool names. When set, any tool whose unwrapped
+   * `toolName` (see {@link unwrapToolCall}) is NOT in this list gets
+   * auto-rejected at the `session/request_permission` boundary — the
+   * `permission_needed` event is never emitted, no UI prompt is shown.
+   *
+   * Takes precedence over `disallowedTools` (matching the contract
+   * documented on `SpawnOptions.allowedTools`).
+   */
+  protected readonly allowedTools: ReadonlySet<string> | null;
+  /**
+   * Optional deny-list of tool names. When set without `allowedTools`,
+   * any matching tool is auto-rejected at the permission boundary.
+   */
+  protected readonly disallowedTools: ReadonlySet<string> | null;
   /** Set true after initialize + (optional authenticate) + session/new succeed. */
   protected ready: Promise<void>;
 
@@ -412,6 +427,50 @@ export abstract class AcpStdioProcess extends EventEmitter implements AgentProce
     };
   }
 
+  /**
+   * Resolve the tool name a filter rule should match against, for a
+   * given incoming `session/request_permission` toolCall. Defaults to
+   * the unwrapped name (`unwrapToolCall(...).toolName`), so the string
+   * the user sees on a `tool_use` AgentEvent is the same one they put
+   * in `allowedTools` / `disallowedTools`.
+   */
+  protected toolNameForFilter(toolCall: AcpPermissionRequest["toolCall"]): string {
+    // Synthesize an AcpSessionUpdate from the permission payload so the
+    // shared unwrap path applies (subclasses already know how to strip
+    // their vendor dispatch wrappers).
+    const synthetic: AcpSessionUpdate = {
+      sessionUpdate: "tool_call",
+      toolCallId: toolCall.toolCallId,
+      kind: toolCall.kind,
+      title: toolCall.title,
+      rawInput: toolCall.rawInput,
+    };
+    return this.unwrapToolCall(synthetic).toolName;
+  }
+
+  /**
+   * Apply the configured `allowedTools` / `disallowedTools` rules to a
+   * permission request. Returns `"deny"` to short-circuit with an
+   * auto-reject, or `null` to fall through to bypass/UI handling.
+   *
+   * Semantics match {@link SpawnOptions.allowedTools}:
+   *   - `allowedTools` set: only listed names pass; everything else
+   *     auto-rejected. `allowedTools` takes precedence over
+   *     `disallowedTools` per the type docstring.
+   *   - `disallowedTools` set (without allowedTools): listed names
+   *     auto-rejected; everything else falls through.
+   *   - Neither set: no filtering.
+   */
+  protected applyToolFilter(toolCall: AcpPermissionRequest["toolCall"]): "deny" | null {
+    if (!this.allowedTools && !this.disallowedTools) return null;
+    const name = this.toolNameForFilter(toolCall);
+    if (this.allowedTools) {
+      return this.allowedTools.has(name) ? null : "deny";
+    }
+    if (this.disallowedTools && this.disallowedTools.has(name)) return "deny";
+    return null;
+  }
+
   // ──── Constructor + initialize ────
 
   constructor(options: SpawnOptions) {
@@ -425,6 +484,14 @@ export abstract class AcpStdioProcess extends EventEmitter implements AgentProce
       options.systemPrompt,
       options.appendSystemPrompt,
     );
+    this.allowedTools =
+      options.allowedTools && options.allowedTools.length > 0
+        ? new Set(options.allowedTools)
+        : null;
+    this.disallowedTools =
+      options.disallowedTools && options.disallowedTools.length > 0
+        ? new Set(options.disallowedTools)
+        : null;
 
     this.ready = this.initialize(options);
     this.ready.catch((err) => {
@@ -604,6 +671,29 @@ export abstract class AcpStdioProcess extends EventEmitter implements AgentProce
     if (req.method === "session/request_permission") {
       const params = req.params as AcpPermissionRequest;
       const requestId = params.toolCall.toolCallId;
+
+      // Tool-filter shortcut: enforce allowedTools / disallowedTools at the
+      // permission boundary before bypassPermissions, so even bypass-mode
+      // sessions still respect the deny-list. The tool name we compare
+      // against is whatever `unwrapToolCall` resolves to — same canonical
+      // string consumers see on the `tool_use` AgentEvent's
+      // `data.toolName`, so the contract is symmetric.
+      const filterDecision = this.applyToolFilter(params.toolCall);
+      if (filterDecision === "deny") {
+        const rejectOpt =
+          params.options.find((o) => o.kind === "reject_always") ??
+          params.options.find((o) => o.kind === "reject_once") ??
+          params.options[params.options.length - 1];
+        if (rejectOpt) {
+          this.write({
+            jsonrpc: "2.0",
+            id: req.id,
+            result: { outcome: { outcome: "selected", optionId: rejectOpt.optionId } },
+          });
+          logger.log("agent", `${this.name}: auto-denied tool "${this.toolNameForFilter(params.toolCall)}" via SpawnOptions tool filter`);
+          return;
+        }
+      }
 
       // Bypass-mode shortcut: pick whichever option carries an "allow"
       // intent (or fall back to the first option) and reply immediately,

--- a/packages/core/src/core/providers/cursor.ts
+++ b/packages/core/src/core/providers/cursor.ts
@@ -36,14 +36,21 @@
  *     `result` is preserved under `data.toolCallResult` so consumers
  *     wanting the structured success/rejected shape have it.
  *
- *   • MCP wiring is left to the user's existing `~/.cursor/mcp.json` for
- *     now. Cursor's ACP server reads it at startup. Per-session injection
- *     of stdio MCP servers (the way Grok handles it via `.grok/config.toml`
- *     + the stdio→HTTP bridge) is a follow-up — Cursor's ACP currently
- *     accepts only what's already declared in the user-level mcp.json.
+ *   • MCP injection mirrors the Grok pattern but writes to
+ *     `<cwd>/.cursor/mcp.json` (JSON) instead of
+ *     `<cwd>/.grok/config.toml` (TOML). Cursor's ACP reads project-scoped
+ *     `mcp.json` at startup, so the on-disk channel works the same way.
+ *     Stdio MCP entries are bridged to HTTP through
+ *     `core/mcp/stdio-http-bridge.ts` (shared with Grok) — Cursor's ACP
+ *     advertises only `{http,sse}` in `initialize.mcpCapabilities`, same
+ *     as Grok, so the bridge is mandatory for stdio. We merge with any
+ *     pre-existing user `mcp.json` and restore it on exit.
  */
 
 import { spawn, execSync } from "child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { bridgeStdioMcpToHttp, type BridgeHandle } from "../mcp/stdio-http-bridge.js";
 import type {
   AgentProvider,
   AgentProcess,
@@ -115,6 +122,21 @@ function unwrapCursorVariant(rawInput: unknown): { variant: string; args: unknow
 // ── Process ─────────────────────────────────────────────────────────────────
 
 export class CursorProcess extends AcpStdioProcess {
+  /**
+   * stdio→HTTP MCP bridges spun up for this session. Each one owns its
+   * own child process + listener; disposed on cursor exit so we don't
+   * leak sockets between sessions.
+   */
+  private mcpBridges: BridgeHandle[] = [];
+  /**
+   * Path to the `<cwd>/.cursor/mcp.json` we touched so cleanup can
+   * restore it. `original` is the file's pre-write contents (`null` if
+   * we created it from scratch — cleanup then deletes it instead of
+   * restoring). `cwd` is recorded so we know whether to remove the
+   * `.cursor` directory too (only if we created it).
+   */
+  private cursorMcpRestore: { path: string; original: string | null; createdDir: boolean } | null = null;
+
   protected get name(): string { return "cursor"; }
 
   /**
@@ -133,6 +155,18 @@ export class CursorProcess extends AcpStdioProcess {
     // through ACP `session/request_permission` regardless of CLI flags.
     const args = ["acp"];
     return { command: resolveCursorPath(options.cwd), args };
+  }
+
+  protected async preHandshake(options: SpawnOptions): Promise<void> {
+    await this.setupMcpBridges(options);
+  }
+
+  protected onExit(_code: number | null): void {
+    this.disposeMcpBridges();
+  }
+
+  protected onPreSpawnCleanup(): void {
+    this.disposeMcpBridges();
   }
 
   /**
@@ -209,6 +243,117 @@ export class CursorProcess extends AcpStdioProcess {
       input: update.rawInput,
       extra: update.title && update.title !== toolName ? { cursorTitle: update.title } : undefined,
     };
+  }
+
+  /**
+   * Spin up HTTP bridges for each stdio MCP entry and merge them into
+   * `<cwd>/.cursor/mcp.json`. We write the project-scoped file (not
+   * `~/.cursor/mcp.json`) so concurrent SNA sessions in different cwds
+   * never fight over the same file, and so we don't touch user-global
+   * state. Pre-existing user entries are preserved across the SNA write
+   * and restored on exit.
+   *
+   * Entries already declared as `{type:"http",url:...}` are passed
+   * through verbatim — no bridge needed. Other unsupported shapes
+   * are dropped with a log.
+   */
+  private async setupMcpBridges(options: SpawnOptions): Promise<void> {
+    if (!options.mcpServers) return;
+
+    // Cursor's mcp.json schema for an HTTP server:
+    //   { "mcpServers": { "<name>": { "url": "...", "headers": {...} } } }
+    type HttpEntry = { url: string; headers?: Record<string, string> };
+    const entries: Record<string, HttpEntry> = {};
+
+    for (const [name, cfg] of Object.entries(options.mcpServers)) {
+      if (!cfg || typeof cfg !== "object") continue;
+      if ("type" in cfg && cfg.type === "http") {
+        const entry: HttpEntry = { url: cfg.url };
+        if (cfg.headers) entry.headers = cfg.headers;
+        entries[name] = entry;
+        continue;
+      }
+      if ("command" in cfg && cfg.command) {
+        const handle = await bridgeStdioMcpToHttp(name, {
+          command: cfg.command,
+          args: cfg.args,
+          env: cfg.env,
+          cwd: cfg.cwd ?? options.cwd,
+        });
+        this.mcpBridges.push(handle);
+        entries[name] = { url: handle.url };
+        continue;
+      }
+      logger.log("agent", `cursor: skipping mcp server '${name}' — unsupported shape`);
+    }
+
+    if (Object.keys(entries).length === 0) return;
+
+    const cfgDir = path.join(options.cwd, ".cursor");
+    const cfgPath = path.join(cfgDir, "mcp.json");
+    let original: string | null = null;
+    let createdDir = false;
+    try {
+      original = fs.readFileSync(cfgPath, "utf-8");
+    } catch {
+      // No mcp.json yet — also remember whether `.cursor/` itself exists,
+      // so cleanup can remove it if we created it. (Prefer not to leave
+      // a stray directory in the user's project root.)
+      try { fs.accessSync(cfgDir); } catch { createdDir = true; }
+    }
+    try { fs.mkdirSync(cfgDir, { recursive: true }); } catch {}
+
+    // Merge: existing user entries first, then SNA entries (SNA wins on
+    // name collision, which matches the intent — if the consumer asked
+    // SNA to expose an MCP named `foo`, that's the one the agent should
+    // see for this session). Unknown top-level keys in the user file are
+    // preserved as-is.
+    let merged: Record<string, unknown>;
+    try {
+      const parsed = original ? JSON.parse(original) : {};
+      merged = (parsed && typeof parsed === "object" && !Array.isArray(parsed))
+        ? { ...parsed as Record<string, unknown> }
+        : {};
+    } catch {
+      // Malformed user file — log and start fresh so we don't lose the
+      // SNA wiring. Original is preserved in `cursorMcpRestore`, so
+      // exit restoration will put the broken file back exactly as it was.
+      logger.log("agent", `cursor: existing ${cfgPath} is not valid JSON; not merging`);
+      merged = {};
+    }
+    const existingServers = (merged.mcpServers && typeof merged.mcpServers === "object")
+      ? merged.mcpServers as Record<string, unknown>
+      : {};
+    merged.mcpServers = { ...existingServers, ...entries };
+
+    fs.writeFileSync(cfgPath, JSON.stringify(merged, null, 2) + "\n");
+    this.cursorMcpRestore = { path: cfgPath, original, createdDir };
+    logger.log("agent", `cursor: wrote ${Object.keys(entries).length} mcpServers entries to ${cfgPath}`);
+  }
+
+  private disposeMcpBridges(): void {
+    for (const b of this.mcpBridges) {
+      try { b.dispose(); } catch {}
+    }
+    this.mcpBridges = [];
+
+    const restore = this.cursorMcpRestore;
+    this.cursorMcpRestore = null;
+    if (!restore) return;
+    try {
+      if (restore.original === null) {
+        fs.unlinkSync(restore.path);
+        if (restore.createdDir) {
+          // Best-effort: only remove the directory if it's empty (the
+          // user might have added other files there in the meantime).
+          try { fs.rmdirSync(path.dirname(restore.path)); } catch { /* not empty */ }
+        }
+      } else {
+        fs.writeFileSync(restore.path, restore.original);
+      }
+    } catch (err) {
+      logger.log("agent", `cursor: failed to restore ${restore.path}: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 }
 


### PR DESCRIPTION
> Depends on #34. The diff against \`main\` will include #34's commit
> until that one merges; once merged, this PR will collapse to its own
> single commit.

## Summary

Closes the last two ⚠ rows in the Cursor column of the provider × feature
matrix:

- **\`allowedTools\` / \`disallowedTools\`** for both Cursor and Grok
  Build, via an ACP-base auto-deny that runs at the
  \`session/request_permission\` boundary — before the UI prompt and
  before any \`bypassPermissions\` shortcut. No on-disk file is touched;
  the rules live only in the spawn options for that one session.
- **Image input** end-to-end for both providers (no code change — the
  existing block translation already worked; this just nails down the
  live verification + minimum-dimension caveat in the docs).

Also confirms (no code change) that ACP exposes no runtime mutation
methods for model / permissionMode / cwd, so the existing
\`applyPatch\` returning every field as leftover is the correct
contract. SessionManager's respawn-with-history-replay path covers
the change.

## Flow change

\`\`\`
incoming session/request_permission
    │
    ├─ applyToolFilter()                  [NEW]
    │    ├─ allowedTools set? yes → require match; else auto-reject
    │    └─ disallowedTools match?      → auto-reject
    │
    ├─ permissionMode == bypassPermissions → auto-approve
    │
    └─ emit permission_needed (UI handles it)
\`\`\`

The tool name matched against the rules is the canonical string
consumers see on \`tool_use\` events (\`data.toolName\`) — the
permission payload is synthesized into an \`AcpSessionUpdate\` and run
through the subclass-overridden \`unwrapToolCall(...)\`, so Grok's
\`use_tool\` dispatch wrapper and Cursor's flattened \`kind\`-as-name
shape both resolve correctly.

\`allowedTools\` takes precedence over \`disallowedTools\` (matching
the \`SpawnOptions.allowedTools\` type docstring). Denial picks
\`reject_always\` when available, falling back to \`reject_once\` and
then the last option (matching the shape any ACP-compliant agent must
support).

## Validation

4/4 live smoke against grok 0.1.212 + cursor 2026.05:

| Test | Result |
|---|---|
| Cursor disallowedTools=[execute] | ✅ tool_use=1, permission_needed=0, model says \"rejected\" |
| Cursor allowedTools=[execute]    | ✅ permission_needed=1 (UI prompt), \"ALLOWED_OK\" in reply |
| Cursor image input (32×32 red PNG) | ✅ \"red\" |
| Grok Build image input (32×32 red PNG) | ✅ \"red\" |

## Behavior correction surfaced by the docs pass

The matrix previously said Grok used a \`--tools\` allow-list — that
was aspirational; the actual code never wired the flag through the
spawn path. Now both ACP providers share the same in-process
intercept, so the entries become symmetric.

## What's intentionally still deferred

- **Glob/pattern matching** in \`allowedTools\` / \`disallowedTools\`
  for the ACP providers — today the auto-deny is exact-string equality.
  Glob (e.g. \`\"shell.*\"\`) is a natural follow-up if real workloads
  need it.
- **Plan mode runtime toggle** — ACP exposes no mutation methods, so
  the only path is respawn-with-history-replay (already handled).
- **Image upscale guard rails** — Grok rejects below 8×8 or below 512
  total pixels; Cursor accepts 16×16. Documented in the matrix; consumers
  feeding tiny thumbnails should upscale to ≥32×32.

## Test plan

- [ ] \`pnpm install && pnpm --filter @sna/core build\` — expect green
- [ ] \`pnpm --filter @sna/docs build\` — expect green
- [ ] (Optional) Reviewer runs \`/tmp/cursor-tools-image-smoke.mjs\`
      against a logged-in Cursor + Grok CLI (not committed)