### PR TITLE
Register runtime CLI paths via launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,28 @@ https://github.com/neuradex/sna/issues
 - **Reasoning effort knob.** A provider-agnostic `reasoningLevel: 0..5` flows to Claude Code's `--effort` and Codex's `model_reasoning_effort` / `turn/start.effort`. Set 0 for autocomplete-grade latency, 5 for deep thinking.
 - **Codex runtime knobs.** `providerOptions.serviceTier` mirrors Codex's `/fast` slash command (values: `"priority"`, `"flex"`, `"batch"`), `providerOptions.profile` maps to `--profile`, and `providerOptions.config` maps to repeatable `-c key=value` overrides. Use `providerOptions.config` for OpenAI-compatible gateways such as OpenRouter or local model servers by configuring Codex's native `model_providers.*` settings. Codex-only on purpose — Claude's `/fast` is a different MODEL variant with its own billing pool, so it's not auto-translated.
 - **Hooks / MCP / policy abstraction.** Define hooks, MCP servers, allowed/disallowed tools once; per-provider adapters apply them. Mid-session provider switches keep the same configuration.
-- **Embedded launcher.** `startSnaServer({ port, dbPath, ... })` from `@sna-sdk/core/electron` or `@sna-sdk/core/node` forks the standalone server, resolves native bindings (asar-aware), and waits for ready.
+- **Embedded launcher.** `startSnaServer({ port, dbPath, runtimePaths, ... })` from `@sna-sdk/core/electron` or `@sna-sdk/core/node` forks the standalone server, resolves native bindings (asar-aware), registers runtime CLI paths, and waits for ready.
 
 ## Quick start
 
 ### As a consumer app
 
 ```ts
-import { startSnaServer } from "@sna-sdk/core/node";
+import { resolveClaudeCli, startSnaServer } from "@sna-sdk/core/node";
 import { SnaClient } from "@sna-sdk/client";
 
-const sna = await startSnaServer({ port: 3099, dbPath: "./data/sna.db" });
+const claude = resolveClaudeCli();
+if (claude.source === "fallback") {
+  throw new Error("Claude Code CLI was not found. Install it or pass runtimePaths.claudeCode.");
+}
+
+const sna = await startSnaServer({
+  port: 3099,
+  dbPath: "./data/sna.db",
+  runtimePaths: {
+    claudeCode: claude.path,
+  },
+});
 
 const client = new SnaClient({ baseUrl: "localhost:3099", ws: true, http: true });
 client.connect();
@@ -63,12 +74,28 @@ client.connect();
 const { sessionId } = await client.sessions.create({ label: "research" });
 await client.agent.start(sessionId, { provider: "claude-code", model: "claude-sonnet-4-6" });
 
-client.agent.onEvent(({ event }) => {
-  if (event.type === "assistant") console.log(event.message);
+let unsubscribe = () => {};
+const done = new Promise<void>((resolve, reject) => {
+  let streamed = false;
+  unsubscribe = client.agent.onEvent(({ event, isHistory }) => {
+    if (isHistory) return;
+    if (event.type === "assistant_delta") {
+      streamed = true;
+      process.stdout.write(event.delta ?? "");
+    }
+    if (event.type === "assistant" && event.message && !streamed) process.stdout.write(event.message);
+    if (event.type === "complete") resolve();
+    if (event.type === "error") reject(new Error(event.message ?? "Agent error"));
+  });
 });
 await client.agent.subscribe(sessionId);
 
 await client.agent.send(sessionId, "What's in this directory?");
+await done;
+
+unsubscribe();
+client.disconnect();
+sna.stop();
 ```
 
 > The running server publishes its own live OpenAPI 3.1 spec — open `http://localhost:3099/docs` for Swagger UI, `http://localhost:3099/openapi.json` for the raw JSON, or `http://localhost:3099/spec` for a plain-text view.

--- a/apps/docs/content/docs/introduction/embedding.ja.mdx
+++ b/apps/docs/content/docs/introduction/embedding.ja.mdx
@@ -24,6 +24,9 @@ const sna = await startSnaServer({
   dbPath: path.join(app.getPath("userData"), "sna.db"),
   maxSessions: 20,
   permissionMode: "acceptEdits",
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+  },
   onLog: (line) => console.log("[sna]", line),
 });
 
