### PR TITLE
docs: add testing mock-attached guide

### DIFF
--- a/apps/docs/content/docs/sdks/index.ja.mdx
+++ b/apps/docs/content/docs/sdks/index.ja.mdx
@@ -9,7 +9,7 @@ SNA は 4 つのパッケージを層別に配布しています。
   <Card title="@sna-sdk/core" href="/ja/docs/sdks/core" description="サーバ、session manager、runtime adapter、completion()." />
   <Card title="@sna-sdk/client" href="/ja/docs/sdks/client" description="TypeScript クライアント。HTTP + WebSocket トランスポート。" />
   <Card title="@sna-sdk/react" href="/ja/docs/sdks/react" description="React フック + ドロップイン chat UI。" />
-  <Card title="@sna-sdk/testing" href="/ja/docs/sdks/testing" description="Mock Anthropic API + 隔離された Claude Code テスト環境。" />
+  <Card title="@sna-sdk/testing" href="/ja/docs/sdks/testing" description="Mock LLM API + 隔離された実 runtime test helper。" />
 </Cards>
 
 ## バージョニング

--- a/apps/docs/content/docs/sdks/index.ko.mdx
+++ b/apps/docs/content/docs/sdks/index.ko.mdx
@@ -9,7 +9,7 @@ SNA는 네 개 패키지를 계층별로 배포합니다.
   <Card title="@sna-sdk/core" href="/ko/docs/sdks/core" description="서버, session manager, runtime adapter, completion()." />
   <Card title="@sna-sdk/client" href="/ko/docs/sdks/client" description="TypeScript 클라이언트. HTTP + WebSocket 전송." />
   <Card title="@sna-sdk/react" href="/ko/docs/sdks/react" description="React 훅 + 드롭인 채팅 UI." />
-  <Card title="@sna-sdk/testing" href="/ko/docs/sdks/testing" description="Mock Anthropic API + 격리된 Claude Code 테스트 환경." />
+  <Card title="@sna-sdk/testing" href="/ko/docs/sdks/testing" description="Mock LLM API + 격리된 실제 런타임 테스트 helper." />
 </Cards>
 
 ## 버저닝

--- a/apps/docs/content/docs/sdks/index.mdx
+++ b/apps/docs/content/docs/sdks/index.mdx
@@ -9,7 +9,7 @@ SNA ships four packages, organized by layer.
   <Card title="@sna-sdk/core" href="/docs/sdks/core" description="Server, session manager, runtime adapters, completion()." />
   <Card title="@sna-sdk/client" href="/docs/sdks/client" description="TypeScript client. HTTP + WebSocket transports." />
   <Card title="@sna-sdk/react" href="/docs/sdks/react" description="React hooks and a drop-in chat UI." />
-  <Card title="@sna-sdk/testing" href="/docs/sdks/testing" description="Mock Anthropic API + isolated Claude Code test env." />
+  <Card title="@sna-sdk/testing" href="/docs/sdks/testing" description="Mock LLM APIs + isolated real-runtime test helpers." />
 </Cards>
 
 ## Versioning

--- a/apps/docs/content/docs/sdks/meta.ja.json
+++ b/apps/docs/content/docs/sdks/meta.ja.json
@@ -25,6 +25,7 @@
     "---@sna-sdk/testing---",
     "testing",
     "testing-mock-api",
+    "testing-mock-attached",
     "testing-cli"
   ]
 }

--- a/apps/docs/content/docs/sdks/meta.json
+++ b/apps/docs/content/docs/sdks/meta.json
@@ -25,6 +25,7 @@
     "---@sna-sdk/testing---",
     "testing",
     "testing-mock-api",
+    "testing-mock-attached",
     "testing-cli"
   ]
 }

--- a/apps/docs/content/docs/sdks/meta.ko.json
+++ b/apps/docs/content/docs/sdks/meta.ko.json
@@ -25,6 +25,7 @@
     "---@sna-sdk/testing---",
     "testing",
     "testing-mock-api",
+    "testing-mock-attached",
     "testing-cli"
   ]
 }

--- a/apps/docs/content/docs/sdks/testing-mock-attached.ja.mdx
+++ b/apps/docs/content/docs/sdks/testing-mock-attached.ja.mdx
@@ -1,0 +1,267 @@
+---
+title: "Mock-Attached Runtime Tests"
+description: "実際の Claude Code、Codex、OpenCode、Grok Build CLI を起動し、model API call だけを local mock に向ける方法。"
+---
+
+# Mock-Attached Runtime Tests
+
+Mock-attached test は、実際の runtime CLI を起動し、model API endpoint だけを local mock server に差し替えます。純粋な fake より強い test です。Provider の実際の spawn argument、config file、environment variable、stream parser、request shape をそのまま通すためです。
+
+SNA が prompt、model、auth、streaming flag、reasoning 設定、provider 固有 config を runtime に正しく渡しているかを確認したい場合に使ってください。
+
+## 検証範囲
+
+| Runtime | 実 process | Mock API route | Main helper |
+| --- | --- | --- | --- |
+| Claude Code | `claude` | Anthropic `POST /v1/messages` | `createClaudeMockEnv()` |
+| Codex | `codex` | OpenAI Responses `POST /v1/responses` | `createCodexMockEnv()` |
+| OpenCode | `opencode serve` | OpenAI Chat Completions `POST /v1/chat/completions` | `createOpenCodeMockConfig()` |
+| Grok Build | `grok agent ... stdio` | OpenAI Responses `POST /v1/responses` | `createGrokMockEnv()` |
+
+Captured request には `authorization`、`model`、`stream`、`userText`、`systemPromptLength`、`requestBody` が含まれます。Prompt の配置や provider 固有 field を正確に検証する場合は raw body に対して assertion を書いてください。
+
+Cursor はまだ mock-attached helper の対象外です。現在サポートされている CLI 経路では、他の runtime と同等に安定した API-base override が確認できていないためです。
+
+## Binary の場所
+
+Test は provider が production で使うものと同じ command override 環境変数を使います。Developer ごとに runtime binary の場所が違っても、同じ test を実行できます。
+
+```bash
+SNA_CLAUDE_COMMAND=/absolute/path/to/claude \
+SNA_CODEX_COMMAND=/absolute/path/to/codex \
+SNA_GROK_COMMAND=/absolute/path/to/grok \
+SNA_OPENCODE_COMMAND=/absolute/path/to/opencode \
+pnpm --filter @sna-sdk/core exec tsx --test test/runtime-mock-attached.test.ts
+```
+
+Override がない場合は各 provider の通常の path lookup が使われます。必要な binary がない場合、test は fake に差し替えるのではなく skip されるべきです。
+
+## Request assertion
+
+Sleep ではなく `waitForRequest()` を使います。Mock server の captured request list を polling し、predicate が match したら返し、timeout したら失敗します。
+
+```ts
+import { startMockOpenAIServer, waitForRequest } from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({ responseText: "OK" });
+
+const request = await waitForRequest(
+  openai,
+  (entry) =>
+    entry.endpoint === "responses" &&
+    entry.userText?.includes("mock attached") &&
+    JSON.stringify(entry.requestBody).includes("SNA system prompt"),
+  { timeoutMs: 15_000 },
+);
+
+expect(request.url).toBe("/v1/responses");
+expect(request.stream).toBe(true);
+expect(request.authorization).toBe("Bearer sk-test");
+```
+
+## Claude Code
+
+`createClaudeMockEnv()` は隔離された Claude config directory を書き、Claude Code を `startMockAnthropicServer()` に向ける environment variable を返します。
+
+```ts
+import { ClaudeCodeProvider } from "@sna-sdk/core/providers";
+import {
+  createClaudeMockEnv,
+  startMockAnthropicServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const anthropic = await startMockAnthropicServer();
+const mockEnv = createClaudeMockEnv({
+  cwd,
+  anthropicBaseUrl: `http://127.0.0.1:${anthropic.port}`,
+  apiKey: "sk-claude-mock",
+});
+
+try {
+  const deltas: string[] = [];
+  const result = await new ClaudeCodeProvider().complete({
+    cwd,
+    prompt: "mock attached claude",
+    model: "claude-sonnet-4-6",
+    systemPrompt: "SNA mock-attached Claude system prompt",
+    extraArgs: ["--bare", "--permission-mode", "bypassPermissions", "--setting-sources", ""],
+    env: mockEnv.env,
+    onDelta: (delta) => deltas.push(delta),
+  });
+
+  const request = await waitForRequest(
+    anthropic,
+    (entry) => JSON.stringify(entry.requestBody).includes("SNA mock-attached Claude system prompt"),
+  );
+
+  expect(request.stream).toBe(true);
+  expect(result.text).toContain("edualc");
+  expect(deltas.join("")).toContain("edualc");
+} finally {
+  anthropic.close();
+}
+```
+
+Helper は `ANTHROPIC_BASE_URL`、`ANTHROPIC_API_KEY`、`CLAUDE_CONFIG_DIR` を設定します。`inheritEnv: false` を使うと、小さな shell allowlist だけを継承してから mock 固有の値を追加します。
+
+## Codex
+
+`createCodexMockEnv()` は、mock server を指す OpenAI Responses provider を含む隔離 `CODEX_HOME/config.toml` を書きます。
+
+```ts
+import { CodexProvider } from "@sna-sdk/core/providers";
+import {
+  createCodexMockEnv,
+  startMockOpenAIServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({ responseText: "codex mock response" });
+const mockEnv = createCodexMockEnv({
+  cwd,
+  openAIBaseUrl: openai.url,
+  apiKey: "sk-codex-mock",
+  model: "gpt-5.4",
+});
+
+try {
+  const result = await new CodexProvider().complete({
+    cwd,
+    prompt: "mock attached codex",
+    model: mockEnv.model,
+    systemPrompt: "SNA mock-attached Codex system prompt",
+    reasoningLevel: 4,
+    providerOptions: { serviceTier: "priority" },
+    env: mockEnv.env,
+  });
+
+  const request = await waitForRequest(openai, (entry) => entry.endpoint === "responses");
+
+  expect(result.text).toBe("codex mock response");
+  expect(request.url).toBe("/v1/responses");
+  expect(request.requestBody.reasoning).toEqual({ effort: "high" });
+  expect(request.requestBody.service_tier).toBe("priority");
+} finally {
+  await openai.close();
+}
+```
+
+Helper は `CODEX_HOME` と `OPENAI_API_KEY` を設定します。生成される config は `wire_api = "responses"` と `base_url = "<mock>/v1"` を使います。
+
+## OpenCode
+
+OpenCode は process environment ではなく SNA provider option で設定します。`createOpenCodeMockConfig()` は、SNA が実際の `opencode serve` runtime に渡す provider config を返します。
+
+```ts
+import { OpenCodeProvider } from "@sna-sdk/core/providers";
+import {
+  createOpenCodeMockConfig,
+  startMockOpenAIServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({ responseText: "Done." });
+const mockConfig = createOpenCodeMockConfig({
+  openAIBaseUrl: openai.url,
+  apiKey: "sk-opencode-mock",
+  providerId: "sna-mock",
+  modelId: "sna-model",
+});
+
+const provider = new OpenCodeProvider();
+const runtime = await provider.prepareRuntime({
+  cwd,
+  model: mockConfig.model,
+  providerOptions: mockConfig.providerOptions,
+});
+
+try {
+  const agent = provider.spawn({
+    cwd,
+    prompt: "mock attached opencode",
+    model: mockConfig.model,
+    systemPrompt: "SNA mock-attached OpenCode system prompt",
+    providerOptions: mockConfig.providerOptions,
+  }, runtime);
+
+  const request = await waitForRequest(
+    openai,
+    (entry) => entry.endpoint === "chat.completions" &&
+      entry.userText === "mock attached opencode",
+    { timeoutMs: 15_000 },
+  );
+
+  expect(request.url).toBe("/v1/chat/completions");
+  expect(request.model).toBe("sna-model");
+  expect(request.stream).toBe(true);
+  agent.kill();
+} finally {
+  await runtime.dispose();
+  await openai.close();
+}
+```
+
+`SNA_OPENCODE_COMMAND` が custom binary を指す場合、provider はその binary の directory を `PATH` の先頭に追加します。SDK 内部の `opencode serve` launch が同じ executable を使うようにするためです。
+
+## Grok Build
+
+`createGrokMockEnv()` は Grok の `HOME` を隔離し、`~/.grok/config.toml` を書き、`XAI_API_KEY` を設定し、SNA Grok provider に渡す provider option を返します。Provider は `grok agent --no-leader --xai-api-base-url <mock>/v1 ... stdio` を起動します。
+
+```ts
+import { GrokProvider } from "@sna-sdk/core/providers";
+import {
+  createGrokMockEnv,
+  startMockOpenAIServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({
+  models: [{ id: "grok-build", owned_by: "xai" }],
+  responseText: "OK",
+});
+const mockEnv = createGrokMockEnv({
+  cwd,
+  openAIBaseUrl: openai.url,
+  apiKey: "sk-grok-mock",
+  model: "grok-build",
+});
+
+try {
+  const events: any[] = [];
+  const agent = new GrokProvider().spawn({
+    cwd,
+    prompt: "Reply with exactly OK for mock attached grok.",
+    model: mockEnv.model,
+    permissionMode: "bypassPermissions",
+    systemPrompt: "SNA mock-attached Grok system prompt",
+    env: mockEnv.env,
+    providerOptions: mockEnv.providerOptions,
+  });
+  agent.on("event", (event) => events.push(event));
+
+  const request = await waitForRequest(
+    openai,
+    (entry) => entry.endpoint === "responses" &&
+      JSON.stringify(entry.requestBody).includes("SNA mock-attached Grok system prompt"),
+    { timeoutMs: 20_000 },
+  );
+
+  expect(request.authorization).toBe("Bearer sk-grok-mock");
+  expect(request.stream).toBe(true);
+  expect(request.model).toBe("grok-build");
+  agent.kill();
+} finally {
+  await openai.close();
+}
+```
+
+Helper は `{ xaiApiBaseUrl: "<mock>/v1", noLeader: true }` 形式の `providerOptions` を返します。追加の process variable は `extraEnv` で渡し、local auth state の継承を避ける test では `inheritEnv: false` を使ってください。
+
+## Cleanup checklist
+
+- Mock server を `mock.close()` または `await mock.close()` で閉じます。
+- Spawn した `AgentProcess` を kill します。
+- OpenCode の `RuntimeHandle` のような準備済み runtime handle を dispose します。
+- Test が作成した temporary cwd/config directory を削除します。
+- `sk-test-mock-sna` のような fake API key を使い、developer-local real token に依存しないでください。

--- a/apps/docs/content/docs/sdks/testing-mock-attached.ko.mdx
+++ b/apps/docs/content/docs/sdks/testing-mock-attached.ko.mdx
@@ -1,0 +1,267 @@
+---
+title: "Mock-Attached 런타임 테스트"
+description: "실제 Claude Code, Codex, OpenCode, Grok Build CLI를 실행하되 model API 호출만 local mock으로 라우팅하는 방법입니다."
+---
+
+# Mock-Attached 런타임 테스트
+
+Mock-attached 테스트는 실제 runtime CLI를 실행하고 model API endpoint만 local mock server로 교체합니다. 순수 fake보다 강한 테스트입니다. Provider의 실제 spawn argument, config file, environment variable, stream parser, request shape를 그대로 통과하기 때문입니다.
+
+SNA가 prompt, model, auth, streaming flag, reasoning 설정, provider별 config를 runtime에 올바르게 넘기는지 증명해야 할 때 이 모드를 사용하십시오.
+
+## 검증 범위
+
+| Runtime | 실제 process | Mock API route | Main helper |
+| --- | --- | --- | --- |
+| Claude Code | `claude` | Anthropic `POST /v1/messages` | `createClaudeMockEnv()` |
+| Codex | `codex` | OpenAI Responses `POST /v1/responses` | `createCodexMockEnv()` |
+| OpenCode | `opencode serve` | OpenAI Chat Completions `POST /v1/chat/completions` | `createOpenCodeMockConfig()` |
+| Grok Build | `grok agent ... stdio` | OpenAI Responses `POST /v1/responses` | `createGrokMockEnv()` |
+
+Captured request에는 `authorization`, `model`, `stream`, `userText`, `systemPromptLength`, `requestBody`가 포함됩니다. Prompt 배치나 provider별 field를 정확히 검증해야 하면 raw body에 대해 assertion을 작성하십시오.
+
+Cursor는 아직 mock-attached helper 범위에 없습니다. 현재 지원되는 CLI 경로에서 다른 runtime처럼 안정적인 API-base override가 확인되지 않았기 때문입니다.
+
+## Binary 위치
+
+테스트는 provider가 production에서 사용하는 것과 같은 command override 환경변수를 사용합니다. 개발자마다 runtime binary 위치가 달라도 같은 테스트를 실행할 수 있습니다.
+
+```bash
+SNA_CLAUDE_COMMAND=/absolute/path/to/claude \
+SNA_CODEX_COMMAND=/absolute/path/to/codex \
+SNA_GROK_COMMAND=/absolute/path/to/grok \
+SNA_OPENCODE_COMMAND=/absolute/path/to/opencode \
+pnpm --filter @sna-sdk/core exec tsx --test test/runtime-mock-attached.test.ts
+```
+
+Override가 없으면 각 provider의 일반 path lookup을 사용합니다. 필요한 binary가 없으면 test는 fake로 대체하지 말고 skip되어야 합니다.
+
+## Request assertion
+
+Sleep 대신 `waitForRequest()`를 사용하십시오. Mock server의 captured request list를 polling하다가 predicate가 match되면 반환하고, timeout이면 실패합니다.
+
+```ts
+import { startMockOpenAIServer, waitForRequest } from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({ responseText: "OK" });
+
+const request = await waitForRequest(
+  openai,
+  (entry) =>
+    entry.endpoint === "responses" &&
+    entry.userText?.includes("mock attached") &&
+    JSON.stringify(entry.requestBody).includes("SNA system prompt"),
+  { timeoutMs: 15_000 },
+);
+
+expect(request.url).toBe("/v1/responses");
+expect(request.stream).toBe(true);
+expect(request.authorization).toBe("Bearer sk-test");
+```
+
+## Claude Code
+
+`createClaudeMockEnv()`는 격리된 Claude config directory를 쓰고, Claude Code를 `startMockAnthropicServer()`로 라우팅하는 environment variable을 반환합니다.
+
+```ts
+import { ClaudeCodeProvider } from "@sna-sdk/core/providers";
+import {
+  createClaudeMockEnv,
+  startMockAnthropicServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const anthropic = await startMockAnthropicServer();
+const mockEnv = createClaudeMockEnv({
+  cwd,
+  anthropicBaseUrl: `http://127.0.0.1:${anthropic.port}`,
+  apiKey: "sk-claude-mock",
+});
+
+try {
+  const deltas: string[] = [];
+  const result = await new ClaudeCodeProvider().complete({
+    cwd,
+    prompt: "mock attached claude",
+    model: "claude-sonnet-4-6",
+    systemPrompt: "SNA mock-attached Claude system prompt",
+    extraArgs: ["--bare", "--permission-mode", "bypassPermissions", "--setting-sources", ""],
+    env: mockEnv.env,
+    onDelta: (delta) => deltas.push(delta),
+  });
+
+  const request = await waitForRequest(
+    anthropic,
+    (entry) => JSON.stringify(entry.requestBody).includes("SNA mock-attached Claude system prompt"),
+  );
+
+  expect(request.stream).toBe(true);
+  expect(result.text).toContain("edualc");
+  expect(deltas.join("")).toContain("edualc");
+} finally {
+  anthropic.close();
+}
+```
+
+Helper는 `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `CLAUDE_CONFIG_DIR`를 설정합니다. `inheritEnv: false`를 사용하면 작은 shell allowlist만 상속한 뒤 mock 전용 값을 추가합니다.
+
+## Codex
+
+`createCodexMockEnv()`는 mock server를 가리키는 OpenAI Responses provider를 포함한 격리 `CODEX_HOME/config.toml`을 씁니다.
+
+```ts
+import { CodexProvider } from "@sna-sdk/core/providers";
+import {
+  createCodexMockEnv,
+  startMockOpenAIServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({ responseText: "codex mock response" });
+const mockEnv = createCodexMockEnv({
+  cwd,
+  openAIBaseUrl: openai.url,
+  apiKey: "sk-codex-mock",
+  model: "gpt-5.4",
+});
+
+try {
+  const result = await new CodexProvider().complete({
+    cwd,
+    prompt: "mock attached codex",
+    model: mockEnv.model,
+    systemPrompt: "SNA mock-attached Codex system prompt",
+    reasoningLevel: 4,
+    providerOptions: { serviceTier: "priority" },
+    env: mockEnv.env,
+  });
+
+  const request = await waitForRequest(openai, (entry) => entry.endpoint === "responses");
+
+  expect(result.text).toBe("codex mock response");
+  expect(request.url).toBe("/v1/responses");
+  expect(request.requestBody.reasoning).toEqual({ effort: "high" });
+  expect(request.requestBody.service_tier).toBe("priority");
+} finally {
+  await openai.close();
+}
+```
+
+Helper는 `CODEX_HOME`, `OPENAI_API_KEY`를 설정합니다. 생성되는 config는 `wire_api = "responses"`, `base_url = "<mock>/v1"`를 사용합니다.
+
+## OpenCode
+
+OpenCode는 process environment가 아니라 SNA provider option으로 설정합니다. `createOpenCodeMockConfig()`는 SNA가 실제 `opencode serve` runtime에 전달할 provider config를 반환합니다.
+
+```ts
+import { OpenCodeProvider } from "@sna-sdk/core/providers";
+import {
+  createOpenCodeMockConfig,
+  startMockOpenAIServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({ responseText: "Done." });
+const mockConfig = createOpenCodeMockConfig({
+  openAIBaseUrl: openai.url,
+  apiKey: "sk-opencode-mock",
+  providerId: "sna-mock",
+  modelId: "sna-model",
+});
+
+const provider = new OpenCodeProvider();
+const runtime = await provider.prepareRuntime({
+  cwd,
+  model: mockConfig.model,
+  providerOptions: mockConfig.providerOptions,
+});
+
+try {
+  const agent = provider.spawn({
+    cwd,
+    prompt: "mock attached opencode",
+    model: mockConfig.model,
+    systemPrompt: "SNA mock-attached OpenCode system prompt",
+    providerOptions: mockConfig.providerOptions,
+  }, runtime);
+
+  const request = await waitForRequest(
+    openai,
+    (entry) => entry.endpoint === "chat.completions" &&
+      entry.userText === "mock attached opencode",
+    { timeoutMs: 15_000 },
+  );
+
+  expect(request.url).toBe("/v1/chat/completions");
+  expect(request.model).toBe("sna-model");
+  expect(request.stream).toBe(true);
+  agent.kill();
+} finally {
+  await runtime.dispose();
+  await openai.close();
+}
+```
+
+`SNA_OPENCODE_COMMAND`가 custom binary를 가리키면 provider는 그 binary의 directory를 `PATH` 앞에 추가합니다. SDK 내부의 `opencode serve` launch가 같은 executable을 사용하게 하기 위해서입니다.
+
+## Grok Build
+
+`createGrokMockEnv()`는 Grok의 `HOME`을 격리하고, `~/.grok/config.toml`을 쓰고, `XAI_API_KEY`를 설정하며, SNA Grok provider에 넘길 provider option을 반환합니다. Provider는 `grok agent --no-leader --xai-api-base-url <mock>/v1 ... stdio`를 시작합니다.
+
+```ts
+import { GrokProvider } from "@sna-sdk/core/providers";
+import {
+  createGrokMockEnv,
+  startMockOpenAIServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({
+  models: [{ id: "grok-build", owned_by: "xai" }],
+  responseText: "OK",
+});
+const mockEnv = createGrokMockEnv({
+  cwd,
+  openAIBaseUrl: openai.url,
+  apiKey: "sk-grok-mock",
+  model: "grok-build",
+});
+
+try {
+  const events: any[] = [];
+  const agent = new GrokProvider().spawn({
+    cwd,
+    prompt: "Reply with exactly OK for mock attached grok.",
+    model: mockEnv.model,
+    permissionMode: "bypassPermissions",
+    systemPrompt: "SNA mock-attached Grok system prompt",
+    env: mockEnv.env,
+    providerOptions: mockEnv.providerOptions,
+  });
+  agent.on("event", (event) => events.push(event));
+
+  const request = await waitForRequest(
+    openai,
+    (entry) => entry.endpoint === "responses" &&
+      JSON.stringify(entry.requestBody).includes("SNA mock-attached Grok system prompt"),
+    { timeoutMs: 20_000 },
+  );
+
+  expect(request.authorization).toBe("Bearer sk-grok-mock");
+  expect(request.stream).toBe(true);
+  expect(request.model).toBe("grok-build");
+  agent.kill();
+} finally {
+  await openai.close();
+}
+```
+
+Helper는 `{ xaiApiBaseUrl: "<mock>/v1", noLeader: true }` 형태의 `providerOptions`를 반환합니다. 추가 process variable은 `extraEnv`로 넣고, local auth state 상속을 피해야 하는 테스트에서는 `inheritEnv: false`를 사용하십시오.
+
+## Cleanup checklist
+
+- Mock server를 `mock.close()` 또는 `await mock.close()`로 닫습니다.
+- Spawn한 `AgentProcess`를 kill합니다.
+- OpenCode의 `RuntimeHandle`처럼 준비한 runtime handle을 dispose합니다.
+- Test가 만든 temporary cwd/config directory를 제거합니다.
+- `sk-test-mock-sna` 같은 fake API key를 사용하고, 개발자 local real token에 의존하지 않습니다.

--- a/apps/docs/content/docs/sdks/testing-mock-attached.mdx
+++ b/apps/docs/content/docs/sdks/testing-mock-attached.mdx
@@ -1,0 +1,267 @@
+---
+title: "Mock-Attached Runtime Tests"
+description: "Run real Claude Code, Codex, OpenCode, and Grok Build CLIs while routing only their model API calls to local mocks."
+---
+
+# Mock-Attached Runtime Tests
+
+Mock-attached tests run the real runtime CLI and replace only the model API endpoint with a local mock server. This is stronger than a pure fake because the test still exercises the provider's real spawn arguments, config files, environment variables, stream parser, and request shape.
+
+Use this mode when you need to prove that SNA actually passes the right prompt, model, auth, streaming flag, reasoning settings, and provider-specific config to the runtime.
+
+## What it verifies
+
+| Runtime | Real process | Mock API route | Main helper |
+| --- | --- | --- | --- |
+| Claude Code | `claude` | Anthropic `POST /v1/messages` | `createClaudeMockEnv()` |
+| Codex | `codex` | OpenAI Responses `POST /v1/responses` | `createCodexMockEnv()` |
+| OpenCode | `opencode serve` | OpenAI Chat Completions `POST /v1/chat/completions` | `createOpenCodeMockConfig()` |
+| Grok Build | `grok agent ... stdio` | OpenAI Responses `POST /v1/responses` | `createGrokMockEnv()` |
+
+The captured request records include `authorization`, `model`, `stream`, `userText`, `systemPromptLength`, and `requestBody`. Assert against the raw body when you need to verify exact prompt placement or provider-specific fields.
+
+Cursor is not covered by mock-attached helpers yet because the current supported CLI path does not expose a stable API-base override equivalent to the other runtimes.
+
+## Binary locations
+
+Tests use the same command override environment variables as the providers. This keeps test runs portable across developer machines where the runtime binary is installed in a different location.
+
+```bash
+SNA_CLAUDE_COMMAND=/absolute/path/to/claude \
+SNA_CODEX_COMMAND=/absolute/path/to/codex \
+SNA_GROK_COMMAND=/absolute/path/to/grok \
+SNA_OPENCODE_COMMAND=/absolute/path/to/opencode \
+pnpm --filter @sna-sdk/core exec tsx --test test/runtime-mock-attached.test.ts
+```
+
+If an override is not set, each provider falls back to its normal path lookup. Tests that require an unavailable binary should skip instead of silently replacing it with a fake.
+
+## Request assertions
+
+Use `waitForRequest()` instead of sleeping. It polls the mock server's captured request list until a predicate matches or the timeout expires.
+
+```ts
+import { startMockOpenAIServer, waitForRequest } from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({ responseText: "OK" });
+
+const request = await waitForRequest(
+  openai,
+  (entry) =>
+    entry.endpoint === "responses" &&
+    entry.userText?.includes("mock attached") &&
+    JSON.stringify(entry.requestBody).includes("SNA system prompt"),
+  { timeoutMs: 15_000 },
+);
+
+expect(request.url).toBe("/v1/responses");
+expect(request.stream).toBe(true);
+expect(request.authorization).toBe("Bearer sk-test");
+```
+
+## Claude Code
+
+`createClaudeMockEnv()` writes an isolated Claude config directory and returns environment variables for routing Claude Code to `startMockAnthropicServer()`.
+
+```ts
+import { ClaudeCodeProvider } from "@sna-sdk/core/providers";
+import {
+  createClaudeMockEnv,
+  startMockAnthropicServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const anthropic = await startMockAnthropicServer();
+const mockEnv = createClaudeMockEnv({
+  cwd,
+  anthropicBaseUrl: `http://127.0.0.1:${anthropic.port}`,
+  apiKey: "sk-claude-mock",
+});
+
+try {
+  const deltas: string[] = [];
+  const result = await new ClaudeCodeProvider().complete({
+    cwd,
+    prompt: "mock attached claude",
+    model: "claude-sonnet-4-6",
+    systemPrompt: "SNA mock-attached Claude system prompt",
+    extraArgs: ["--bare", "--permission-mode", "bypassPermissions", "--setting-sources", ""],
+    env: mockEnv.env,
+    onDelta: (delta) => deltas.push(delta),
+  });
+
+  const request = await waitForRequest(
+    anthropic,
+    (entry) => JSON.stringify(entry.requestBody).includes("SNA mock-attached Claude system prompt"),
+  );
+
+  expect(request.stream).toBe(true);
+  expect(result.text).toContain("edualc");
+  expect(deltas.join("")).toContain("edualc");
+} finally {
+  anthropic.close();
+}
+```
+
+The helper sets `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, and `CLAUDE_CONFIG_DIR`. With `inheritEnv: false`, only a small shell allowlist is inherited before mock-specific values are added.
+
+## Codex
+
+`createCodexMockEnv()` writes an isolated `CODEX_HOME/config.toml` with an OpenAI Responses provider pointing at the mock server.
+
+```ts
+import { CodexProvider } from "@sna-sdk/core/providers";
+import {
+  createCodexMockEnv,
+  startMockOpenAIServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({ responseText: "codex mock response" });
+const mockEnv = createCodexMockEnv({
+  cwd,
+  openAIBaseUrl: openai.url,
+  apiKey: "sk-codex-mock",
+  model: "gpt-5.4",
+});
+
+try {
+  const result = await new CodexProvider().complete({
+    cwd,
+    prompt: "mock attached codex",
+    model: mockEnv.model,
+    systemPrompt: "SNA mock-attached Codex system prompt",
+    reasoningLevel: 4,
+    providerOptions: { serviceTier: "priority" },
+    env: mockEnv.env,
+  });
+
+  const request = await waitForRequest(openai, (entry) => entry.endpoint === "responses");
+
+  expect(result.text).toBe("codex mock response");
+  expect(request.url).toBe("/v1/responses");
+  expect(request.requestBody.reasoning).toEqual({ effort: "high" });
+  expect(request.requestBody.service_tier).toBe("priority");
+} finally {
+  await openai.close();
+}
+```
+
+The helper sets `CODEX_HOME` and `OPENAI_API_KEY`. The generated config uses `wire_api = "responses"` and `base_url = "<mock>/v1"`.
+
+## OpenCode
+
+OpenCode is configured through SNA provider options rather than process environment. `createOpenCodeMockConfig()` returns a provider config that SNA passes to the real `opencode serve` runtime.
+
+```ts
+import { OpenCodeProvider } from "@sna-sdk/core/providers";
+import {
+  createOpenCodeMockConfig,
+  startMockOpenAIServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({ responseText: "Done." });
+const mockConfig = createOpenCodeMockConfig({
+  openAIBaseUrl: openai.url,
+  apiKey: "sk-opencode-mock",
+  providerId: "sna-mock",
+  modelId: "sna-model",
+});
+
+const provider = new OpenCodeProvider();
+const runtime = await provider.prepareRuntime({
+  cwd,
+  model: mockConfig.model,
+  providerOptions: mockConfig.providerOptions,
+});
+
+try {
+  const agent = provider.spawn({
+    cwd,
+    prompt: "mock attached opencode",
+    model: mockConfig.model,
+    systemPrompt: "SNA mock-attached OpenCode system prompt",
+    providerOptions: mockConfig.providerOptions,
+  }, runtime);
+
+  const request = await waitForRequest(
+    openai,
+    (entry) => entry.endpoint === "chat.completions" &&
+      entry.userText === "mock attached opencode",
+    { timeoutMs: 15_000 },
+  );
+
+  expect(request.url).toBe("/v1/chat/completions");
+  expect(request.model).toBe("sna-model");
+  expect(request.stream).toBe(true);
+  agent.kill();
+} finally {
+  await runtime.dispose();
+  await openai.close();
+}
+```
+
+When `SNA_OPENCODE_COMMAND` points to a custom binary, the provider prepends that binary's directory to `PATH` so the SDK's internal `opencode serve` launch uses the same executable.
+
+## Grok Build
+
+`createGrokMockEnv()` isolates Grok's `HOME`, writes `~/.grok/config.toml`, sets `XAI_API_KEY`, and returns provider options for SNA's Grok provider. The provider starts `grok agent --no-leader --xai-api-base-url <mock>/v1 ... stdio`.
+
+```ts
+import { GrokProvider } from "@sna-sdk/core/providers";
+import {
+  createGrokMockEnv,
+  startMockOpenAIServer,
+  waitForRequest,
+} from "@sna-sdk/testing";
+
+const openai = await startMockOpenAIServer({
+  models: [{ id: "grok-build", owned_by: "xai" }],
+  responseText: "OK",
+});
+const mockEnv = createGrokMockEnv({
+  cwd,
+  openAIBaseUrl: openai.url,
+  apiKey: "sk-grok-mock",
+  model: "grok-build",
+});
+
+try {
+  const events: any[] = [];
+  const agent = new GrokProvider().spawn({
+    cwd,
+    prompt: "Reply with exactly OK for mock attached grok.",
+    model: mockEnv.model,
+    permissionMode: "bypassPermissions",
+    systemPrompt: "SNA mock-attached Grok system prompt",
+    env: mockEnv.env,
+    providerOptions: mockEnv.providerOptions,
+  });
+  agent.on("event", (event) => events.push(event));
+
+  const request = await waitForRequest(
+    openai,
+    (entry) => entry.endpoint === "responses" &&
+      JSON.stringify(entry.requestBody).includes("SNA mock-attached Grok system prompt"),
+    { timeoutMs: 20_000 },
+  );
+
+  expect(request.authorization).toBe("Bearer sk-grok-mock");
+  expect(request.stream).toBe(true);
+  expect(request.model).toBe("grok-build");
+  agent.kill();
+} finally {
+  await openai.close();
+}
+```
+
+The helper returns `providerOptions` with `{ xaiApiBaseUrl: "<mock>/v1", noLeader: true }`. Use `extraEnv` for additional process variables and `inheritEnv: false` when a test must avoid inheriting local auth state.
+
+## Cleanup checklist
+
+- Close mock servers with `mock.close()` or `await mock.close()`.
+- Kill spawned `AgentProcess` instances.
+- Dispose prepared runtime handles such as OpenCode's `RuntimeHandle`.
+- Remove temporary cwd/config directories created by the test.
+- Prefer fake API keys like `sk-test-mock-sna`; never rely on developer-local real tokens.

--- a/apps/docs/content/docs/sdks/testing.ja.mdx
+++ b/apps/docs/content/docs/sdks/testing.ja.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Testing SDK"
-description: "決定的な SNA 統合テストのための Mock runtime サーバーと CLI ハーネスです。"
+description: "決定的な SNA 統合テストのための mock LLM API、実 runtime の mock-attached helper、CLI ハーネスです。"
 ---
 # Testing SDK
 
-`@sna-sdk/testing` は、テストが実際の Anthropic、OpenAI、Claude アカウントに依存しないようにするためのパッケージです。ローカルの Anthropic 互換 API サーバー、OpenAI 互換 API サーバー、インスタンスごとに設定とログを分離する CLI wrapper を提供します。
+`@sna-sdk/testing` は、テストが実際の Anthropic、OpenAI、xAI、Claude アカウントに依存しないようにするためのパッケージです。ローカルの Anthropic 互換 API サーバー、OpenAI 互換 API サーバー、実 runtime CLI を mock API に接続する helper、インスタンスごとに設定とログを分離する CLI wrapper を提供します。
 
-スモークテスト、runtime adapter テスト、予測可能な agent 出力が必要な UI flow に使ってください。
+スモークテスト、runtime adapter テスト、mock-attached CLI contract テスト、予測可能な agent 出力が必要な UI flow に使ってください。
 
 ## Install
 
@@ -17,4 +17,5 @@ pnpm add @sna-sdk/testing@0.15.0
 ## Public surfaces
 
 - [testing-mock-api](/ja/docs/sdks/testing-mock-api)
+- [testing-mock-attached](/ja/docs/sdks/testing-mock-attached)
 - [testing-cli](/ja/docs/sdks/testing-cli)

--- a/apps/docs/content/docs/sdks/testing.ko.mdx
+++ b/apps/docs/content/docs/sdks/testing.ko.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Testing SDK"
-description: "결정적인 SNA 통합 테스트를 위한 Mock runtime 서버와 CLI 하네스입니다."
+description: "결정적인 SNA 통합 테스트를 위한 mock LLM API, 실제 런타임 mock-attached helper, CLI 하네스입니다."
 ---
 # Testing SDK
 
-`@sna-sdk/testing`은 테스트가 실제 Anthropic, OpenAI, Claude 계정에 의존하지 않도록 제공됩니다. 로컬 Anthropic 호환 API 서버, OpenAI 호환 API 서버, 인스턴스별 설정 및 로그를 분리하는 CLI wrapper를 제공합니다.
+`@sna-sdk/testing`은 테스트가 실제 Anthropic, OpenAI, xAI, Claude 계정에 의존하지 않도록 제공됩니다. 로컬 Anthropic 호환 API 서버, OpenAI 호환 API 서버, 실제 runtime CLI를 mock API에 연결하는 helper, 인스턴스별 설정 및 로그를 분리하는 CLI wrapper를 제공합니다.
 
-스모크 테스트, runtime adapter 테스트, 예측 가능한 agent 출력이 필요한 UI flow에 사용하십시오.
+스모크 테스트, runtime adapter 테스트, mock-attached CLI contract 테스트, 예측 가능한 agent 출력이 필요한 UI flow에 사용하십시오.
 
 ## Install
 
@@ -17,4 +17,5 @@ pnpm add @sna-sdk/testing@0.15.0
 ## Public surfaces
 
 - [testing-mock-api](/ko/docs/sdks/testing-mock-api)
+- [testing-mock-attached](/ko/docs/sdks/testing-mock-attached)
 - [testing-cli](/ko/docs/sdks/testing-cli)

--- a/apps/docs/content/docs/sdks/testing.mdx
+++ b/apps/docs/content/docs/sdks/testing.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Testing SDK"
-description: "Mock runtime server and CLI harness for deterministic SNA integration tests."
+description: "Mock LLM APIs, real-runtime mock-attached helpers, and CLI harnesses for deterministic SNA integration tests."
 ---
 # Testing SDK
 
-`@sna-sdk/testing` exists so tests do not need real Anthropic, OpenAI, or Claude accounts. It provides local Anthropic-compatible and OpenAI-compatible API servers plus a CLI wrapper that isolates configuration and logs per instance.
+`@sna-sdk/testing` exists so tests do not need real Anthropic, OpenAI, xAI, or Claude accounts. It provides local Anthropic-compatible and OpenAI-compatible API servers, helpers for running real runtime CLIs against those mocks, and a CLI wrapper that isolates configuration and logs per instance.
 
-Use it for smoke tests, runtime-adapter tests, and UI flows that need predictable agent output.
+Use it for smoke tests, runtime-adapter tests, mock-attached CLI contract tests, and UI flows that need predictable agent output.
 
 ## Install
 
@@ -17,4 +17,5 @@ pnpm add @sna-sdk/testing@0.15.0
 ## Public surfaces
 
 - [testing-mock-api](/docs/sdks/testing-mock-api)
+- [testing-mock-attached](/docs/sdks/testing-mock-attached)
 - [testing-cli](/docs/sdks/testing-cli)


### PR DESCRIPTION
## Summary
- add a new SDK docs page for mock-attached real-runtime testing in English, Korean, and Japanese
- document Claude Code, Codex, OpenCode, and Grok Build helper setup, request assertions, stream/request shape checks, cleanup, and binary override env vars
- update SDK overview/testing navigation so the new guide is discoverable

## Verification
- `pnpm --filter docs types:check`
- `pnpm --filter docs build`

## Note
- `pnpm --filter docs lint` currently fails before linting these docs because `eslint-plugin-react`'s `react/display-name` rule crashes under the repository's ESLint 10 setup while loading an existing app file.