@@ -42,6 +45,8 @@ const sna = await startSnaServer({
   ```
 - `dbPath` は `app.getPath("userData")` 配下に置きます。これにより、
   アップグレード後も SQLite ファイルが残ります。
+- ユーザーが選んだランタイム CLI path は app settings に保存し、SNA 起動時に
+  `runtimePaths` で渡します。
 - カスタムビルドの `better_sqlite3.node` をデフォルト位置外に置く
   場合は、`nativeBinding` を渡します。
 

--- a/apps/docs/content/docs/introduction/embedding.ko.mdx
+++ b/apps/docs/content/docs/introduction/embedding.ko.mdx
@@ -23,6 +23,9 @@ const sna = await startSnaServer({
   dbPath: path.join(app.getPath("userData"), "sna.db"),
   maxSessions: 20,
   permissionMode: "acceptEdits",
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+  },
   onLog: (line) => console.log("[sna]", line),
 });
 
@@ -41,6 +44,8 @@ const sna = await startSnaServer({
   ```
 - `dbPath`는 `app.getPath("userData")` 하위에 둡니다. 그래야 업그레이드
   후에도 SQLite 파일이 유지됩니다.
+- 사용자가 선택한 런타임 CLI 경로는 앱 설정에 저장하고, SNA 시작 시
+  `runtimePaths`로 넘깁니다.
 - 커스텀 빌드한 `better_sqlite3.node`를 기본 위치 밖에 둔다면
   `nativeBinding`을 넘깁니다.
 

--- a/apps/docs/content/docs/introduction/embedding.mdx
+++ b/apps/docs/content/docs/introduction/embedding.mdx
@@ -23,6 +23,9 @@ const sna = await startSnaServer({
   dbPath: path.join(app.getPath("userData"), "sna.db"),
   maxSessions: 20,
   permissionMode: "acceptEdits",
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+  },
   onLog: (line) => console.log("[sna]", line),
 });
 
@@ -41,6 +44,8 @@ const sna = await startSnaServer({
   ```
 - `dbPath` should land under `app.getPath("userData")` so the SQLite
   file survives upgrades.
+- Store user-selected runtime CLI paths in app settings and pass them through
+  `runtimePaths` when starting SNA.
 - Pass `nativeBinding` if you ship a custom-built `better_sqlite3.node`
   outside the default location.
 

--- a/apps/docs/content/docs/introduction/index.ja.mdx
+++ b/apps/docs/content/docs/introduction/index.ja.mdx
@@ -53,8 +53,8 @@ SNA server  ──spawn──►  claude | codex | opencode
 ## 前提
 
 - **Node.js 20+**
-- **`PATH` 上に少なくとも 1 つのランタイム CLI**: `claude`,
-  `codex`, `opencode` のいずれか
+- **少なくとも 1 つのランタイム CLI**: `PATH` 上の `claude`,
+  `codex`, `opencode` のいずれか、または SNA 起動時に渡す明示的な `runtimePaths`
 - パッケージマネージャ。例では `pnpm` を使いますが、npm / yarn / bun でも構いません。
 
 ## 1. インストール
@@ -76,11 +76,16 @@ SNA はまだ `0.x.x` 系です。アプリで使う場合は、正確なパッ�
 アプリ内で:
 
 ```ts
-import { startSnaServer } from "@sna-sdk/core/node";
+import { resolveClaudeCli, startSnaServer } from "@sna-sdk/core/node";
+
+const claude = resolveClaudeCli();
 
 const sna = await startSnaServer({
   port: 3099,
   dbPath: "./data/sna.db",
+  runtimePaths: {
+    claudeCode: claude.path,
+  },
 });
 ```
 

--- a/apps/docs/content/docs/introduction/index.ko.mdx
+++ b/apps/docs/content/docs/introduction/index.ko.mdx
@@ -53,7 +53,7 @@ SNA server  ──spawn──►  claude | codex | opencode
 ## 사전 준비
 
 - **Node.js 20+**
-- **`PATH`에 런타임 CLI 하나 이상**: `claude`, `codex`, `opencode` 중 하나
+- **런타임 CLI 하나 이상**: `PATH`의 `claude`, `codex`, `opencode` 중 하나 또는 SNA 시작 시 넘기는 명시적 `runtimePaths`
 - 패키지 매니저. 예시는 `pnpm`이지만 npm / yarn / bun도 가능합니다.
 
 ## 1. 설치
@@ -74,11 +74,16 @@ SNA는 아직 `0.x.x` 버전대라 앱에서 사용할 때는 정확한 패키�
 앱 안에서:
 
 ```ts
-import { startSnaServer } from "@sna-sdk/core/node";
+import { resolveClaudeCli, startSnaServer } from "@sna-sdk/core/node";
+
+const claude = resolveClaudeCli();
 
 const sna = await startSnaServer({
   port: 3099,
   dbPath: "./data/sna.db",
+  runtimePaths: {
+    claudeCode: claude.path,
+  },
 });
 ```
 

--- a/apps/docs/content/docs/introduction/index.mdx
+++ b/apps/docs/content/docs/introduction/index.mdx
@@ -52,7 +52,7 @@ history, runtime swaps, attribution), read **[What is SNA?](/docs/introduction/w
 ## Prerequisites
 
 - **Node.js 20+**.
-- **At least one runtime CLI on `PATH`**: `claude`, `codex`, or `opencode`.
+- **At least one runtime CLI**: `claude`, `codex`, or `opencode` on `PATH`, or an explicit `runtimePaths` entry when starting SNA.
 - A package manager. Examples below use `pnpm`, but npm / yarn / bun work too.
 
 ## 1. Install
@@ -74,11 +74,16 @@ checklist plus CLI overrides.
 In your app:
 
 ```ts
-import { startSnaServer } from "@sna-sdk/core/node";
+import { resolveClaudeCli, startSnaServer } from "@sna-sdk/core/node";
+
+const claude = resolveClaudeCli();
 
 const sna = await startSnaServer({
   port: 3099,
   dbPath: "./data/sna.db",
+  runtimePaths: {
+    claudeCode: claude.path,
+  },
 });
 ```
 

--- a/apps/docs/content/docs/introduction/install.ja.mdx
+++ b/apps/docs/content/docs/introduction/install.ja.mdx
@@ -60,6 +60,20 @@ codex --version
 opencode --version
 ```
 
-非標準の場所にある場合は、呼び出し時に `providerOptions.cliPath` で
-上書きするか、環境変数 `SNA_CLAUDE_PATH` / `SNA_CODEX_COMMAND` を
-設定してください。
+非標準の場所にある場合は、SNA 起動時にパスを登録します。
+
+```ts
+await startSnaServer({
+  dbPath: "./data/sna.db",
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+    codex: "/opt/homebrew/bin/codex",
+    opencode: "/opt/homebrew/bin/opencode",
+  },
+});
+```
+
+低レベルの環境変数は `SNA_CLAUDE_COMMAND`、`SNA_CODEX_COMMAND`、
+`SNA_OPENCODE_COMMAND`、`SNA_GROK_COMMAND`、`SNA_CURSOR_COMMAND` です。
+組み込みアプリでは、サーバー起動設定と同じ場所にパスを残せる
+`runtimePaths` を優先してください。

--- a/apps/docs/content/docs/introduction/install.ko.mdx
+++ b/apps/docs/content/docs/introduction/install.ko.mdx
@@ -58,6 +58,20 @@ codex --version
 opencode --version
 ```
 
-비표준 위치에 있다면 호출 시점에 `providerOptions.cliPath`로
-오버라이드하거나, 환경 변수 `SNA_CLAUDE_PATH` / `SNA_CODEX_COMMAND`를
-설정합니다.
+비표준 위치에 있다면 SNA를 시작할 때 경로를 등록합니다.
+
+```ts
+await startSnaServer({
+  dbPath: "./data/sna.db",
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+    codex: "/opt/homebrew/bin/codex",
+    opencode: "/opt/homebrew/bin/opencode",
+  },
+});
+```
+
+하위 레벨 환경 변수는 `SNA_CLAUDE_COMMAND`, `SNA_CODEX_COMMAND`,
+`SNA_OPENCODE_COMMAND`, `SNA_GROK_COMMAND`, `SNA_CURSOR_COMMAND`입니다.
+임베디드 앱에서는 서버 시작 설정 안에 경로가 함께 남는 `runtimePaths`를
+우선 사용하십시오.

--- a/apps/docs/content/docs/introduction/install.mdx
+++ b/apps/docs/content/docs/introduction/install.mdx
@@ -57,6 +57,20 @@ codex --version
 opencode --version
 ```
 
-If a binary lives somewhere non-standard, override per-call via
-`providerOptions.cliPath` or set `SNA_CLAUDE_PATH` / `SNA_CODEX_COMMAND`
-in the environment.
+If a binary lives somewhere non-standard, register it when starting SNA:
+
+```ts
+await startSnaServer({
+  dbPath: "./data/sna.db",
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+    codex: "/opt/homebrew/bin/codex",
+    opencode: "/opt/homebrew/bin/opencode",
+  },
+});
+```
+
+The lower-level environment variables are `SNA_CLAUDE_COMMAND`,
+`SNA_CODEX_COMMAND`, `SNA_OPENCODE_COMMAND`, `SNA_GROK_COMMAND`, and
+`SNA_CURSOR_COMMAND`. `runtimePaths` is preferred for embedded apps because the
+path lives in the same startup config as the server.

--- a/apps/docs/content/docs/sdks/client-agent.ja.mdx
+++ b/apps/docs/content/docs/sdks/client-agent.ja.mdx
@@ -379,7 +379,7 @@ await client.agent.listModels(runtime: string, config?: ListModelsConfig): Promi
 | Field | Type | Description |
 | --- | --- | --- |
 | `runtime` | `string` | 調べるランタイム。例: `claude-code`、`codex`、`opencode`、`grok`、`cursor`。 |
-| `config.cliPath` | `string` | ランタイム CLI path override。 |
+| `config.cliPath` | `string` | モデル一覧取得だけに使うランタイム CLI パス上書き。エージェントの spawn パスにはランチャーの `runtimePaths` を使ってください。 |
 | `config.refresh` | `boolean` | cache を使わず再取得します。 |
 
 **Returns**

--- a/apps/docs/content/docs/sdks/client-agent.ko.mdx
+++ b/apps/docs/content/docs/sdks/client-agent.ko.mdx
@@ -379,7 +379,7 @@ await client.agent.listModels(runtime: string, config?: ListModelsConfig): Promi
 | Field | Type | Description |
 | --- | --- | --- |
 | `runtime` | `string` | 조회할 런타임입니다. 예: `claude-code`, `codex`, `opencode`, `grok`, `cursor`. |
-| `config.cliPath` | `string` | 런타임 CLI path override입니다. |
+| `config.cliPath` | `string` | 모델 목록 조회에만 쓰는 런타임 CLI 경로 덮어쓰기입니다. 에이전트 spawn 경로는 런처의 `runtimePaths`를 사용하십시오. |
 | `config.refresh` | `boolean` | cache를 건너뜁니다. |
 
 **Returns**

--- a/apps/docs/content/docs/sdks/client-agent.mdx
+++ b/apps/docs/content/docs/sdks/client-agent.mdx
@@ -379,7 +379,7 @@ await client.agent.listModels(runtime: string, config?: ListModelsConfig): Promi
 | Field | Type | Description |
 | --- | --- | --- |
 | `runtime` | `string` | Runtime to inspect, for example `claude-code`, `codex`, `opencode`, `grok`, or `cursor`. |
-| `config.cliPath` | `string` | Runtime CLI path override. |
+| `config.cliPath` | `string` | Runtime CLI path override for model listing only. Use launcher `runtimePaths` for agent spawn paths. |
 | `config.refresh` | `boolean` | Bypass cache. |
 
 **Returns**

--- a/apps/docs/content/docs/sdks/core-launchers.ja.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.ja.mdx
@@ -11,7 +11,7 @@ description: "SNA サーバーを起動するための Node および Electron �
 | `@sna-sdk/core/node` | `startSnaServer(options)` | Node host から SNA を起動します。 |
 | `@sna-sdk/core/electron` | `startSnaServer(options)` | Electron host から SNA を forked child process として起動します。 |
 | `@sna-sdk/core/electron` | `startSnaServerInProcess(options)` | 現在の Electron main process 内で SNA を実行します。 |
-| `@sna-sdk/core/electron` | `resolveClaudeCli`, `validateClaudePath`, `cacheClaudePath` | Claude Code CLI installation を検出、検証します。 |
+| `@sna-sdk/core/node`, `@sna-sdk/core/electron` | `resolveClaudeCli`, `resolveCodexCli`, `resolveOpenCodeCli` | setup / diagnostics 画面で使うランタイム CLI installation を検出します。 |
 
 Launcher handle は、サーバー停止と、検出された URL を `@sna-sdk/client` または `@sna-sdk/react` へ渡すために十分な情報を公開します。
 
@@ -34,7 +34,16 @@ type SnaServerOptions = {
   onLog?: (line: string) => void;
   dataDir?: string;
   logLevel?: "info" | "warn" | "error" | "silent";
+  runtimePaths?: RuntimePaths;
   langfuse?: { publicKey: string; secretKey: string; baseUrl?: string };
+};
+
+type RuntimePaths = {
+  claudeCode?: string;
+  codex?: string;
+  opencode?: string;
+  grok?: string;
+  cursor?: string;
 };
 ```
 
@@ -48,12 +57,17 @@ type SnaServerOptions = {
 | `model` | SDK default | Runtime call のデフォルト model。 |
 | `permissionTimeoutMs` | `0` | `0` の場合、permission prompt response は host が管理します。正の値なら timeout 後に自動 deny します。 |
 | `nativeBinding` | auto-detected | 明示的な `better-sqlite3` native binding path。Custom Electron build で使います。 |
-| `env` | `{}` | 追加 environment variable。Launcher が生成した値を override します。 |
+| `env` | `{}` | 追加環境変数。ここに置いたランタイムコマンド環境変数は `runtimePaths` から生成された値を上書きします。 |
 | `readyTimeout` | `15000` | Standalone process が ready line を出すまで待つ時間(ms)。 |
 | `onLog` | none | Child process の stdout/stderr line、または in-process mode の SDK logger line を受け取ります。 |
 | `dataDir` | `dbPath` から計算 | Image と asset storage の base directory。 |
 | `logLevel` | `info` | In-process logger output を filter します。Forked server の file log は全 level を記録し続けます。 |
+| `runtimePaths` | auto-detect | 明示的なランタイム CLI コマンドまたは絶対パス。`SNA_CLAUDE_COMMAND`、`SNA_CODEX_COMMAND`、`SNA_OPENCODE_COMMAND`、`SNA_GROK_COMMAND`、`SNA_CURSOR_COMMAND` に変換されます。 |
 | `langfuse` | none | Metadata で tracing を opt in した session で Langfuse tracing を有効にします。 |
+
+ホストアプリに設定画面がある場合や、ユーザーが選んだ CLI 位置を保存する
+場合は `runtimePaths` を使ってください。`env` は最後の退避手段として
+残り、`runtimePaths` から生成された値を上書きします。
 
 ## Forked vs in-process
 
@@ -74,6 +88,9 @@ In-process mode は default agent を自動 spawn しません。Host が HTTP�
 const handle = await startSnaServer({
   dbPath: "/Users/me/Library/Application Support/MyApp/sna.db",
   port: 3099,
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+  },
 });
 
 handle.stop();
@@ -127,6 +144,14 @@ type InProcessSnaServerHandle = {
 ### `resolveClaudeCli(options?)`
 
 利用可能な Claude Code CLI path を探します。ランタイムを開始できない理由を setup または diagnostics 画面で説明する場合に使います。
+
+### `resolveCodexCli(options?)`
+
+同じ env/cache/static/shell 順序で利用可能な Codex CLI path を探します。
+
+### `resolveOpenCodeCli(options?)`
+
+同じ env/cache/static/shell 順序で利用可能な OpenCode CLI path を探します。
 
 ### `validateClaudePath(path)`
 

--- a/apps/docs/content/docs/sdks/core-launchers.ko.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.ko.mdx
@@ -11,7 +11,7 @@ description: "SNA 서버를 시작하기 위한 Node 및 Electron 실행 표면�
 | `@sna-sdk/core/node` | `startSnaServer(options)` | Node host에서 SNA를 시작합니다. |
 | `@sna-sdk/core/electron` | `startSnaServer(options)` | Electron host에서 SNA를 forked child process로 시작합니다. |
 | `@sna-sdk/core/electron` | `startSnaServerInProcess(options)` | 현재 Electron main process 안에서 SNA를 실행합니다. |
-| `@sna-sdk/core/electron` | `resolveClaudeCli`, `validateClaudePath`, `cacheClaudePath` | Claude Code CLI 설치를 찾고 검증합니다. |
+| `@sna-sdk/core/node`, `@sna-sdk/core/electron` | `resolveClaudeCli`, `resolveCodexCli`, `resolveOpenCodeCli` | setup 및 diagnostics 화면에서 사용할 런타임 CLI 설치를 찾습니다. |
 
 Launcher handle은 서버를 중지하고 발견된 URL을 `@sna-sdk/client` 또는 `@sna-sdk/react`에 전달하기에 충분한 정보를 노출합니다.
 
@@ -34,7 +34,16 @@ type SnaServerOptions = {
   onLog?: (line: string) => void;
   dataDir?: string;
   logLevel?: "info" | "warn" | "error" | "silent";
+  runtimePaths?: RuntimePaths;
   langfuse?: { publicKey: string; secretKey: string; baseUrl?: string };
+};
+
+type RuntimePaths = {
+  claudeCode?: string;
+  codex?: string;
+  opencode?: string;
+  grok?: string;
+  cursor?: string;
 };
 ```
 
@@ -48,12 +57,17 @@ type SnaServerOptions = {
 | `model` | SDK default | Runtime call의 기본 model. |
 | `permissionTimeoutMs` | `0` | `0`이면 permission prompt 응답을 host가 직접 관리합니다. 양수면 timeout 뒤 자동 deny됩니다. |
 | `nativeBinding` | auto-detected | 명시적인 `better-sqlite3` native binding path. Custom Electron build에서 사용합니다. |
-| `env` | `{}` | 추가 environment variable. Launcher가 만든 값을 override합니다. |
+| `env` | `{}` | 추가 환경 변수. 여기에 둔 런타임 명령 환경 변수는 `runtimePaths`에서 생성된 값을 덮어씁니다. |
 | `readyTimeout` | `15000` | Standalone process가 ready line을 출력할 때까지 기다리는 시간(ms). |
 | `onLog` | none | Child process의 stdout/stderr line, 또는 in-process mode의 SDK logger line을 받습니다. |
 | `dataDir` | `dbPath`에서 계산 | Image와 asset storage의 base directory. |
 | `logLevel` | `info` | In-process logger output을 filter합니다. Forked server의 file log는 모든 level을 계속 기록합니다. |
+| `runtimePaths` | auto-detect | 명시적인 런타임 CLI 명령 또는 절대 경로입니다. 각각 `SNA_CLAUDE_COMMAND`, `SNA_CODEX_COMMAND`, `SNA_OPENCODE_COMMAND`, `SNA_GROK_COMMAND`, `SNA_CURSOR_COMMAND`로 변환됩니다. |
 | `langfuse` | none | Metadata로 tracing을 opt-in한 session에서 Langfuse tracing을 켭니다. |
+
+호스트 앱에 설정 화면이 있거나 사용자가 선택한 CLI 위치를 저장한다면
+`runtimePaths`를 사용하십시오. `env`는 여전히 마지막 우회 수단으로 남아
+있으며, `runtimePaths`에서 생성된 값을 덮어씁니다.
 
 ## Forked vs in-process
 
@@ -74,6 +88,9 @@ In-process mode는 default agent를 자동으로 spawn하지 않습니다. Host�
 const handle = await startSnaServer({
   dbPath: "/Users/me/Library/Application Support/MyApp/sna.db",
   port: 3099,
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+  },
 });
 
 handle.stop();
@@ -127,6 +144,14 @@ type InProcessSnaServerHandle = {
 ### `resolveClaudeCli(options?)`
 
 사용 가능한 Claude Code CLI path를 찾습니다. Provider를 시작할 수 없는 이유를 setup 또는 diagnostics 화면에서 설명할 때 사용합니다.
+
+### `resolveCodexCli(options?)`
+
+같은 env/cache/static/shell 순서로 사용 가능한 Codex CLI path를 찾습니다.
+
+### `resolveOpenCodeCli(options?)`
+
+같은 env/cache/static/shell 순서로 사용 가능한 OpenCode CLI path를 찾습니다.
 
 ### `validateClaudePath(path)`
 

--- a/apps/docs/content/docs/sdks/core-launchers.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.mdx
@@ -11,7 +11,7 @@ Launchers are for host applications that need to start SNA as part of their own 
 | `@sna-sdk/core/node` | `startSnaServer(options)` | Starts SNA from a Node host. |
 | `@sna-sdk/core/electron` | `startSnaServer(options)` | Starts SNA from an Electron host as a forked child process. |
 | `@sna-sdk/core/electron` | `startSnaServerInProcess(options)` | Runs SNA in the current Electron main process. |
-| `@sna-sdk/core/electron` | `resolveClaudeCli`, `validateClaudePath`, `cacheClaudePath` | Finds and validates Claude Code CLI installations. |
+| `@sna-sdk/core/node`, `@sna-sdk/core/electron` | `resolveClaudeCli`, `resolveCodexCli`, `resolveOpenCodeCli` | Finds runtime CLI installations for setup and diagnostics. |
 
 Launcher handles expose enough information to stop the server and pass the discovered URL to `@sna-sdk/client` or `@sna-sdk/react`.
 
@@ -34,7 +34,16 @@ type SnaServerOptions = {
   onLog?: (line: string) => void;
   dataDir?: string;
   logLevel?: "info" | "warn" | "error" | "silent";
+  runtimePaths?: RuntimePaths;
   langfuse?: { publicKey: string; secretKey: string; baseUrl?: string };
+};
+
+type RuntimePaths = {
+  claudeCode?: string;
+  codex?: string;
+  opencode?: string;
+  grok?: string;
+  cursor?: string;
 };
 ```
 
@@ -48,12 +57,17 @@ type SnaServerOptions = {
 | `model` | SDK default | Default model for runtime calls. |
 | `permissionTimeoutMs` | `0` | `0` leaves permission prompts under host control; positive values auto-deny after the timeout. |
 | `nativeBinding` | auto-detected | Explicit `better-sqlite3` native binding path. Use this for custom Electron builds. |
-| `env` | `{}` | Extra environment variables. These override launcher-generated values. |
+| `env` | `{}` | Extra environment variables. Runtime command variables here override values generated from `runtimePaths`. |
 | `readyTimeout` | `15000` | Milliseconds to wait for the standalone process to print the ready line. |
 | `onLog` | none | Receives stdout/stderr lines from the child process or SDK logger lines in in-process mode. |
 | `dataDir` | derived from `dbPath` | Base directory for image and asset storage. |
 | `logLevel` | `info` | Filters in-process logger output. Forked server file logs still record all levels. |
+| `runtimePaths` | auto-detect | Explicit runtime CLI commands or absolute paths. They map to `SNA_CLAUDE_COMMAND`, `SNA_CODEX_COMMAND`, `SNA_OPENCODE_COMMAND`, `SNA_GROK_COMMAND`, and `SNA_CURSOR_COMMAND`. |
 | `langfuse` | none | Enables tracing for sessions whose metadata opts in. |
+
+Use `runtimePaths` when the host app has a setup screen or stores user-selected
+CLI locations. `env` is still available as the final escape hatch and overrides
+the values generated from `runtimePaths`.
 
 ## Forked vs in-process
 
@@ -74,6 +88,9 @@ Starts SNA from a plain Node host and returns a handle with connection informati
 const handle = await startSnaServer({
   dbPath: "/Users/me/Library/Application Support/MyApp/sna.db",
   port: 3099,
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+  },
 });
 
 handle.stop();
@@ -127,6 +144,14 @@ type InProcessSnaServerHandle = {
 ### `resolveClaudeCli(options?)`
 
 Finds a usable Claude Code CLI path. Use it during setup or diagnostics to explain why a runtime cannot start.
+
+### `resolveCodexCli(options?)`
+
+Finds a usable Codex CLI path with the same env/cache/static/shell lookup order.
+
+### `resolveOpenCodeCli(options?)`
+
+Finds a usable OpenCode CLI path with the same env/cache/static/shell lookup order.
 
 ### `validateClaudePath(path)`
 

--- a/docs/app-setup.md
+++ b/docs/app-setup.md
@@ -24,6 +24,9 @@ const sna = await startSnaServer({
   dbPath: "./data/sna.db",
   maxSessions: 20,
   permissionMode: "acceptEdits",
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+  },
   onLog: (line) => console.log("[sna]", line),
 });
 // sna.port    — actual port (may differ from `port` if 0 was passed)
@@ -31,7 +34,7 @@ const sna = await startSnaServer({
 // sna.stop()  — graceful SIGTERM
 ```
 
-For Electron, swap to `@sna-sdk/core/electron` and add `asarUnpack: ["node_modules/@sna-sdk/core/**"]` to electron-builder. The Electron launcher additionally locates the consumer app's electron-rebuilt `better-sqlite3` and threads the binding path through.
+For Electron, swap to `@sna-sdk/core/electron` and add `asarUnpack: ["node_modules/@sna-sdk/core/**"]` to electron-builder. The Electron launcher additionally locates the consumer app's electron-rebuilt `better-sqlite3` and threads the binding path through. Store user-selected runtime CLI paths in your app settings and pass them through `runtimePaths`.
 
 ### Connecting from any framework
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,6 +259,9 @@ const sna = await startSnaServer({
   dbPath: path.join(process.cwd(), "data/sna.db"),
   maxSessions: 20,
   permissionMode: "acceptEdits",
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+  },
   onLog: (line) => console.log("[sna]", line),
 });
 // sna.process — ChildProcess
@@ -268,7 +271,7 @@ const sna = await startSnaServer({
 
 The Electron variant additionally resolves asar-unpacked paths and locates the consumer app's electron-rebuilt `better-sqlite3`. Add `asarUnpack: ["node_modules/@sna-sdk/core/**"]` to electron-builder.
 
-Supported `SnaServerOptions`: `port`, `dbPath`, `cwd`, `maxSessions`, `permissionMode`, `model`, `nativeBinding`, `env`, `readyTimeout`, `onLog`.
+Supported `SnaServerOptions`: `port`, `dbPath`, `cwd`, `maxSessions`, `permissionMode`, `model`, `nativeBinding`, `env`, `runtimePaths`, `readyTimeout`, `onLog`.
 
 ### Configuration
 
@@ -285,3 +288,11 @@ Supported `SnaServerOptions`: `port`, `dbPath`, `cwd`, `maxSessions`, `permissio
 | `SNA_PERMISSION_TIMEOUT_MS` | Auto-deny after this many ms (0 = app controls) |
 | `SNA_SQLITE_NATIVE_BINDING` | Absolute path to `better_sqlite3.node` (Electron) |
 | `SNA_CLAUDE_COMMAND` | Override the Claude binary |
+| `SNA_CODEX_COMMAND` | Override the Codex binary |
+| `SNA_OPENCODE_COMMAND` | Override the OpenCode binary |
+| `SNA_GROK_COMMAND` | Override the Grok binary |
+| `SNA_CURSOR_COMMAND` | Override the Cursor headless agent binary |
+
+Embedded hosts should prefer `startSnaServer({ runtimePaths })`, which maps to
+the same `SNA_*_COMMAND` variables while keeping runtime path registration in
+the server startup config.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -70,7 +70,7 @@ Conversation history is the SDK's source of truth. Provider-native session ids (
 
 ### Launcher API, not "is the app"
 
-The earlier shape of this project tried to own the entire app environment — `sna up` would install dependencies, manage `pnpm dev`, set up `.claude/settings.json`. That coupling fights the "library you embed" framing. The current recommendation is `startSnaServer({ port, dbPath, ... })`: forks the standalone server, resolves native bindings, waits for ready. The consumer app's web framework, lifecycle, and process supervision stay in the consumer app.
+The earlier shape of this project tried to own the entire app environment — `sna up` would install dependencies, manage `pnpm dev`, set up `.claude/settings.json`. That coupling fights the "library you embed" framing. The current recommendation is `startSnaServer({ port, dbPath, runtimePaths, ... })`: forks the standalone server, resolves native bindings, registers runtime CLI paths, waits for ready. The consumer app's web framework, lifecycle, setup UI, and process supervision stay in the consumer app.
 
 ### Mock Anthropic API for tests
 

--- a/packages/client/src/sna-client.ts
+++ b/packages/client/src/sna-client.ts
@@ -749,8 +749,9 @@ export interface RunOnceResult {
 /**
  * Caller-supplied config for `agent.listModels`. Most fields are runtime-
  * specific. Pass an empty object (or omit) for static catalogs such as
- * claude-code and codex. Pass `cliPath` to override OpenCode binary lookup.
- * Set `refresh: true` to bypass provider caches.
+ * claude-code. `cliPath` only affects model listing for runtimes that inspect
+ * their CLI; use launcher `runtimePaths` for agent spawn paths. Set
+ * `refresh: true` to bypass provider caches.
  */
 export interface ListModelsConfig {
   cliPath?: string;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,7 +15,7 @@ Your app → SNA server → spawn(agentic CLI runtime) → events back over WS
 - **Canonical conversation model** — `chat_messages` rows split a message into orthogonal `actor` × `kind` axes. `history/canonical.ts` rebuilds blocks; `history/{claude-code,codex,opencode}.ts` adapters convert canonical → native wire format.
 - **One-shot completion** — `completion({ prompt, model?, provider?, reasoningLevel? })` for short single-prompt jobs. Each provider implements its own optimal one-shot path (Codex `exec --ephemeral` or pooled thread; Claude `-p`; OpenCode pooled session or ephemeral serve). Opportunistically reuses a pooled daemon when one is already alive for the cwd, so high-frequency callers (autocomplete, etc.) don't pay per-call cold-start.
 - **Cross-runtime latency and Codex config knobs** — `reasoningLevel: 0..5` (mapped per runtime), Codex-only `providerOptions.serviceTier` (mirrors Codex `/fast`: `"priority"`, `"flex"`, `"batch"`), `providerOptions.profile` (`--profile`), and `providerOptions.config` (repeatable `-c key=value` overrides, including Codex `model_providers.*` entries for OpenAI-compatible gateways such as OpenRouter or local model servers).
-- **Launcher API** — `startSnaServer({ port, dbPath, ... })` from `@sna-sdk/core/node` or `@sna-sdk/core/electron`. Forks the standalone server, resolves native bindings, waits for ready.
+- **Launcher API** — `startSnaServer({ port, dbPath, runtimePaths, ... })` from `@sna-sdk/core/node` or `@sna-sdk/core/electron`. Forks the standalone server, resolves native bindings, registers runtime CLI paths, waits for ready.
 - **PreToolUse hook** — `scripts/hook.ts`, auto-injected by `ClaudeCodeProvider.spawn()`. No manual `.claude/settings.json` editing needed.
 
 ## Install
@@ -37,6 +37,9 @@ const sna = await startSnaServer({
   port: 3099,
   dbPath: "./data/sna.db",
   maxSessions: 20,
+  runtimePaths: {
+    claudeCode: "/opt/homebrew/bin/claude",
+  },
 });
 ```
 
@@ -176,6 +179,13 @@ const db = getDb();
 | `SNA_PERMISSION_TIMEOUT_MS` | Auto-deny after N ms (0 = app controls) |
 | `SNA_SQLITE_NATIVE_BINDING` | Absolute path to `better_sqlite3.node` (Electron packaged apps) |
 | `SNA_CLAUDE_COMMAND` | Override the Claude binary |
+| `SNA_CODEX_COMMAND` | Override the Codex binary |
+| `SNA_OPENCODE_COMMAND` | Override the OpenCode binary |
+| `SNA_GROK_COMMAND` | Override the Grok binary |
+| `SNA_CURSOR_COMMAND` | Override the Cursor headless agent binary |
+
+When launching SNA through `@sna-sdk/core/node` or `@sna-sdk/core/electron`,
+prefer `startSnaServer({ runtimePaths })` over setting these variables by hand.
 
 ## Documentation
 

--- a/packages/core/src/core/providers/types.ts
+++ b/packages/core/src/core/providers/types.ts
@@ -312,11 +312,12 @@ export interface AgentProvider {
 /**
  * Caller-supplied configuration for listModels.
  *
- * Most fields are only used by specific providers. OpenCode honors `cliPath`
- * to override the default `opencode` binary.
+ * Most fields are only used by specific providers. `cliPath` only affects
+ * model listing for runtimes that inspect their CLI. Use launcher
+ * `runtimePaths` for agent spawn paths.
  */
 export interface ListModelsConfig {
-  /** Override CLI binary path (opencode). */
+  /** Override CLI binary path for model listing. */
   cliPath?: string;
   /** Bypass the in-memory cache. */
   refresh?: boolean;

--- a/packages/core/src/electron/index.ts
+++ b/packages/core/src/electron/index.ts
@@ -38,9 +38,15 @@ import { fileURLToPath } from "url";
 import fs from "fs";
 import http from "http";
 
-// Re-export Claude CLI resolution utilities for consumer apps (e.g., Loom preflight)
+// Re-export CLI resolution utilities for consumer app setup/preflight screens.
 export { resolveClaudeCli, validateClaudePath, cacheClaudePath, parseCommandVOutput } from "../core/providers/claude-code.js";
 export type { ResolveResult } from "../core/providers/claude-code.js";
+export { resolveCodexCli, validateCodexPath, cacheCodexPath } from "../core/providers/codex.js";
+export type { CodexResolveResult } from "../core/providers/codex.js";
+export { resolveOpenCodeCli, validateOpenCodePath, cacheOpenCodePath } from "../core/providers/opencode.js";
+export type { OpenCodeResolveResult } from "../core/providers/opencode.js";
+export { resolveGrokPath } from "../core/providers/grok.js";
+export { resolveCursorPath } from "../core/providers/cursor.js";
 export type { LogLevel } from "../lib/logger.js";
 import path from "path";
 
@@ -100,8 +106,8 @@ export interface SnaServerOptions {
   nativeBinding?: string;
 
   /**
-   * Extra env vars merged into the server process environment.
-   * These take precedence over the launcher's defaults.
+   * Extra env vars merged into the server process environment. Runtime command
+   * variables here take precedence over values generated from `runtimePaths`.
    */
   env?: Record<string, string>;
 
@@ -137,6 +143,22 @@ export interface SnaServerOptions {
   logLevel?: LogLevel;
 
   /**
+   * Explicit CLI commands or absolute paths for agent runtimes.
+   *
+   * These map to the same environment variables used by the lower-level
+   * provider resolvers:
+   * - claudeCode -> SNA_CLAUDE_COMMAND
+   * - codex      -> SNA_CODEX_COMMAND
+   * - opencode   -> SNA_OPENCODE_COMMAND
+   * - grok       -> SNA_GROK_COMMAND
+   * - cursor     -> SNA_CURSOR_COMMAND
+   *
+   * Values may be absolute binary paths or wrapper commands. `env` is merged
+   * after this object, so `env.SNA_*_COMMAND` remains the final escape hatch.
+   */
+  runtimePaths?: RuntimePaths;
+
+  /**
    * Optional Langfuse tracing config.
    * When present, sessions with `meta.langfuseTrace: true` emit Langfuse traces.
    * Requires `langfuse` npm package installed.
@@ -147,6 +169,19 @@ export interface SnaServerOptions {
     baseUrl?: string;
   };
 
+}
+
+export interface RuntimePaths {
+  /** Claude Code CLI command/path. Maps to SNA_CLAUDE_COMMAND. */
+  claudeCode?: string;
+  /** Codex CLI command/path. Maps to SNA_CODEX_COMMAND. */
+  codex?: string;
+  /** OpenCode CLI command/path. Maps to SNA_OPENCODE_COMMAND. */
+  opencode?: string;
+  /** Grok CLI command/path. Maps to SNA_GROK_COMMAND. */
+  grok?: string;
+  /** Cursor headless agent CLI command/path. Maps to SNA_CURSOR_COMMAND. */
+  cursor?: string;
 }
 
 export interface SnaServerHandle {
@@ -206,6 +241,30 @@ function buildNodePath(): string | undefined {
   return existing ? `${unpacked}${path.delimiter}${existing}` : unpacked;
 }
 
+const runtimePathEnvKeys: Record<keyof RuntimePaths, string> = {
+  claudeCode: "SNA_CLAUDE_COMMAND",
+  codex: "SNA_CODEX_COMMAND",
+  opencode: "SNA_OPENCODE_COMMAND",
+  grok: "SNA_GROK_COMMAND",
+  cursor: "SNA_CURSOR_COMMAND",
+};
+
+export function runtimePathsToEnv(runtimePaths?: RuntimePaths): Record<string, string> {
+  const env: Record<string, string> = {};
+  if (!runtimePaths) return env;
+  for (const [runtime, envKey] of Object.entries(runtimePathEnvKeys) as Array<[keyof RuntimePaths, string]>) {
+    const value = runtimePaths[runtime]?.trim();
+    if (value) env[envKey] = value;
+  }
+  return env;
+}
+
+function applyProcessEnv(env: Record<string, string>): void {
+  for (const [key, value] of Object.entries(env)) {
+    process.env[key] = value;
+  }
+}
+
 // ── Core launcher ─────────────────────────────────────────────────────────────
 
 /**
@@ -231,6 +290,7 @@ export async function startSnaServer(options: SnaServerOptions): Promise<SnaServ
     consumerModules = path.resolve(bsPkg, "../..");
   } catch { /* not found — peer dep will resolve normally */ }
 
+  const runtimeEnv = runtimePathsToEnv(options.runtimePaths);
   const env: Record<string, string> = {
     ...(process.env as Record<string, string>),
     SNA_PORT: String(port),
@@ -243,6 +303,7 @@ export async function startSnaServer(options: SnaServerOptions): Promise<SnaServ
     ...(options.nativeBinding ? { SNA_SQLITE_NATIVE_BINDING: options.nativeBinding } : {}),
     ...(consumerModules ? { SNA_MODULES_PATH: consumerModules } : {}),
     ...(nodePath ? { NODE_PATH: nodePath } : {}),
+    ...runtimeEnv,
     // Consumer overrides last so they can always win
     ...(options.env ?? {}),
   };
@@ -369,6 +430,11 @@ export async function startSnaServerInProcess(
 
   // Apply log level filtering (default: "info" = current behavior)
   snaLogger.setLogLevel(options.logLevel ?? "info");
+
+  applyProcessEnv({
+    ...runtimePathsToEnv(options.runtimePaths),
+    ...(options.env ?? {}),
+  });
 
   // Configure SNA SDK before any module reads config
   setConfig({

--- a/packages/core/src/node/index.ts
+++ b/packages/core/src/node/index.ts
@@ -22,5 +22,27 @@
  * // sna.stop()  — graceful shutdown
  */
 
-export { startSnaServer } from "../electron/index.js";
-export type { SnaServerOptions, SnaServerHandle } from "../electron/index.js";
+export {
+  startSnaServer,
+  resolveClaudeCli,
+  validateClaudePath,
+  cacheClaudePath,
+  parseCommandVOutput,
+  resolveCodexCli,
+  validateCodexPath,
+  cacheCodexPath,
+  resolveOpenCodeCli,
+  validateOpenCodePath,
+  cacheOpenCodePath,
+  resolveGrokPath,
+  resolveCursorPath,
+  runtimePathsToEnv,
+} from "../electron/index.js";
+export type {
+  SnaServerOptions,
+  SnaServerHandle,
+  RuntimePaths,
+  ResolveResult,
+  CodexResolveResult,
+  OpenCodeResolveResult,
+} from "../electron/index.js";

--- a/packages/core/test/runtime-path-registration.test.ts
+++ b/packages/core/test/runtime-path-registration.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  runtimePathsToEnv,
+  startSnaServerInProcess,
+} from "../src/electron/index.js";
+import { resetConfig } from "../src/config.js";
+import { resetDb } from "../src/db/schema.js";
+
+const ENV_KEYS = [
+  "SNA_CLAUDE_COMMAND",
+  "SNA_CODEX_COMMAND",
+  "SNA_OPENCODE_COMMAND",
+  "SNA_GROK_COMMAND",
+  "SNA_CURSOR_COMMAND",
+  "SNA_PORT",
+  "SNA_DB_PATH",
+  "SNA_DATA_DIR",
+  "SNA_PERMISSION_MODE",
+  "SNA_MODEL",
+  "SNA_PERMISSION_TIMEOUT_MS",
+  "SNA_SQLITE_NATIVE_BINDING",
+  "SNA_MODULES_PATH",
+] as const;
+
+const savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetConfig();
+  resetDb();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("runtime path registration", () => {
+  it("maps launcher runtimePaths to provider command env vars", () => {
+    assert.deepEqual(runtimePathsToEnv({
+      claudeCode: "/bin/claude",
+      codex: "/bin/codex",
+      opencode: "/bin/opencode",
+      grok: "/bin/grok",
+      cursor: "/bin/agent",
+    }), {
+      SNA_CLAUDE_COMMAND: "/bin/claude",
+      SNA_CODEX_COMMAND: "/bin/codex",
+      SNA_OPENCODE_COMMAND: "/bin/opencode",
+      SNA_GROK_COMMAND: "/bin/grok",
+      SNA_CURSOR_COMMAND: "/bin/agent",
+    });
+  });
+
+  it("applies runtimePaths in in-process launcher and lets env override them", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sna-runtime-paths-"));
+    tempDirs.push(dir);
+
+    const handle = await startSnaServerInProcess({
+      port: 0,
+      dbPath: path.join(dir, "sna.db"),
+      logLevel: "silent",
+      runtimePaths: {
+        claudeCode: "/runtime/claude",
+        codex: "/runtime/codex",
+        opencode: "/runtime/opencode",
+        grok: "/runtime/grok",
+        cursor: "/runtime/agent",
+      },
+      env: {
+        SNA_CLAUDE_COMMAND: "/env/claude",
+      },
+    });
+
+    try {
+      assert.equal(process.env.SNA_CLAUDE_COMMAND, "/env/claude");
+      assert.equal(process.env.SNA_CODEX_COMMAND, "/runtime/codex");
+      assert.equal(process.env.SNA_OPENCODE_COMMAND, "/runtime/opencode");
+      assert.equal(process.env.SNA_GROK_COMMAND, "/runtime/grok");
+      assert.equal(process.env.SNA_CURSOR_COMMAND, "/runtime/agent");
+    } finally {
+      await handle.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add launcher-level runtimePaths for Claude Code, Codex, OpenCode, Grok, and Cursor CLI paths
- re-export runtime CLI resolution helpers from node/electron launcher entrypoints
- update README and docs quickstarts/install/launcher references to use runtimePaths instead of incorrect per-call path guidance
- add runtime path registration tests

## Verification
- pnpm --filter @sna-sdk/core rebuild better-sqlite3
- node --import tsx --test test/runtime-path-registration.test.ts test/claude-path-resolution.test.ts test/opencode-provider.test.ts test/list-models.test.ts
- pnpm --filter @sna-sdk/core build
- pnpm --filter @sna-sdk/core test
- pnpm --filter @sna-sdk/client build
- pnpm --dir apps/docs types:check
- pnpm --dir apps/docs build