### PR TITLE
docs: add Loom cookbook patterns

### DIFF
--- a/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
@@ -12,10 +12,19 @@ Product には通常、独自の session または project row があります�
 
 ```ts
 type AppSession = {
+  // Product が所有する安定した identity です。Rename/archive/fork はこの id を基準にします。
   id: string;
+
+  // User-facing label です。Runtime process label とは分けておくと移行しやすいです。
   name: string;
+
+  // Local project がまだない session もあるため nullable にします。
   projectPath: string | null;
+
+  // 現在接続している SNA head です。Runtime switch、fold、fork で変わることがあります。
   snaSessionId: string | null;
+
+  // Local SNA と cloud SNA instance を同じ product model で扱うための field です。
   snaInstanceId: "local" | string;
 };
 ```
@@ -42,20 +51,27 @@ WebSocket state は connection 単位です。App が local SNA と cloud SNA in
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
+// Instance id ごとに client を 1 つだけ作り、WebSocket の重複接続を避けます。
 const clients = new Map<string, SnaClient>();
+
+// UI は特定 client ではなく app-level listener set に subscribe します。
 const eventListeners = new Set<(event: unknown) => void>();
 const permissionListeners = new Set<(event: unknown) => void>();
 
 function installAggregator(client: SnaClient) {
+  // Runtime event を 1 つの product event bus に集めます。
   client.agent.onEvent((event) => {
     for (const listener of eventListeners) listener(event);
   });
+
+  // Permission request も connection ごとに届くため、同じように fan-in します。
   client.agent.onPermissionRequest((event) => {
     for (const listener of permissionListeners) listener(event);
   });
 }
 
 export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
+  // すでに接続済みの instance なら同じ client を再利用します。
   const existing = clients.get(instanceId);
   if (existing) return existing;
   if (!baseUrl) throw new Error(`baseUrl required for ${instanceId}`);
@@ -63,12 +79,15 @@ export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
   const client = new SnaClient({ baseUrl, ws: true, http: true });
   clients.set(instanceId, client);
   installAggregator(client);
+
+  // connect と permission subscription は client 作成時に一度だけ行います。
   client.connect();
   client.agent.subscribePermissions().catch(() => {});
   return client;
 }
 
 export function onAgentEventAll(listener: (event: unknown) => void) {
+  // React effect の cleanup としてそのまま使える unsubscribe を返します。
   eventListeners.add(listener);
   return () => eventListeners.delete(listener);
 }
@@ -89,7 +108,10 @@ Renderer には raw SNA call ではなく domain wrapper を公開します。
 
 ```ts
 export async function ensureAgentAlive(snaSessionId: string, isNewSession = false) {
+  // Renderer が SNA id を持っていても、product session は host 側で resolve します。
   const appSession = sessionStore.findBySnaId(snaSessionId);
+
+  // Host endpoint が cwd、model、cloud wake、context injection などの product logic を持ちます。
   await appFetch("/agent/ensure", {
     method: "POST",
     body: JSON.stringify({
@@ -101,6 +123,7 @@ export async function ensureAgentAlive(snaSessionId: string, isNewSession = fals
 }
 
 export async function sendMessage(snaSessionId: string, message: string) {
+  // Send も host 経由にすると、pending model/runtime change を user-turn 境界で適用できます。
   return appFetch("/agent/send", {
     method: "POST",
     body: JSON.stringify({ snaSessionId, message }),
@@ -108,6 +131,7 @@ export async function sendMessage(snaSessionId: string, message: string) {
 }
 
 export function subscribeAgent(snaSessionId: string) {
+  // Event stream は token latency を下げるため SNA WebSocket に直接接続します。
   return clientForSnaSession(snaSessionId).agent.subscribe(snaSessionId, { since: 0 });
 }
 ```
@@ -116,18 +140,21 @@ Component は `ensureAgentAlive`、`sendMessage`、`subscribeAgent` という pr
 
 ## 4. `/agent/ensure` を idempotent にする
 
-Start-vs-resume の判断は host が持つべきです。UI が runtime history の有無、cloud wake の必要性、remote container 内で有効な cwd を判断しないようにします。
+Start-vs-resume の判断は host が持つと責任範囲が明確になります。UI が runtime history の有無、cloud wake の必要性、remote container 内で有効な cwd を判断しない形にすると安定します。
 
 ```ts
 async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
+  // Product session を基準に local/cloud SNA instance を選びます。
   const instance = snaForAppSession(appSessionId);
   await wakeIfCloudInstance(instance);
 
+  // Request に id がなければ product DB に保存された SNA id を使うか、新しく作ります。
   const snaSessionId = requestedSnaId ?? await loadOrCreateSnaId(appSessionId);
   if (await instance.isAlive(snaSessionId)) {
     return { status: "already_alive", snaSessionId };
   }
 
+  // Agent config は host で組み立て、renderer は domain-level に保ちます。
   const { config, cwd } = await buildAgentConfig(appSessionId, snaSessionId);
   await instance.createSession({
     id: snaSessionId,
@@ -140,30 +167,35 @@ async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
     .then((res) => res.ok && res.data.messages.length > 0)
     .catch(() => false);
 
+  // 新規または history のない head は start、既存 history がある head は resume します。
   return isNewSession || !hasHistory
     ? instance.startAgent(snaSessionId, { ...config, force: true, cwd })
     : instance.resumeAgent(snaSessionId, config);
 }
 ```
 
-この endpoint は tab focus、reload recovery、send preflight から何度呼ばれても安全であるべきです。
+この endpoint は tab focus、reload recovery、send preflight から何度呼ばれても安全な形にしておくと扱いやすいです。
 
 ## 5. Product context は user-turn 境界で注入する
 
-Metadata を独立した model turn として送らないでください。User message を forward する直前に context を作り、その message に product-owned tag を prepend / append します。
+Metadata は独立した model turn として送るより、User message を forward する直前に context を作り、その message に product-owned tag を prepend / append する形が扱いやすいです。
 
 ```ts
 async function sendAgentMessage({ snaSessionId, message }) {
   let finalMessage = message;
 
+  // Pending model/runtime selection は実際の user turn 直前に reconcile します。
   await reconcileSelectedModel(snaSessionId);
 
+  // 一度だけ消費する system metadata は user turn に付けて送ります。
   const pendingMeta = consumePendingSystemMeta(snaSessionId);
   if (pendingMeta) finalMessage = `${pendingMeta}\n${finalMessage}`;
 
+  // Retrieval context は現在の user message を基準に作ると stale context を減らせます。
   const retrievalContext = await maybeBuildRetrievalContext(snaSessionId, finalMessage);
   if (retrievalContext) finalMessage += `\n${retrievalContext}`;
 
+  // Agent が見るのは、product context が付いた最終 user turn です。
   return snaForSnaSession(snaSessionId).sendMessage(snaSessionId, finalMessage);
 }
 ```
@@ -187,7 +219,7 @@ User message が保存される前に新しい SNA head を broadcast すると�
 
 ## 7. Permission はすべての client で subscribe する
 
-Permission subscription は WebSocket ごとです。Permission dialog が mount されたあとに cloud client が作られる可能性があるなら、その新しい client でも subscribe してください。
+Permission subscription は WebSocket ごとです。Permission dialog が mount されたあとに cloud client が作られる可能性があるなら、その新しい client でも subscribe しておくと安全です。
 
 ```ts
 export async function subscribePermissions() {
@@ -209,21 +241,26 @@ export function respondPermission(snaSessionId: string, approved: boolean) {
 
 ## 8. React subscription は app root に置く
 
-SNA event bridge は chat surface より上に mount します。Chat pane、route、side panel は agent が streaming 中でも unmount されることがあります。Root-level hook が WebSocket listener を維持し、event を store に流し込むべきです。
+SNA event bridge は chat surface より上に mount します。Chat pane、route、side panel は agent が streaming 中でも unmount されることがあります。Root-level hook が WebSocket listener を維持し、event を store に流し込む構成が安定します。
 
 ```tsx
 function AppShell() {
+  // Product session hydration は app boot の責務として root に置きます。
   const hydrateSessions = useSessionStore((state) => state.hydrate);
   const sessions = useSessionStore((state) => state.sessions);
+
+  // Permission UI は現在 route だけでなく、既知の全 session を見られると安全です。
   const sessionIds = useMemo(
     () => sessions.flatMap((session) => session.snaSessionId ? [session.snaSessionId] : []),
     [sessions],
   );
 
+  // Event bridge は route/chat pane より上に置くと streaming 中の unmount に強くなります。
   useAgentEventStream();
   const { pending, clearPending } = usePermissionRequests(sessionIds);
 
   useEffect(() => {
+    // SNA connection lifecycle も root component が所有します。
     hydrateSessions();
     connectSna();
     return () => disconnectSna();
@@ -252,6 +289,7 @@ function useAgentEventStream() {
   const handleEvent = useMessageStore((state) => state.handleEvent);
 
   useEffect(() => {
+    // Listener は一度だけ設置し、event を store に正規化して入れます。
     return onAgentEvent(({ session, cursor, event, isHistory }) => {
       handleEvent(session, { cursor, event, isHistory });
     });
@@ -261,8 +299,13 @@ function useAgentEventStream() {
     const cleanups = sessions
       .filter((session) => session.snaSessionId)
       .map((session) => {
+        // Product session id と SNA session id の mapping を store に伝えます。
         register(session.snaSessionId!, session.id);
+
+        // Mount 時に最近の event を復元し、その後の stream を続けます。
         subscribeAgent(session.snaSessionId!, { since: 0, tail: 200 }).catch(() => {});
+
+        // Session list が変わったら古い subscription を片付けます。
         return () => unsubscribeAgent(session.snaSessionId!).catch(() => {});
       });
 
@@ -277,7 +320,7 @@ Permission UI も同じ理由で root に mount する方が安全です。こ�
 
 | 状況 | この pattern を使うか |
 | --- | --- |
-| Product DB のない単一 CLI wrapper | 通常は不要です。SNA を直接呼んでください。 |
-| Local SNA と renderer UI を持つ Electron app | 使ってください。Command path と event path を分けます。 |
-| Local + cloud SNA instance を同時に扱う app | 使ってください。Client registry と event aggregator が必要です。 |
-| Retrieval、project、policy context を注入する app | 使ってください。Send-time context building を host に集約します。 |
+| Product DB のない単一 CLI wrapper | 通常は不要です。SNA を直接呼ぶ方が単純です。 |
+| Local SNA と renderer UI を持つ Electron app | よく合います。Command path と event path を分けると扱いやすいです。 |
+| Local + cloud SNA instance を同時に扱う app | よく合います。Client registry と event aggregator が必要です。 |
+| Retrieval、project、policy context を注入する app | よく合います。Send-time context building を host に集約すると扱いやすいです。 |

--- a/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
@@ -1,0 +1,283 @@
+---
+title: Agentic app hosting
+description: 実アプリに SNA を組み込むときに Loom で使っている product integration pattern。
+icon: AppWindow
+---
+
+Loom は SNA を一回限りの chat endpoint としてではなく、local / cloud 対応の agent runtime としてアプリ内に組み込んでいます。Product が project、tab、document、permission、background workflow を agent の周辺に持つ場合、次の pattern が役立ちます。
+
+## 1. App session と SNA session を分ける
+
+Product には通常、独自の session または project row があります。その row を user-facing object として維持し、現在接続している SNA session id を別 field に保存します。
+
+```ts
+type AppSession = {
+  id: string;
+  name: string;
+  projectPath: string | null;
+  snaSessionId: string | null;
+  snaInstanceId: "local" | string;
+};
+```
+
+この分離により、app は runtime process を product object と混同せずに rename、archive、move、fork を扱えます。App session の identity を保ったまま local SNA から cloud SNA instance へ移すこともできます。
+
+1 つの app session が時間とともに複数の SNA session head を作る可能性があるなら、link table を置きます。
+
+```sql
+CREATE TABLE session_sna_links (
+  session_id TEXT NOT NULL,
+  sna_session_id TEXT NOT NULL,
+  instance_id TEXT NOT NULL DEFAULT 'local',
+  source TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, sna_session_id)
+);
+```
+
+## 2. SNA instance ごとに `SnaClient` を 1 つ持つ
+
+WebSocket state は connection 単位です。App が local SNA と cloud SNA instance を同時に扱うなら、instance ごとに client を cache し、event は 1 つの listener set に fan-in します。
+
+```ts
+import { SnaClient } from "@sna-sdk/client";
+
+const clients = new Map<string, SnaClient>();
+const eventListeners = new Set<(event: unknown) => void>();
+const permissionListeners = new Set<(event: unknown) => void>();
+
+function installAggregator(client: SnaClient) {
+  client.agent.onEvent((event) => {
+    for (const listener of eventListeners) listener(event);
+  });
+  client.agent.onPermissionRequest((event) => {
+    for (const listener of permissionListeners) listener(event);
+  });
+}
+
+export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
+  const existing = clients.get(instanceId);
+  if (existing) return existing;
+  if (!baseUrl) throw new Error(`baseUrl required for ${instanceId}`);
+
+  const client = new SnaClient({ baseUrl, ws: true, http: true });
+  clients.set(instanceId, client);
+  installAggregator(client);
+  client.connect();
+  client.agent.subscribePermissions().catch(() => {});
+  return client;
+}
+
+export function onAgentEventAll(listener: (event: unknown) => void) {
+  eventListeners.add(listener);
+  return () => eventListeners.delete(listener);
+}
+```
+
+重要なのは、UI component が特定の WebSocket ではなく app-level aggregator に subscribe することです。あとから cloud instance が増えても、UI を remount せずにその client を aggregator に参加させられます。
+
+## 3. Command は host 経由、event は SNA から直接受ける
+
+Loom は path を分けています。
+
+| Path | Route | 理由 |
+| --- | --- | --- |
+| Lifecycle command | renderer → app host HTTP → SNA HTTP | Host が app DB から config を作り、cloud instance を起こし、model selection を reconcile し、product context を注入できます。 |
+| Event stream | renderer → SNA WebSocket | すべての token を app server 経由にせず、UI が低 latency で runtime event を受け取れます。 |
+
+Renderer には raw SNA call ではなく domain wrapper を公開します。
+
+```ts
+export async function ensureAgentAlive(snaSessionId: string, isNewSession = false) {
+  const appSession = sessionStore.findBySnaId(snaSessionId);
+  await appFetch("/agent/ensure", {
+    method: "POST",
+    body: JSON.stringify({
+      appSessionId: appSession.id,
+      snaSessionId,
+      isNewSession,
+    }),
+  });
+}
+
+export async function sendMessage(snaSessionId: string, message: string) {
+  return appFetch("/agent/send", {
+    method: "POST",
+    body: JSON.stringify({ snaSessionId, message }),
+  });
+}
+
+export function subscribeAgent(snaSessionId: string) {
+  return clientForSnaSession(snaSessionId).agent.subscribe(snaSessionId, { since: 0 });
+}
+```
+
+Component は `ensureAgentAlive`、`sendMessage`、`subscribeAgent` という product verb だけを知っていれば済みます。
+
+## 4. `/agent/ensure` を idempotent にする
+
+Start-vs-resume の判断は host が持つべきです。UI が runtime history の有無、cloud wake の必要性、remote container 内で有効な cwd を判断しないようにします。
+
+```ts
+async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
+  const instance = snaForAppSession(appSessionId);
+  await wakeIfCloudInstance(instance);
+
+  const snaSessionId = requestedSnaId ?? await loadOrCreateSnaId(appSessionId);
+  if (await instance.isAlive(snaSessionId)) {
+    return { status: "already_alive", snaSessionId };
+  }
+
+  const { config, cwd } = await buildAgentConfig(appSessionId, snaSessionId);
+  await instance.createSession({
+    id: snaSessionId,
+    label: config.label ?? appSessionId,
+    cwd,
+    meta: debugMode ? { langfuseTrace: true } : undefined,
+  });
+
+  const hasHistory = await instance.getMessages(snaSessionId, { limit: 1 })
+    .then((res) => res.ok && res.data.messages.length > 0)
+    .catch(() => false);
+
+  return isNewSession || !hasHistory
+    ? instance.startAgent(snaSessionId, { ...config, force: true, cwd })
+    : instance.resumeAgent(snaSessionId, config);
+}
+```
+
+この endpoint は tab focus、reload recovery、send preflight から何度呼ばれても安全であるべきです。
+
+## 5. Product context は user-turn 境界で注入する
+
+Metadata を独立した model turn として送らないでください。User message を forward する直前に context を作り、その message に product-owned tag を prepend / append します。
+
+```ts
+async function sendAgentMessage({ snaSessionId, message }) {
+  let finalMessage = message;
+
+  await reconcileSelectedModel(snaSessionId);
+
+  const pendingMeta = consumePendingSystemMeta(snaSessionId);
+  if (pendingMeta) finalMessage = `${pendingMeta}\n${finalMessage}`;
+
+  const retrievalContext = await maybeBuildRetrievalContext(snaSessionId, finalMessage);
+  if (retrievalContext) finalMessage += `\n${retrievalContext}`;
+
+  return snaForSnaSession(snaSessionId).sendMessage(snaSessionId, finalMessage);
+}
+```
+
+これにより runtime history はきれいに保たれます。Start/resume のあと agent が最初に見るのは、app の現在の world で補強された実際の user turn です。
+
+## 6. 重い状態変更は send まで遅延する
+
+Context folding、model change、runtime switch などの pending operation があるなら、次の user-turn 境界で適用します。User が送信した直後、model が応答するまでの自然な待ち時間に kill/resume/replay のコストを隠せます。
+
+安全な順序は次の通りです。
+
+1. Active SNA head を resolve します。
+2. Pending fork / fold operation を適用します。
+3. 選択された model / runtime を reconcile します。
+4. 最終 message context を作ります。
+5. `sendMessage` を呼びます。
+6. User message が persist されたあとに session change を broadcast します。
+
+User message が保存される前に新しい SNA head を broadcast すると、renderer が optimistic user message を含まない timeline に先に resubscribe してしまうことがあります。
+
+## 7. Permission はすべての client で subscribe する
+
+Permission subscription は WebSocket ごとです。Permission dialog が mount されたあとに cloud client が作られる可能性があるなら、その新しい client でも subscribe してください。
+
+```ts
+export async function subscribePermissions() {
+  await Promise.all(
+    [...clients.values()].map((client) =>
+      client.agent.subscribePermissions().catch(() => {}),
+    ),
+  );
+}
+
+export function respondPermission(snaSessionId: string, approved: boolean) {
+  return clientForSnaSession(snaSessionId)
+    .agent
+    .respondPermission(snaSessionId, approved);
+}
+```
+
+これがないと、cloud instance 上の agent が tool decision を待っているのに、UI は local SNA にしか subscribe していない状態になりえます。
+
+## 8. React subscription は app root に置く
+
+SNA event bridge は chat surface より上に mount します。Chat pane、route、side panel は agent が streaming 中でも unmount されることがあります。Root-level hook が WebSocket listener を維持し、event を store に流し込むべきです。
+
+```tsx
+function AppShell() {
+  const hydrateSessions = useSessionStore((state) => state.hydrate);
+  const sessions = useSessionStore((state) => state.sessions);
+  const sessionIds = useMemo(
+    () => sessions.flatMap((session) => session.snaSessionId ? [session.snaSessionId] : []),
+    [sessions],
+  );
+
+  useAgentEventStream();
+  const { pending, clearPending } = usePermissionRequests(sessionIds);
+
+  useEffect(() => {
+    hydrateSessions();
+    connectSna();
+    return () => disconnectSna();
+  }, [hydrateSessions]);
+
+  return (
+    <>
+      <AppRoutes />
+      {pending[0] && (
+        <PermissionDialog
+          request={pending[0]}
+          onDone={() => clearPending(pending[0].sessionId)}
+        />
+      )}
+    </>
+  );
+}
+```
+
+Event hook は listener を一度だけ登録し、session list が変わるたびに表示中または既知の SNA session を subscribe します。
+
+```ts
+function useAgentEventStream() {
+  const sessions = useSessionStore((state) => state.sessions);
+  const register = useMessageStore((state) => state.register);
+  const handleEvent = useMessageStore((state) => state.handleEvent);
+
+  useEffect(() => {
+    return onAgentEvent(({ session, cursor, event, isHistory }) => {
+      handleEvent(session, { cursor, event, isHistory });
+    });
+  }, [handleEvent]);
+
+  useEffect(() => {
+    const cleanups = sessions
+      .filter((session) => session.snaSessionId)
+      .map((session) => {
+        register(session.snaSessionId!, session.id);
+        subscribeAgent(session.snaSessionId!, { since: 0, tail: 200 }).catch(() => {});
+        return () => unsubscribeAgent(session.snaSessionId!).catch(() => {});
+      });
+
+    return () => cleanups.forEach((cleanup) => cleanup());
+  }, [sessions, register]);
+}
+```
+
+Permission UI も同じ理由で root に mount する方が安全です。これは現在選択中の chat panel の子 state ではなく、product state です。
+
+## いつ使うか
+
+| 状況 | この pattern を使うか |
+| --- | --- |
+| Product DB のない単一 CLI wrapper | 通常は不要です。SNA を直接呼んでください。 |
+| Local SNA と renderer UI を持つ Electron app | 使ってください。Command path と event path を分けます。 |
+| Local + cloud SNA instance を同時に扱う app | 使ってください。Client registry と event aggregator が必要です。 |
+| Retrieval、project、policy context を注入する app | 使ってください。Send-time context building を host に集約します。 |

--- a/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
@@ -1,0 +1,283 @@
+---
+title: Agentic app hosting
+description: 실제 앱 안에 SNA를 내장할 때 Loom에서 쓰는 제품 통합 패턴입니다.
+icon: AppWindow
+---
+
+Loom은 SNA를 일회성 chat endpoint로 쓰지 않고, local/cloud agent runtime으로 앱 안에 내장합니다. 제품이 project, tab, document, permission, background workflow를 agent 주변에 가지고 있을 때 아래 패턴이 유용합니다.
+
+## 1. 앱 세션과 SNA 세션을 분리하기
+
+제품에는 보통 자체 session 또는 project row가 있습니다. 그 row를 사용자에게 보이는 객체로 유지하고, 현재 붙어 있는 SNA session id를 별도 필드로 저장하십시오.
+
+```ts
+type AppSession = {
+  id: string;
+  name: string;
+  projectPath: string | null;
+  snaSessionId: string | null;
+  snaInstanceId: "local" | string;
+};
+```
+
+이 분리 덕분에 앱은 runtime process를 제품 객체로 착각하지 않고 rename, archive, move, fork를 처리할 수 있습니다. 앱 세션의 identity를 유지한 채 local SNA에서 cloud SNA로 옮기는 것도 가능합니다.
+
+한 앱 세션이 시간이 지나며 여러 SNA session head를 만들 수 있다면 link table을 두십시오.
+
+```sql
+CREATE TABLE session_sna_links (
+  session_id TEXT NOT NULL,
+  sna_session_id TEXT NOT NULL,
+  instance_id TEXT NOT NULL DEFAULT 'local',
+  source TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, sna_session_id)
+);
+```
+
+## 2. SNA instance마다 `SnaClient` 하나 사용하기
+
+WebSocket state는 connection 단위입니다. 앱이 local SNA와 cloud SNA instance를 동시에 다룰 수 있다면 instance마다 client를 cache하고, event는 하나의 listener set으로 fan-in하십시오.
+
+```ts
+import { SnaClient } from "@sna-sdk/client";
+
+const clients = new Map<string, SnaClient>();
+const eventListeners = new Set<(event: unknown) => void>();
+const permissionListeners = new Set<(event: unknown) => void>();
+
+function installAggregator(client: SnaClient) {
+  client.agent.onEvent((event) => {
+    for (const listener of eventListeners) listener(event);
+  });
+  client.agent.onPermissionRequest((event) => {
+    for (const listener of permissionListeners) listener(event);
+  });
+}
+
+export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
+  const existing = clients.get(instanceId);
+  if (existing) return existing;
+  if (!baseUrl) throw new Error(`baseUrl required for ${instanceId}`);
+
+  const client = new SnaClient({ baseUrl, ws: true, http: true });
+  clients.set(instanceId, client);
+  installAggregator(client);
+  client.connect();
+  client.agent.subscribePermissions().catch(() => {});
+  return client;
+}
+
+export function onAgentEventAll(listener: (event: unknown) => void) {
+  eventListeners.add(listener);
+  return () => eventListeners.delete(listener);
+}
+```
+
+핵심은 UI component가 특정 WebSocket이 아니라 앱 레벨 aggregator에 subscribe한다는 점입니다. 나중에 cloud instance가 추가되어도 UI를 remount하지 않고 해당 client를 aggregator에 붙일 수 있습니다.
+
+## 3. Command는 host를 통하고 event는 SNA로 직접 받기
+
+Loom은 경로를 분리합니다.
+
+| Path | Route | 이유 |
+| --- | --- | --- |
+| Lifecycle command | renderer → app host HTTP → SNA HTTP | Host가 앱 DB에서 config를 만들고, cloud instance를 깨우고, model selection을 reconcile하고, 제품 context를 주입할 수 있습니다. |
+| Event stream | renderer → SNA WebSocket | 모든 token을 앱 서버로 proxy하지 않고 UI가 낮은 latency로 runtime event를 받습니다. |
+
+Renderer에는 raw SNA call보다 domain wrapper를 노출하십시오.
+
+```ts
+export async function ensureAgentAlive(snaSessionId: string, isNewSession = false) {
+  const appSession = sessionStore.findBySnaId(snaSessionId);
+  await appFetch("/agent/ensure", {
+    method: "POST",
+    body: JSON.stringify({
+      appSessionId: appSession.id,
+      snaSessionId,
+      isNewSession,
+    }),
+  });
+}
+
+export async function sendMessage(snaSessionId: string, message: string) {
+  return appFetch("/agent/send", {
+    method: "POST",
+    body: JSON.stringify({ snaSessionId, message }),
+  });
+}
+
+export function subscribeAgent(snaSessionId: string) {
+  return clientForSnaSession(snaSessionId).agent.subscribe(snaSessionId, { since: 0 });
+}
+```
+
+Component는 `ensureAgentAlive`, `sendMessage`, `subscribeAgent` 같은 제품 verb만 알면 됩니다.
+
+## 4. `/agent/ensure`를 idempotent하게 만들기
+
+Start-vs-resume 판단은 host가 소유해야 합니다. UI가 runtime history 유무, cloud wake 필요 여부, remote container 안에서 유효한 cwd를 판단하게 하지 마십시오.
+
+```ts
+async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
+  const instance = snaForAppSession(appSessionId);
+  await wakeIfCloudInstance(instance);
+
+  const snaSessionId = requestedSnaId ?? await loadOrCreateSnaId(appSessionId);
+  if (await instance.isAlive(snaSessionId)) {
+    return { status: "already_alive", snaSessionId };
+  }
+
+  const { config, cwd } = await buildAgentConfig(appSessionId, snaSessionId);
+  await instance.createSession({
+    id: snaSessionId,
+    label: config.label ?? appSessionId,
+    cwd,
+    meta: debugMode ? { langfuseTrace: true } : undefined,
+  });
+
+  const hasHistory = await instance.getMessages(snaSessionId, { limit: 1 })
+    .then((res) => res.ok && res.data.messages.length > 0)
+    .catch(() => false);
+
+  return isNewSession || !hasHistory
+    ? instance.startAgent(snaSessionId, { ...config, force: true, cwd })
+    : instance.resumeAgent(snaSessionId, config);
+}
+```
+
+이 endpoint는 tab focus, reload recovery, send preflight에서 반복 호출되어도 안전해야 합니다.
+
+## 5. 제품 context는 user-turn 경계에서 주입하기
+
+Metadata를 별도 model turn으로 보내지 마십시오. 사용자 message를 forwarding하기 직전에 context를 만들고, 그 message에 제품 소유 tag를 prepend/append하십시오.
+
+```ts
+async function sendAgentMessage({ snaSessionId, message }) {
+  let finalMessage = message;
+
+  await reconcileSelectedModel(snaSessionId);
+
+  const pendingMeta = consumePendingSystemMeta(snaSessionId);
+  if (pendingMeta) finalMessage = `${pendingMeta}\n${finalMessage}`;
+
+  const retrievalContext = await maybeBuildRetrievalContext(snaSessionId, finalMessage);
+  if (retrievalContext) finalMessage += `\n${retrievalContext}`;
+
+  return snaForSnaSession(snaSessionId).sendMessage(snaSessionId, finalMessage);
+}
+```
+
+이렇게 하면 runtime history가 깨끗하게 유지됩니다. Start/resume 이후 agent가 처음 보는 것은 앱의 현재 world로 보강된 실제 사용자 turn입니다.
+
+## 6. 비용 큰 상태 변경은 send 시점까지 미루기
+
+Context folding, model change, runtime switch 같은 pending operation이 있다면 다음 user-turn 경계에서 적용하십시오. 사용자가 보낸 직후 model이 응답하기 전의 자연스러운 대기 시간이 kill/resume/replay 비용을 가려줍니다.
+
+안전한 순서는 다음과 같습니다.
+
+1. Active SNA head를 resolve합니다.
+2. Pending fork/fold operation을 적용합니다.
+3. 선택된 model/runtime을 reconcile합니다.
+4. 최종 message context를 만듭니다.
+5. `sendMessage`를 호출합니다.
+6. User message가 persist된 뒤 session 변경을 broadcast합니다.
+
+User message가 저장되기 전에 새 SNA head를 broadcast하면 renderer가 optimistic user message가 없는 timeline에 먼저 resubscribe할 수 있습니다.
+
+## 7. Permission은 모든 client에서 subscribe하기
+
+Permission subscription은 WebSocket별입니다. Permission dialog가 mount된 뒤 cloud client가 생성될 수 있다면, 새 client에도 subscribe해야 합니다.
+
+```ts
+export async function subscribePermissions() {
+  await Promise.all(
+    [...clients.values()].map((client) =>
+      client.agent.subscribePermissions().catch(() => {}),
+    ),
+  );
+}
+
+export function respondPermission(snaSessionId: string, approved: boolean) {
+  return clientForSnaSession(snaSessionId)
+    .agent
+    .respondPermission(snaSessionId, approved);
+}
+```
+
+이 처리가 없으면 cloud instance의 agent가 tool decision을 기다리는데 UI는 local SNA에만 subscribe한 상태가 될 수 있습니다.
+
+## 8. React subscription은 app root에 유지하기
+
+SNA event bridge는 chat surface보다 위에 mount하십시오. Chat pane, route, side panel은 agent가 streaming 중일 때도 unmount될 수 있습니다. Root-level hook이 WebSocket listener를 유지하고 event를 store로 전달해야 합니다.
+
+```tsx
+function AppShell() {
+  const hydrateSessions = useSessionStore((state) => state.hydrate);
+  const sessions = useSessionStore((state) => state.sessions);
+  const sessionIds = useMemo(
+    () => sessions.flatMap((session) => session.snaSessionId ? [session.snaSessionId] : []),
+    [sessions],
+  );
+
+  useAgentEventStream();
+  const { pending, clearPending } = usePermissionRequests(sessionIds);
+
+  useEffect(() => {
+    hydrateSessions();
+    connectSna();
+    return () => disconnectSna();
+  }, [hydrateSessions]);
+
+  return (
+    <>
+      <AppRoutes />
+      {pending[0] && (
+        <PermissionDialog
+          request={pending[0]}
+          onDone={() => clearPending(pending[0].sessionId)}
+        />
+      )}
+    </>
+  );
+}
+```
+
+Event hook은 한 번만 listener를 등록하고, session list가 바뀔 때 보이는/알려진 SNA session들을 subscribe해야 합니다.
+
+```ts
+function useAgentEventStream() {
+  const sessions = useSessionStore((state) => state.sessions);
+  const register = useMessageStore((state) => state.register);
+  const handleEvent = useMessageStore((state) => state.handleEvent);
+
+  useEffect(() => {
+    return onAgentEvent(({ session, cursor, event, isHistory }) => {
+      handleEvent(session, { cursor, event, isHistory });
+    });
+  }, [handleEvent]);
+
+  useEffect(() => {
+    const cleanups = sessions
+      .filter((session) => session.snaSessionId)
+      .map((session) => {
+        register(session.snaSessionId!, session.id);
+        subscribeAgent(session.snaSessionId!, { since: 0, tail: 200 }).catch(() => {});
+        return () => unsubscribeAgent(session.snaSessionId!).catch(() => {});
+      });
+
+    return () => cleanups.forEach((cleanup) => cleanup());
+  }, [sessions, register]);
+}
+```
+
+Permission UI도 같은 이유로 root에 mount하는 편이 안전합니다. 이것은 현재 선택된 chat panel의 자식 상태가 아니라 제품 상태입니다.
+
+## 언제 쓰나
+
+| 상황 | 이 패턴 사용? |
+| --- | --- |
+| 제품 DB가 없는 단일 CLI wrapper | 보통 필요 없습니다. SNA를 직접 호출하십시오. |
+| Local SNA와 renderer UI가 있는 Electron 앱 | 사용하십시오. Command와 event path를 분리하십시오. |
+| Local + cloud SNA instance를 함께 쓰는 앱 | 사용하십시오. Client registry와 event aggregator가 필요합니다. |
+| Retrieval, project, policy context를 주입하는 앱 | 사용하십시오. Send-time context building을 host에 모으십시오. |

--- a/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
@@ -8,21 +8,30 @@ Loom은 SNA를 일회성 chat endpoint로 쓰지 않고, local/cloud agent runti
 
 ## 1. 앱 세션과 SNA 세션을 분리하기
 
-제품에는 보통 자체 session 또는 project row가 있습니다. 그 row를 사용자에게 보이는 객체로 유지하고, 현재 붙어 있는 SNA session id를 별도 필드로 저장하십시오.
+제품에는 보통 자체 session 또는 project row가 있습니다. 그 row를 사용자에게 보이는 객체로 유지하고, 현재 붙어 있는 SNA session id를 별도 필드로 저장합니다.
 
 ```ts
 type AppSession = {
+  // Product가 소유하는 안정적인 identity입니다. Rename/archive/fork는 이 id를 기준으로 처리합니다.
   id: string;
+
+  // User-facing label입니다. Runtime process label과 분리해두면 migration이 쉬워집니다.
   name: string;
+
+  // Local project가 없을 수도 있으므로 nullable로 둡니다.
   projectPath: string | null;
+
+  // 현재 붙어 있는 SNA head입니다. Runtime switch나 fork 때 바뀔 수 있습니다.
   snaSessionId: string | null;
+
+  // Local SNA와 cloud SNA instance를 같은 product model로 다루기 위한 field입니다.
   snaInstanceId: "local" | string;
 };
 ```
 
 이 분리 덕분에 앱은 runtime process를 제품 객체로 착각하지 않고 rename, archive, move, fork를 처리할 수 있습니다. 앱 세션의 identity를 유지한 채 local SNA에서 cloud SNA로 옮기는 것도 가능합니다.
 
-한 앱 세션이 시간이 지나며 여러 SNA session head를 만들 수 있다면 link table을 두십시오.
+한 앱 세션이 시간이 지나며 여러 SNA session head를 만들 수 있다면 link table을 두는 패턴이 다루기 쉽습니다.
 
 ```sql
 CREATE TABLE session_sna_links (
@@ -37,25 +46,32 @@ CREATE TABLE session_sna_links (
 
 ## 2. SNA instance마다 `SnaClient` 하나 사용하기
 
-WebSocket state는 connection 단위입니다. 앱이 local SNA와 cloud SNA instance를 동시에 다룰 수 있다면 instance마다 client를 cache하고, event는 하나의 listener set으로 fan-in하십시오.
+WebSocket state는 connection 단위입니다. 앱이 local SNA와 cloud SNA instance를 동시에 다룰 수 있다면 instance마다 client를 cache하고, event는 하나의 listener set으로 fan-in합니다.
 
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
+// Instance id마다 client를 하나만 만듭니다. WebSocket 중복 연결을 막는 역할입니다.
 const clients = new Map<string, SnaClient>();
+
+// UI는 특정 client가 아니라 app-level listener set에 subscribe합니다.
 const eventListeners = new Set<(event: unknown) => void>();
 const permissionListeners = new Set<(event: unknown) => void>();
 
 function installAggregator(client: SnaClient) {
+  // Runtime event를 하나의 app event bus로 모읍니다.
   client.agent.onEvent((event) => {
     for (const listener of eventListeners) listener(event);
   });
+
+  // Permission request도 client별로 들어오므로 같은 방식으로 fan-in합니다.
   client.agent.onPermissionRequest((event) => {
     for (const listener of permissionListeners) listener(event);
   });
 }
 
 export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
+  // 이미 연결된 instance라면 같은 client를 재사용합니다.
   const existing = clients.get(instanceId);
   if (existing) return existing;
   if (!baseUrl) throw new Error(`baseUrl required for ${instanceId}`);
@@ -63,12 +79,15 @@ export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
   const client = new SnaClient({ baseUrl, ws: true, http: true });
   clients.set(instanceId, client);
   installAggregator(client);
+
+  // connect와 permission subscription은 client 생성 직후 한 번만 수행합니다.
   client.connect();
   client.agent.subscribePermissions().catch(() => {});
   return client;
 }
 
 export function onAgentEventAll(listener: (event: unknown) => void) {
+  // React hook에서 cleanup으로 바로 쓸 수 있도록 unsubscribe 함수를 반환합니다.
   eventListeners.add(listener);
   return () => eventListeners.delete(listener);
 }
@@ -85,11 +104,14 @@ Loom은 경로를 분리합니다.
 | Lifecycle command | renderer → app host HTTP → SNA HTTP | Host가 앱 DB에서 config를 만들고, cloud instance를 깨우고, model selection을 reconcile하고, 제품 context를 주입할 수 있습니다. |
 | Event stream | renderer → SNA WebSocket | 모든 token을 앱 서버로 proxy하지 않고 UI가 낮은 latency로 runtime event를 받습니다. |
 
-Renderer에는 raw SNA call보다 domain wrapper를 노출하십시오.
+Renderer에는 raw SNA call보다 domain wrapper를 노출하는 식으로 경계를 잡습니다.
 
 ```ts
 export async function ensureAgentAlive(snaSessionId: string, isNewSession = false) {
+  // Renderer는 SNA id를 받더라도 product session으로 다시 resolve합니다.
   const appSession = sessionStore.findBySnaId(snaSessionId);
+
+  // Host endpoint가 cwd, model, cloud wake, context injection 같은 product logic을 소유합니다.
   await appFetch("/agent/ensure", {
     method: "POST",
     body: JSON.stringify({
@@ -101,6 +123,7 @@ export async function ensureAgentAlive(snaSessionId: string, isNewSession = fals
 }
 
 export async function sendMessage(snaSessionId: string, message: string) {
+  // Send도 host를 거치면 pending model/runtime change를 user-turn 경계에서 적용할 수 있습니다.
   return appFetch("/agent/send", {
     method: "POST",
     body: JSON.stringify({ snaSessionId, message }),
@@ -108,6 +131,7 @@ export async function sendMessage(snaSessionId: string, message: string) {
 }
 
 export function subscribeAgent(snaSessionId: string) {
+  // Event stream은 token latency를 줄이기 위해 SNA WebSocket에 직접 붙습니다.
   return clientForSnaSession(snaSessionId).agent.subscribe(snaSessionId, { since: 0 });
 }
 ```
@@ -116,18 +140,21 @@ Component는 `ensureAgentAlive`, `sendMessage`, `subscribeAgent` 같은 제품 v
 
 ## 4. `/agent/ensure`를 idempotent하게 만들기
 
-Start-vs-resume 판단은 host가 소유해야 합니다. UI가 runtime history 유무, cloud wake 필요 여부, remote container 안에서 유효한 cwd를 판단하게 하지 마십시오.
+Start-vs-resume 판단은 host가 소유하게 두면 흐름이 단순해집니다. UI가 runtime history 유무, cloud wake 필요 여부, remote container 안에서 유효한 cwd를 판단하지 않게 두면 안정적입니다.
 
 ```ts
 async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
+  // App session을 기준으로 local/cloud SNA instance를 고릅니다.
   const instance = snaForAppSession(appSessionId);
   await wakeIfCloudInstance(instance);
 
+  // 요청 id가 없으면 product DB에 저장된 SNA id를 쓰거나 새로 만듭니다.
   const snaSessionId = requestedSnaId ?? await loadOrCreateSnaId(appSessionId);
   if (await instance.isAlive(snaSessionId)) {
     return { status: "already_alive", snaSessionId };
   }
 
+  // Agent config는 host에서 조립합니다. UI가 model args나 cwd를 직접 만들지 않습니다.
   const { config, cwd } = await buildAgentConfig(appSessionId, snaSessionId);
   await instance.createSession({
     id: snaSessionId,
@@ -140,6 +167,7 @@ async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
     .then((res) => res.ok && res.data.messages.length > 0)
     .catch(() => false);
 
+  // 새 session이거나 history가 없으면 start, 기존 head라면 resume으로 복구합니다.
   return isNewSession || !hasHistory
     ? instance.startAgent(snaSessionId, { ...config, force: true, cwd })
     : instance.resumeAgent(snaSessionId, config);
@@ -150,20 +178,24 @@ async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
 
 ## 5. 제품 context는 user-turn 경계에서 주입하기
 
-Metadata를 별도 model turn으로 보내지 마십시오. 사용자 message를 forwarding하기 직전에 context를 만들고, 그 message에 제품 소유 tag를 prepend/append하십시오.
+Metadata를 별도 model turn으로 보내기보다, 사용자 message를 forwarding하기 직전에 context를 만들고 그 message에 제품 소유 tag를 prepend/append하면 runtime history가 깨끗합니다.
 
 ```ts
 async function sendAgentMessage({ snaSessionId, message }) {
   let finalMessage = message;
 
+  // Pending model/runtime 선택은 실제 user turn 직전에 reconcile합니다.
   await reconcileSelectedModel(snaSessionId);
 
+  // 한 번만 소비되어야 하는 system metadata는 user turn에 붙여 보냅니다.
   const pendingMeta = consumePendingSystemMeta(snaSessionId);
   if (pendingMeta) finalMessage = `${pendingMeta}\n${finalMessage}`;
 
+  // Retrieval context도 현재 user message 기준으로 계산해야 stale context가 줄어듭니다.
   const retrievalContext = await maybeBuildRetrievalContext(snaSessionId, finalMessage);
   if (retrievalContext) finalMessage += `\n${retrievalContext}`;
 
+  // 최종적으로 agent가 보는 것은 context가 붙은 실제 user turn입니다.
   return snaForSnaSession(snaSessionId).sendMessage(snaSessionId, finalMessage);
 }
 ```
@@ -172,7 +204,7 @@ async function sendAgentMessage({ snaSessionId, message }) {
 
 ## 6. 비용 큰 상태 변경은 send 시점까지 미루기
 
-Context folding, model change, runtime switch 같은 pending operation이 있다면 다음 user-turn 경계에서 적용하십시오. 사용자가 보낸 직후 model이 응답하기 전의 자연스러운 대기 시간이 kill/resume/replay 비용을 가려줍니다.
+Context folding, model change, runtime switch 같은 pending operation은 다음 user-turn 경계에서 적용합니다. 사용자가 보낸 직후 model이 응답하기 전의 자연스러운 대기 시간이 kill/resume/replay 비용을 가려줍니다.
 
 안전한 순서는 다음과 같습니다.
 
@@ -209,21 +241,26 @@ export function respondPermission(snaSessionId: string, approved: boolean) {
 
 ## 8. React subscription은 app root에 유지하기
 
-SNA event bridge는 chat surface보다 위에 mount하십시오. Chat pane, route, side panel은 agent가 streaming 중일 때도 unmount될 수 있습니다. Root-level hook이 WebSocket listener를 유지하고 event를 store로 전달해야 합니다.
+SNA event bridge는 chat surface보다 위에 mount해두면 route unmount에 안전합니다. Chat pane, route, side panel은 agent가 streaming 중일 때도 unmount될 수 있습니다. Root-level hook이 WebSocket listener를 유지하고 event를 store로 전달하면 안정적입니다.
 
 ```tsx
 function AppShell() {
+  // App boot 때 product sessions를 먼저 hydrate합니다.
   const hydrateSessions = useSessionStore((state) => state.hydrate);
   const sessions = useSessionStore((state) => state.sessions);
+
+  // Permission dialog는 현재 route뿐 아니라 모든 known session을 볼 수 있어야 합니다.
   const sessionIds = useMemo(
     () => sessions.flatMap((session) => session.snaSessionId ? [session.snaSessionId] : []),
     [sessions],
   );
 
+  // 이 hook은 route보다 오래 살아야 하므로 app root에서 호출합니다.
   useAgentEventStream();
   const { pending, clearPending } = usePermissionRequests(sessionIds);
 
   useEffect(() => {
+    // SNA connection lifecycle도 root component가 소유합니다.
     hydrateSessions();
     connectSna();
     return () => disconnectSna();
@@ -252,6 +289,7 @@ function useAgentEventStream() {
   const handleEvent = useMessageStore((state) => state.handleEvent);
 
   useEffect(() => {
+    // Listener는 한 번만 설치하고, 들어오는 event는 store에 정규화해서 넣습니다.
     return onAgentEvent(({ session, cursor, event, isHistory }) => {
       handleEvent(session, { cursor, event, isHistory });
     });
@@ -261,8 +299,13 @@ function useAgentEventStream() {
     const cleanups = sessions
       .filter((session) => session.snaSessionId)
       .map((session) => {
+        // Product session id와 SNA session id의 mapping을 store에 알려줍니다.
         register(session.snaSessionId!, session.id);
+
+        // Mount 시 최근 event를 tail로 복구하고 이후 stream을 이어받습니다.
         subscribeAgent(session.snaSessionId!, { since: 0, tail: 200 }).catch(() => {});
+
+        // Session list가 바뀌면 이전 subscription을 정리합니다.
         return () => unsubscribeAgent(session.snaSessionId!).catch(() => {});
       });
 
@@ -277,7 +320,7 @@ Permission UI도 같은 이유로 root에 mount하는 편이 안전합니다. �
 
 | 상황 | 이 패턴 사용? |
 | --- | --- |
-| 제품 DB가 없는 단일 CLI wrapper | 보통 필요 없습니다. SNA를 직접 호출하십시오. |
-| Local SNA와 renderer UI가 있는 Electron 앱 | 사용하십시오. Command와 event path를 분리하십시오. |
-| Local + cloud SNA instance를 함께 쓰는 앱 | 사용하십시오. Client registry와 event aggregator가 필요합니다. |
-| Retrieval, project, policy context를 주입하는 앱 | 사용하십시오. Send-time context building을 host에 모으십시오. |
+| 제품 DB가 없는 단일 CLI wrapper | 보통은 필요 없습니다. SNA를 직접 호출하는 편이 단순합니다. |
+| Local SNA와 renderer UI가 있는 Electron 앱 | 잘 맞습니다. Command와 event path를 분리하면 좋습니다. |
+| Local + cloud SNA instance를 함께 쓰는 앱 | 잘 맞습니다. Client registry와 event aggregator가 필요합니다. |
+| Retrieval, project, policy context를 주입하는 앱 | 잘 맞습니다. Send-time context building을 host에 모으면 다루기 쉽습니다. |

--- a/apps/docs/content/docs/cookbook/agentic-apps.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.mdx
@@ -12,10 +12,19 @@ Your product likely has its own session or project row. Keep that row as the use
 
 ```ts
 type AppSession = {
+  // App-owned identity. Rename/archive/fork should target this id.
   id: string;
+
+  // User-facing label, separate from any runtime process label.
   name: string;
+
+  // Some sessions may not be attached to a local project yet.
   projectPath: string | null;
+
+  // Active SNA head. This can change after runtime switch, fold, or fork.
   snaSessionId: string | null;
+
+  // Lets the same app model point at local SNA or a cloud SNA instance.
   snaInstanceId: "local" | string;
 };
 ```
@@ -42,20 +51,27 @@ WebSocket state belongs to a connection. If your app can talk to local SNA and c
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
+// One client per instance prevents duplicate WebSocket connections.
 const clients = new Map<string, SnaClient>();
+
+// UI subscribes to the app-level listener set, not to a specific client.
 const eventListeners = new Set<(event: unknown) => void>();
 const permissionListeners = new Set<(event: unknown) => void>();
 
 function installAggregator(client: SnaClient) {
+  // Fan runtime events into one product event bus.
   client.agent.onEvent((event) => {
     for (const listener of eventListeners) listener(event);
   });
+
+  // Permission requests are also connection-scoped, so fan them in too.
   client.agent.onPermissionRequest((event) => {
     for (const listener of permissionListeners) listener(event);
   });
 }
 
 export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
+  // Reuse the existing client if this instance is already connected.
   const existing = clients.get(instanceId);
   if (existing) return existing;
   if (!baseUrl) throw new Error(`baseUrl required for ${instanceId}`);
@@ -63,12 +79,15 @@ export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
   const client = new SnaClient({ baseUrl, ws: true, http: true });
   clients.set(instanceId, client);
   installAggregator(client);
+
+  // Connect and subscribe once, when the client is created.
   client.connect();
   client.agent.subscribePermissions().catch(() => {});
   return client;
 }
 
 export function onAgentEventAll(listener: (event: unknown) => void) {
+  // Returning cleanup makes this easy to use from React effects.
   eventListeners.add(listener);
   return () => eventListeners.delete(listener);
 }
@@ -89,7 +108,10 @@ In the renderer, expose a domain wrapper rather than raw SNA calls:
 
 ```ts
 export async function ensureAgentAlive(snaSessionId: string, isNewSession = false) {
+  // The renderer may have an SNA id, but the host owns the app session row.
   const appSession = sessionStore.findBySnaId(snaSessionId);
+
+  // The host can build cwd/model/context and wake cloud instances if needed.
   await appFetch("/agent/ensure", {
     method: "POST",
     body: JSON.stringify({
@@ -101,6 +123,7 @@ export async function ensureAgentAlive(snaSessionId: string, isNewSession = fals
 }
 
 export async function sendMessage(snaSessionId: string, message: string) {
+  // Sending through the host lets pending model/runtime changes apply at the user-turn boundary.
   return appFetch("/agent/send", {
     method: "POST",
     body: JSON.stringify({ snaSessionId, message }),
@@ -108,6 +131,7 @@ export async function sendMessage(snaSessionId: string, message: string) {
 }
 
 export function subscribeAgent(snaSessionId: string) {
+  // Events stay direct to SNA for low token latency.
   return clientForSnaSession(snaSessionId).agent.subscribe(snaSessionId, { since: 0 });
 }
 ```
@@ -120,14 +144,17 @@ The host should own start-vs-resume. The UI should not decide whether a runtime 
 
 ```ts
 async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
+  // Pick local or cloud SNA from the product session, not from UI state.
   const instance = snaForAppSession(appSessionId);
   await wakeIfCloudInstance(instance);
 
+  // Reuse the stored SNA id when possible; create one only when needed.
   const snaSessionId = requestedSnaId ?? await loadOrCreateSnaId(appSessionId);
   if (await instance.isAlive(snaSessionId)) {
     return { status: "already_alive", snaSessionId };
   }
 
+  // The host assembles agent config so renderer code stays domain-level.
   const { config, cwd } = await buildAgentConfig(appSessionId, snaSessionId);
   await instance.createSession({
     id: snaSessionId,
@@ -140,6 +167,7 @@ async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
     .then((res) => res.ok && res.data.messages.length > 0)
     .catch(() => false);
 
+  // Start empty/new heads, resume heads that already have normalized history.
   return isNewSession || !hasHistory
     ? instance.startAgent(snaSessionId, { ...config, force: true, cwd })
     : instance.resumeAgent(snaSessionId, config);
@@ -156,14 +184,18 @@ Avoid sending metadata as its own model turn. Build the context right before for
 async function sendAgentMessage({ snaSessionId, message }) {
   let finalMessage = message;
 
+  // Apply pending model/runtime choices immediately before the real user turn.
   await reconcileSelectedModel(snaSessionId);
 
+  // One-time system metadata rides with the user's turn instead of becoming its own model turn.
   const pendingMeta = consumePendingSystemMeta(snaSessionId);
   if (pendingMeta) finalMessage = `${pendingMeta}\n${finalMessage}`;
 
+  // Retrieval should be calculated from the current user text to avoid stale context.
   const retrievalContext = await maybeBuildRetrievalContext(snaSessionId, finalMessage);
   if (retrievalContext) finalMessage += `\n${retrievalContext}`;
 
+  // The agent receives one final user turn enriched with product context.
   return snaForSnaSession(snaSessionId).sendMessage(snaSessionId, finalMessage);
 }
 ```
@@ -213,17 +245,22 @@ Mount the SNA event bridge above the chat surface. Chat panes, routes, and side 
 
 ```tsx
 function AppShell() {
+  // Product session hydration belongs at app boot.
   const hydrateSessions = useSessionStore((state) => state.hydrate);
   const sessions = useSessionStore((state) => state.sessions);
+
+  // Permission UI needs every known session, not only the current route.
   const sessionIds = useMemo(
     () => sessions.flatMap((session) => session.snaSessionId ? [session.snaSessionId] : []),
     [sessions],
   );
 
+  // Keep the event bridge mounted above routes and chat panes.
   useAgentEventStream();
   const { pending, clearPending } = usePermissionRequests(sessionIds);
 
   useEffect(() => {
+    // The root owns SNA connection lifecycle.
     hydrateSessions();
     connectSna();
     return () => disconnectSna();
@@ -252,6 +289,7 @@ function useAgentEventStream() {
   const handleEvent = useMessageStore((state) => state.handleEvent);
 
   useEffect(() => {
+    // Install the global event listener once and normalize events into the store.
     return onAgentEvent(({ session, cursor, event, isHistory }) => {
       handleEvent(session, { cursor, event, isHistory });
     });
@@ -261,8 +299,13 @@ function useAgentEventStream() {
     const cleanups = sessions
       .filter((session) => session.snaSessionId)
       .map((session) => {
+        // Tell the store how app sessions map to SNA sessions.
         register(session.snaSessionId!, session.id);
+
+        // Recover recent events on mount, then continue streaming.
         subscribeAgent(session.snaSessionId!, { since: 0, tail: 200 }).catch(() => {});
+
+        // Clean up old subscriptions when the session list changes.
         return () => unsubscribeAgent(session.snaSessionId!).catch(() => {});
       });
 

--- a/apps/docs/content/docs/cookbook/agentic-apps.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.mdx
@@ -1,0 +1,283 @@
+---
+title: Agentic app hosting
+description: Product integration patterns from Loom for embedding SNA inside a real app.
+icon: AppWindow
+---
+
+Loom embeds SNA as a local and cloud-capable agent runtime rather than treating it as a throwaway chat endpoint. These patterns are useful when a product owns projects, tabs, documents, permissions, and background workflows around an agent.
+
+## 1. Keep app sessions separate from SNA sessions
+
+Your product likely has its own session or project row. Keep that row as the user-facing object, then store the active SNA session id on it.
+
+```ts
+type AppSession = {
+  id: string;
+  name: string;
+  projectPath: string | null;
+  snaSessionId: string | null;
+  snaInstanceId: "local" | string;
+};
+```
+
+This separation lets the app rename, archive, move, or fork its own session without pretending the runtime process is the product object. It also lets one app session migrate from local SNA to a cloud SNA instance while preserving the app-level identity.
+
+Keep a link table if a single app session can produce multiple SNA session heads over time:
+
+```sql
+CREATE TABLE session_sna_links (
+  session_id TEXT NOT NULL,
+  sna_session_id TEXT NOT NULL,
+  instance_id TEXT NOT NULL DEFAULT 'local',
+  source TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, sna_session_id)
+);
+```
+
+## 2. Use one `SnaClient` per SNA instance
+
+WebSocket state belongs to a connection. If your app can talk to local SNA and cloud SNA instances at the same time, cache a client per instance and fan events into one listener set.
+
+```ts
+import { SnaClient } from "@sna-sdk/client";
+
+const clients = new Map<string, SnaClient>();
+const eventListeners = new Set<(event: unknown) => void>();
+const permissionListeners = new Set<(event: unknown) => void>();
+
+function installAggregator(client: SnaClient) {
+  client.agent.onEvent((event) => {
+    for (const listener of eventListeners) listener(event);
+  });
+  client.agent.onPermissionRequest((event) => {
+    for (const listener of permissionListeners) listener(event);
+  });
+}
+
+export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
+  const existing = clients.get(instanceId);
+  if (existing) return existing;
+  if (!baseUrl) throw new Error(`baseUrl required for ${instanceId}`);
+
+  const client = new SnaClient({ baseUrl, ws: true, http: true });
+  clients.set(instanceId, client);
+  installAggregator(client);
+  client.connect();
+  client.agent.subscribePermissions().catch(() => {});
+  return client;
+}
+
+export function onAgentEventAll(listener: (event: unknown) => void) {
+  eventListeners.add(listener);
+  return () => eventListeners.delete(listener);
+}
+```
+
+The important part is that UI components subscribe to the app-level aggregator, not to a specific WebSocket. When a cloud instance appears later, its client can join the aggregator without remounting the UI.
+
+## 3. Route commands through the host, events through SNA
+
+Loom uses a split path:
+
+| Path | Route | Why |
+| --- | --- | --- |
+| Lifecycle commands | renderer → app host HTTP → SNA HTTP | The host can build config from app DB, wake cloud instances, reconcile model selection, and inject product context. |
+| Event stream | renderer → SNA WebSocket | The UI receives low-latency runtime events without proxying every token through the app server. |
+
+In the renderer, expose a domain wrapper rather than raw SNA calls:
+
+```ts
+export async function ensureAgentAlive(snaSessionId: string, isNewSession = false) {
+  const appSession = sessionStore.findBySnaId(snaSessionId);
+  await appFetch("/agent/ensure", {
+    method: "POST",
+    body: JSON.stringify({
+      appSessionId: appSession.id,
+      snaSessionId,
+      isNewSession,
+    }),
+  });
+}
+
+export async function sendMessage(snaSessionId: string, message: string) {
+  return appFetch("/agent/send", {
+    method: "POST",
+    body: JSON.stringify({ snaSessionId, message }),
+  });
+}
+
+export function subscribeAgent(snaSessionId: string) {
+  return clientForSnaSession(snaSessionId).agent.subscribe(snaSessionId, { since: 0 });
+}
+```
+
+Components stay small because they talk to product verbs: `ensureAgentAlive`, `sendMessage`, `subscribeAgent`.
+
+## 4. Make `/agent/ensure` idempotent
+
+The host should own start-vs-resume. The UI should not decide whether a runtime has history, whether a cloud instance needs waking, or which cwd exists inside the remote container.
+
+```ts
+async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
+  const instance = snaForAppSession(appSessionId);
+  await wakeIfCloudInstance(instance);
+
+  const snaSessionId = requestedSnaId ?? await loadOrCreateSnaId(appSessionId);
+  if (await instance.isAlive(snaSessionId)) {
+    return { status: "already_alive", snaSessionId };
+  }
+
+  const { config, cwd } = await buildAgentConfig(appSessionId, snaSessionId);
+  await instance.createSession({
+    id: snaSessionId,
+    label: config.label ?? appSessionId,
+    cwd,
+    meta: debugMode ? { langfuseTrace: true } : undefined,
+  });
+
+  const hasHistory = await instance.getMessages(snaSessionId, { limit: 1 })
+    .then((res) => res.ok && res.data.messages.length > 0)
+    .catch(() => false);
+
+  return isNewSession || !hasHistory
+    ? instance.startAgent(snaSessionId, { ...config, force: true, cwd })
+    : instance.resumeAgent(snaSessionId, config);
+}
+```
+
+This endpoint should be safe to call repeatedly from tab focus, reload recovery, or "send" preflight.
+
+## 5. Inject product context at the user-turn boundary
+
+Avoid sending metadata as its own model turn. Build the context right before forwarding the user's message, then prepend or append product-owned tags to that message.
+
+```ts
+async function sendAgentMessage({ snaSessionId, message }) {
+  let finalMessage = message;
+
+  await reconcileSelectedModel(snaSessionId);
+
+  const pendingMeta = consumePendingSystemMeta(snaSessionId);
+  if (pendingMeta) finalMessage = `${pendingMeta}\n${finalMessage}`;
+
+  const retrievalContext = await maybeBuildRetrievalContext(snaSessionId, finalMessage);
+  if (retrievalContext) finalMessage += `\n${retrievalContext}`;
+
+  return snaForSnaSession(snaSessionId).sendMessage(snaSessionId, finalMessage);
+}
+```
+
+This keeps runtime history clean: the first thing the agent sees after start/resume is the user's actual turn, enriched with the app's current world.
+
+## 6. Defer expensive state changes until send
+
+If the app has pending operations such as context folding, model changes, or runtime switches, apply them at the next user-turn boundary. The user's natural pause before the model responds hides the cost of kill/resume/replay.
+
+The safe ordering is:
+
+1. Resolve the active SNA head.
+2. Apply pending fork or fold operations.
+3. Reconcile selected model/runtime.
+4. Build final message context.
+5. Call `sendMessage`.
+6. Broadcast session changes after the user message is persisted.
+
+Broadcasting a new SNA head before the user message lands can make the renderer resubscribe to a timeline that does not contain the optimistic user message yet.
+
+## 7. Subscribe permissions on every client
+
+Permission subscriptions are per WebSocket. If a cloud client is created after the permission dialog mounted, subscribe that new client too.
+
+```ts
+export async function subscribePermissions() {
+  await Promise.all(
+    [...clients.values()].map((client) =>
+      client.agent.subscribePermissions().catch(() => {}),
+    ),
+  );
+}
+
+export function respondPermission(snaSessionId: string, approved: boolean) {
+  return clientForSnaSession(snaSessionId)
+    .agent
+    .respondPermission(snaSessionId, approved);
+}
+```
+
+Without this, the agent can be waiting for a tool decision on a cloud instance while the UI only subscribed to the local SNA.
+
+## 8. Keep React subscriptions at the app root
+
+Mount the SNA event bridge above the chat surface. Chat panes, routes, and side panels can unmount while an agent is still streaming. A root-level hook keeps the WebSocket listener alive and routes events into a store.
+
+```tsx
+function AppShell() {
+  const hydrateSessions = useSessionStore((state) => state.hydrate);
+  const sessions = useSessionStore((state) => state.sessions);
+  const sessionIds = useMemo(
+    () => sessions.flatMap((session) => session.snaSessionId ? [session.snaSessionId] : []),
+    [sessions],
+  );
+
+  useAgentEventStream();
+  const { pending, clearPending } = usePermissionRequests(sessionIds);
+
+  useEffect(() => {
+    hydrateSessions();
+    connectSna();
+    return () => disconnectSna();
+  }, [hydrateSessions]);
+
+  return (
+    <>
+      <AppRoutes />
+      {pending[0] && (
+        <PermissionDialog
+          request={pending[0]}
+          onDone={() => clearPending(pending[0].sessionId)}
+        />
+      )}
+    </>
+  );
+}
+```
+
+The event hook should register once, then subscribe each visible or known SNA session as the session list changes.
+
+```ts
+function useAgentEventStream() {
+  const sessions = useSessionStore((state) => state.sessions);
+  const register = useMessageStore((state) => state.register);
+  const handleEvent = useMessageStore((state) => state.handleEvent);
+
+  useEffect(() => {
+    return onAgentEvent(({ session, cursor, event, isHistory }) => {
+      handleEvent(session, { cursor, event, isHistory });
+    });
+  }, [handleEvent]);
+
+  useEffect(() => {
+    const cleanups = sessions
+      .filter((session) => session.snaSessionId)
+      .map((session) => {
+        register(session.snaSessionId!, session.id);
+        subscribeAgent(session.snaSessionId!, { since: 0, tail: 200 }).catch(() => {});
+        return () => unsubscribeAgent(session.snaSessionId!).catch(() => {});
+      });
+
+    return () => cleanups.forEach((cleanup) => cleanup());
+  }, [sessions, register]);
+}
+```
+
+This is the same reason permission UI should be root-mounted. It is product state, not a child of the currently selected chat panel.
+
+## When this pattern fits
+
+| Situation | Use this pattern? |
+| --- | --- |
+| Single CLI wrapper with no product DB | Probably not. Call SNA directly. |
+| Electron app with local SNA and renderer UI | Yes. Split commands and events. |
+| App with local plus cloud SNA instances | Yes. Use a client registry and event aggregator. |
+| App that injects retrieval, project, or policy context | Yes. Centralize send-time context building in the host. |

--- a/apps/docs/content/docs/cookbook/index.ja.mdx
+++ b/apps/docs/content/docs/cookbook/index.ja.mdx
@@ -11,6 +11,8 @@ icon: LayoutGrid
   <Card title="権限フロー" href="/ja/docs/cookbook/permissions" description="承認 UI の接続と safe-tool allowlist。" />
   <Card title="マルチランタイムセッション" href="/ja/docs/cookbook/multi-provider" description="履歴を保ったままスレッド途中でランタイムを切り替え。" />
   <Card title="Agentic app hosting" href="/ja/docs/cookbook/agentic-apps" description="Loom で使っている SNA 組み込みアプリのパターン。" />
+  <Card title="One-shot jobs" href="/ja/docs/cookbook/one-shot-jobs" description="completion、runOnce、runOnceStream で product task を処理。" />
+  <Card title="Runtime setup" href="/ja/docs/cookbook/runtime-setup" description="runtime 検出、path 保存、model 登録、install test。" />
 </Cards>
 
 足りないレシピがあれば [GitHub](https://github.com/neuradex/sna/issues)

--- a/apps/docs/content/docs/cookbook/index.ja.mdx
+++ b/apps/docs/content/docs/cookbook/index.ja.mdx
@@ -10,6 +10,7 @@ icon: LayoutGrid
   <Card title="ストリーミング completion" href="/ja/docs/cookbook/streaming" description="単発プロンプトのトークン単位 UX。" />
   <Card title="権限フロー" href="/ja/docs/cookbook/permissions" description="承認 UI の接続と safe-tool allowlist。" />
   <Card title="マルチランタイムセッション" href="/ja/docs/cookbook/multi-provider" description="履歴を保ったままスレッド途中でランタイムを切り替え。" />
+  <Card title="Agentic app hosting" href="/ja/docs/cookbook/agentic-apps" description="Loom で使っている SNA 組み込みアプリのパターン。" />
 </Cards>
 
 足りないレシピがあれば [GitHub](https://github.com/neuradex/sna/issues)

--- a/apps/docs/content/docs/cookbook/index.ko.mdx
+++ b/apps/docs/content/docs/cookbook/index.ko.mdx
@@ -10,6 +10,7 @@ icon: LayoutGrid
   <Card title="스트리밍 completion" href="/ko/docs/cookbook/streaming" description="단발 프롬프트의 토큰 단위 UX." />
   <Card title="권한 흐름" href="/ko/docs/cookbook/permissions" description="승인 UI 연결과 safe-tool allowlist." />
   <Card title="멀티 런타임 세션" href="/ko/docs/cookbook/multi-provider" description="히스토리를 유지한 채 스레드 도중 런타임 교체." />
+  <Card title="Agentic app hosting" href="/ko/docs/cookbook/agentic-apps" description="Loom에서 쓰는 SNA 내장 앱 패턴." />
 </Cards>
 
 빠진 레시피가 있으면 [GitHub](https://github.com/neuradex/sna/issues)에

--- a/apps/docs/content/docs/cookbook/index.ko.mdx
+++ b/apps/docs/content/docs/cookbook/index.ko.mdx
@@ -11,6 +11,8 @@ icon: LayoutGrid
   <Card title="권한 흐름" href="/ko/docs/cookbook/permissions" description="승인 UI 연결과 safe-tool allowlist." />
   <Card title="멀티 런타임 세션" href="/ko/docs/cookbook/multi-provider" description="히스토리를 유지한 채 스레드 도중 런타임 교체." />
   <Card title="Agentic app hosting" href="/ko/docs/cookbook/agentic-apps" description="Loom에서 쓰는 SNA 내장 앱 패턴." />
+  <Card title="One-shot jobs" href="/ko/docs/cookbook/one-shot-jobs" description="completion, runOnce, runOnceStream으로 제품 작업 처리." />
+  <Card title="Runtime setup" href="/ko/docs/cookbook/runtime-setup" description="런타임 감지, 경로 저장, 모델 등록, 설치 테스트." />
 </Cards>
 
 빠진 레시피가 있으면 [GitHub](https://github.com/neuradex/sna/issues)에

--- a/apps/docs/content/docs/cookbook/index.mdx
+++ b/apps/docs/content/docs/cookbook/index.mdx
@@ -10,6 +10,7 @@ Task-shaped recipes for the patterns we get asked about most.
   <Card title="Streaming completions" href="/docs/cookbook/streaming" description="Token-by-token UX for one-shot prompts and runOnce." />
   <Card title="Permission flows" href="/docs/cookbook/permissions" description="Wiring approval UIs and safe-tool allowlists." />
   <Card title="Multi-runtime sessions" href="/docs/cookbook/multi-provider" description="Switch runtimes mid-thread without losing history." />
+  <Card title="Agentic app hosting" href="/docs/cookbook/agentic-apps" description="Patterns from Loom for embedding SNA inside a product." />
 </Cards>
 
 Missing a recipe? File an issue on

--- a/apps/docs/content/docs/cookbook/index.mdx
+++ b/apps/docs/content/docs/cookbook/index.mdx
@@ -11,6 +11,8 @@ Task-shaped recipes for the patterns we get asked about most.
   <Card title="Permission flows" href="/docs/cookbook/permissions" description="Wiring approval UIs and safe-tool allowlists." />
   <Card title="Multi-runtime sessions" href="/docs/cookbook/multi-provider" description="Switch runtimes mid-thread without losing history." />
   <Card title="Agentic app hosting" href="/docs/cookbook/agentic-apps" description="Patterns from Loom for embedding SNA inside a product." />
+  <Card title="One-shot jobs" href="/docs/cookbook/one-shot-jobs" description="Use completion, runOnce, and runOnceStream for product tasks." />
+  <Card title="Runtime setup" href="/docs/cookbook/runtime-setup" description="Detect runtimes, persist paths, register models, and test installs." />
 </Cards>
 
 Missing a recipe? File an issue on

--- a/apps/docs/content/docs/cookbook/meta.ja.json
+++ b/apps/docs/content/docs/cookbook/meta.ja.json
@@ -1,7 +1,7 @@
 {
   "title": "Cookbook",
-  "description": "ストリーミング、権限 UI、マルチプロバイダのパターン。",
+  "description": "ストリーミング、権限 UI、マルチプロバイダ、アプリホストのパターン。",
   "icon": "ChefHat",
   "root": true,
-  "pages": ["index", "streaming", "permissions", "multi-provider"]
+  "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps"]
 }

--- a/apps/docs/content/docs/cookbook/meta.ja.json
+++ b/apps/docs/content/docs/cookbook/meta.ja.json
@@ -1,7 +1,7 @@
 {
   "title": "Cookbook",
-  "description": "ストリーミング、権限 UI、マルチプロバイダ、アプリホストのパターン。",
+  "description": "ストリーミング、権限 UI、マルチプロバイダ、runtime setup、アプリホストのパターン。",
   "icon": "ChefHat",
   "root": true,
-  "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps"]
+  "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps", "one-shot-jobs", "runtime-setup"]
 }

--- a/apps/docs/content/docs/cookbook/meta.json
+++ b/apps/docs/content/docs/cookbook/meta.json
@@ -1,7 +1,7 @@
 {
   "title": "Cookbook",
-  "description": "Recipes for streaming, permissions, multi-provider.",
+  "description": "Recipes for streaming, permissions, multi-provider, and app hosting patterns.",
   "icon": "ChefHat",
   "root": true,
-  "pages": ["index", "streaming", "permissions", "multi-provider"]
+  "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps"]
 }

--- a/apps/docs/content/docs/cookbook/meta.json
+++ b/apps/docs/content/docs/cookbook/meta.json
@@ -1,7 +1,7 @@
 {
   "title": "Cookbook",
-  "description": "Recipes for streaming, permissions, multi-provider, and app hosting patterns.",
+  "description": "Recipes for streaming, permissions, multi-provider, runtime setup, and app hosting patterns.",
   "icon": "ChefHat",
   "root": true,
-  "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps"]
+  "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps", "one-shot-jobs", "runtime-setup"]
 }

--- a/apps/docs/content/docs/cookbook/meta.ko.json
+++ b/apps/docs/content/docs/cookbook/meta.ko.json
@@ -1,7 +1,7 @@
 {
   "title": "Cookbook",
-  "description": "스트리밍, 권한 UI, 멀티 프로바이더 패턴.",
+  "description": "스트리밍, 권한 UI, 멀티 프로바이더, 앱 호스팅 패턴.",
   "icon": "ChefHat",
   "root": true,
-  "pages": ["index", "streaming", "permissions", "multi-provider"]
+  "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps"]
 }

--- a/apps/docs/content/docs/cookbook/meta.ko.json
+++ b/apps/docs/content/docs/cookbook/meta.ko.json
@@ -1,7 +1,7 @@
 {
   "title": "Cookbook",
-  "description": "스트리밍, 권한 UI, 멀티 프로바이더, 앱 호스팅 패턴.",
+  "description": "스트리밍, 권한 UI, 멀티 프로바이더, 런타임 설정, 앱 호스팅 패턴.",
   "icon": "ChefHat",
   "root": true,
-  "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps"]
+  "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps", "one-shot-jobs", "runtime-setup"]
 }

--- a/apps/docs/content/docs/cookbook/one-shot-jobs.ja.mdx
+++ b/apps/docs/content/docs/cookbook/one-shot-jobs.ja.mdx
@@ -1,0 +1,167 @@
+---
+title: One-shot jobs
+description: completion、runOnce、runOnceStream call を product feature に使う pattern。
+icon: Zap
+---
+
+Loom は、ユーザーの長期 chat thread に入れたくない作業に one-shot call を使います。例: session title、query parsing、retrieval filtering、runtime health check、小さな background decision。
+
+## 最小の surface を選ぶ
+
+| Job shape | API | 理由 |
+| --- | --- | --- |
+| Text transform, classification, JSON extraction | `agent.completion()` | 最速 path。temporary session lifecycle がありません。 |
+| Agent が tool を使う、または provider 固有の agent behavior が必要 | `agent.runOnce()` | temporary session を作成し、完了を待ってから cleanup します。 |
+| Browser/Electron UI が one-shot の進捗を live 表示する | `agent.runOnceStream()` | HTTP SSE stream。長期 chat session は作りません。 |
+
+One-shot prompt は狭く保つと扱いやすいです。これは product plumbing であり、open-ended conversation ではありません。
+
+## `completion` で text-only utility を作る
+
+Title generation、intent classification、小さな parser call に使いやすい pattern です。
+
+```ts
+import type { SnaClient } from "@sna-sdk/client";
+
+export async function generateSessionTitle(client: SnaClient, firstMessage: string) {
+  const result = await client.agent.completion({
+    // Prompt は単一目的に保つと、失敗原因を log から見つけやすくなります。
+    prompt: `Create a 2-5 word title for this first user message:\n\n${firstMessage}`,
+
+    // App の model registry が選んだ cheap/fast model を使います。
+    model: "claude-haiku-4-5-20251001",
+
+    // Label を付けると trace と log を product feature ごとに検索できます。
+    label: "session-title",
+
+    // One-shot UX は早く失敗し、default title に fallback する方が安全です。
+    timeout: 30_000,
+
+    // Pure text transform では tool permission を開きません。
+    permissionMode: "bypassPermissions",
+  });
+
+  if (!result.text?.trim()) return null;
+
+  // Title は UI string なので quote/newline/prose を整理します。
+  return result.text.trim().replace(/^["']|["']$/g, "").split("\n")[0].slice(0, 50);
+}
+```
+
+## Fallback 付き structured extraction
+
+Model は JSON を fence で囲んだり、malformed output を返したりします。Parse failure は通常の branch として扱うと安全です。
+
+```ts
+type ParsedQuery = {
+  subject: string | null;
+  predicate: string | null;
+  object: string | null;
+  mode: "exact" | "broad";
+};
+
+const FALLBACK_QUERY: ParsedQuery = {
+  subject: null,
+  predicate: null,
+  object: null,
+  mode: "broad",
+};
+
+export async function parseQuery(client: SnaClient, userText: string): Promise<ParsedQuery> {
+  const result = await client.agent.completion({
+    // Schema は prompt に含めますが、log で検査できる長さに保ちます。
+    prompt: [
+      "Return ONLY JSON matching this TypeScript type:",
+      "{ subject: string|null; predicate: string|null; object: string|null; mode: 'exact'|'broad' }",
+      "",
+      userText,
+    ].join("\n"),
+    model: "claude-haiku-4-5-20251001",
+    label: "query-parse",
+    timeout: 30_000,
+    permissionMode: "bypassPermissions",
+  });
+
+  if (!result.text) return FALLBACK_QUERY;
+
+  // よくある fenced output は受け入れますが、任意の prose を黙って通しません。
+  const cleaned = result.text
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```\s*$/i, "")
+    .trim();
+
+  try {
+    const parsed = JSON.parse(cleaned);
+    return {
+      subject: typeof parsed.subject === "string" ? parsed.subject : null,
+      predicate: typeof parsed.predicate === "string" ? parsed.predicate : null,
+      object: typeof parsed.object === "string" ? parsed.object : null,
+      mode: parsed.mode === "exact" ? "exact" : "broad",
+    };
+  } catch {
+    // Malformed one-shot result は app を crash させず、feature を degrade します。
+    return FALLBACK_QUERY;
+  }
+}
+```
+
+## `runOnce` で runtime health check を行う
+
+実際の runtime path と agent bootstrap を動かす必要がある場合は `runOnce` が便利です。選択された CLI path は先に host settings または SNA launcher environment に反映し、`runOnce` は設定済み runtime が実際に応答できるかを見る役割にすると安全です。
+
+```ts
+export async function testRuntime(client: SnaClient, runtimeId: string) {
+  const result = await client.agent.runOnce({
+    provider: runtimeId,
+
+    // Runtime cache や project file が dev mode を汚さないよう cwd を隔離します。
+    cwd: `/tmp/my-app-runtime-tests/${runtimeId}`,
+
+    // Health check は permission prompt や tool call を発生させてはいけません。
+    permissionMode: "bypassPermissions",
+    systemPrompt: "Reply exactly APP_RUNTIME_OK and do not use tools.",
+    message: "Reply exactly: APP_RUNTIME_OK",
+
+    // Runtime first-run setup は遅いことがあるため、十分な timeout を置きます。
+    timeout: 120_000,
+  });
+
+  if (!result.result?.includes("APP_RUNTIME_OK")) {
+    return { ok: false, reason: "unexpected-response", response: result.result };
+  }
+  return { ok: true };
+}
+```
+
+## Streaming one-shot UI
+
+既存 session に接続しない作業でも、UI が live progress を見せたい場合は `runOnceStream` が便利です。
+
+```ts
+export async function previewPlan(client: SnaClient, request: string, append: (text: string) => void) {
+  for await (const event of client.agent.runOnceStream({
+    // Temporary one-shot run です。終了後に session は保持されません。
+    message: request,
+    provider: "codex",
+    model: "gpt-5.4-mini",
+    permissionMode: "bypassPermissions",
+    timeout: 60_000,
+  })) {
+    if (event.type === "assistant_delta") {
+      // 届いた token delta をそのまま UI に追加します。
+      append(String(event.delta ?? ""));
+    }
+    if (event.type === "error") {
+      throw new Error(String(event.error ?? "runOnceStream failed"));
+    }
+  }
+}
+```
+
+## Guardrails
+
+- すべての call に `label` を付けると product trace が読みやすくなります。
+- Timeout と明示的な fallback を用意しておくと運用しやすいです。
+- Prompt が tool を使わない作業のときだけ `permissionMode: "bypassPermissions"` を使うと安全です。
+- User が明示的に求めた output でない限り、one-shot result を user conversation に入れない方が扱いやすいです。
+- 繰り返し実行される background work は provider を hardcode せず、runtime/model registry から model を選ぶ構成が便利です。

--- a/apps/docs/content/docs/cookbook/one-shot-jobs.ko.mdx
+++ b/apps/docs/content/docs/cookbook/one-shot-jobs.ko.mdx
@@ -1,0 +1,167 @@
+---
+title: One-shot jobs
+description: completion, runOnce, runOnceStream 호출을 제품 기능에 쓰는 패턴입니다.
+icon: Zap
+---
+
+Loom은 사용자 장기 chat thread에 들어가면 안 되는 작업에 one-shot 호출을 씁니다. 예: session title, query parsing, retrieval filtering, runtime health check, 작은 background decision.
+
+## 가장 작은 surface 선택하기
+
+| 작업 형태 | API | 이유 |
+| --- | --- | --- |
+| Text transform, classification, JSON extraction | `agent.completion()` | 가장 빠른 경로입니다. 임시 session lifecycle이 없습니다. |
+| Agent가 tool을 쓰거나 provider별 agent behavior가 필요함 | `agent.runOnce()` | 임시 session을 만들고 완료를 기다린 뒤 정리합니다. |
+| Browser/Electron UI가 one-shot 진행 상황을 live로 보여줘야 함 | `agent.runOnceStream()` | HTTP SSE stream입니다. 장기 chat session은 만들지 않습니다. |
+
+One-shot prompt는 좁게 유지합니다. 이것은 제품 plumbing이지 open-ended conversation이 아닙니다.
+
+## `completion`으로 text-only utility 만들기
+
+Title generation, intent classification, 작은 parser call에 유용한 패턴입니다.
+
+```ts
+import type { SnaClient } from "@sna-sdk/client";
+
+export async function generateSessionTitle(client: SnaClient, firstMessage: string) {
+  const result = await client.agent.completion({
+    // Prompt를 한 가지 일만 하게 유지하면 실패 원인을 로그에서 찾기 쉽습니다.
+    prompt: `Create a 2-5 word title for this first user message:\n\n${firstMessage}`,
+
+    // 앱의 model registry가 고른 cheap/fast model을 사용합니다.
+    model: "claude-haiku-4-5-20251001",
+
+    // Label을 넣으면 trace와 log를 제품 기능별로 검색할 수 있습니다.
+    label: "session-title",
+
+    // One-shot UX는 빨리 실패하고 기본 title로 fallback하는 편이 낫습니다.
+    timeout: 30_000,
+
+    // 순수 text transform에는 tool permission을 열지 않습니다.
+    permissionMode: "bypassPermissions",
+  });
+
+  if (!result.text?.trim()) return null;
+
+  // Title은 UI string이므로 quote/newline/prose를 정리합니다.
+  return result.text.trim().replace(/^["']|["']$/g, "").split("\n")[0].slice(0, 50);
+}
+```
+
+## Fallback이 있는 structured extraction
+
+Model은 JSON을 fence로 감싸거나 malformed output을 낼 수 있습니다. Parse failure는 정상적인 branch로 다룹니다.
+
+```ts
+type ParsedQuery = {
+  subject: string | null;
+  predicate: string | null;
+  object: string | null;
+  mode: "exact" | "broad";
+};
+
+const FALLBACK_QUERY: ParsedQuery = {
+  subject: null,
+  predicate: null,
+  object: null,
+  mode: "broad",
+};
+
+export async function parseQuery(client: SnaClient, userText: string): Promise<ParsedQuery> {
+  const result = await client.agent.completion({
+    // Schema는 prompt에 넣되, log에서 검사할 수 있을 정도로 짧게 유지합니다.
+    prompt: [
+      "Return ONLY JSON matching this TypeScript type:",
+      "{ subject: string|null; predicate: string|null; object: string|null; mode: 'exact'|'broad' }",
+      "",
+      userText,
+    ].join("\n"),
+    model: "claude-haiku-4-5-20251001",
+    label: "query-parse",
+    timeout: 30_000,
+    permissionMode: "bypassPermissions",
+  });
+
+  if (!result.text) return FALLBACK_QUERY;
+
+  // 흔한 fenced output은 허용하지만, 임의 prose를 조용히 통과시키지는 않습니다.
+  const cleaned = result.text
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```\s*$/i, "")
+    .trim();
+
+  try {
+    const parsed = JSON.parse(cleaned);
+    return {
+      subject: typeof parsed.subject === "string" ? parsed.subject : null,
+      predicate: typeof parsed.predicate === "string" ? parsed.predicate : null,
+      object: typeof parsed.object === "string" ? parsed.object : null,
+      mode: parsed.mode === "exact" ? "exact" : "broad",
+    };
+  } catch {
+    // Malformed one-shot 결과는 앱을 crash시키지 말고 기능만 degrade합니다.
+    return FALLBACK_QUERY;
+  }
+}
+```
+
+## `runOnce`로 runtime health check 하기
+
+실제 runtime path와 agent bootstrap을 실행해야 할 때는 `runOnce`가 맞습니다. 선택된 CLI path는 먼저 host settings나 SNA launcher environment에 반영해두고, `runOnce`는 설정된 runtime이 실제로 응답하는지 확인하는 역할로 두는 구조가 안전합니다.
+
+```ts
+export async function testRuntime(client: SnaClient, runtimeId: string) {
+  const result = await client.agent.runOnce({
+    provider: runtimeId,
+
+    // Runtime cache나 project file이 dev mode를 오염시키지 않도록 cwd를 격리합니다.
+    cwd: `/tmp/my-app-runtime-tests/${runtimeId}`,
+
+    // Health check는 permission prompt를 띄우거나 tool을 호출하면 안 됩니다.
+    permissionMode: "bypassPermissions",
+    systemPrompt: "Reply exactly APP_RUNTIME_OK and do not use tools.",
+    message: "Reply exactly: APP_RUNTIME_OK",
+
+    // Runtime first-run setup은 느릴 수 있으므로 충분한 timeout을 둡니다.
+    timeout: 120_000,
+  });
+
+  if (!result.result?.includes("APP_RUNTIME_OK")) {
+    return { ok: false, reason: "unexpected-response", response: result.result };
+  }
+  return { ok: true };
+}
+```
+
+## Streaming one-shot UI
+
+기존 session에 붙지 않는 작업이지만 UI가 live progress를 보여줘야 하면 `runOnceStream`이 맞습니다.
+
+```ts
+export async function previewPlan(client: SnaClient, request: string, append: (text: string) => void) {
+  for await (const event of client.agent.runOnceStream({
+    // 임시 one-shot run입니다. 종료 후 session은 유지되지 않습니다.
+    message: request,
+    provider: "codex",
+    model: "gpt-5.4-mini",
+    permissionMode: "bypassPermissions",
+    timeout: 60_000,
+  })) {
+    if (event.type === "assistant_delta") {
+      // 도착하는 token delta를 그대로 UI에 추가합니다.
+      append(String(event.delta ?? ""));
+    }
+    if (event.type === "error") {
+      throw new Error(String(event.error ?? "runOnceStream failed"));
+    }
+  }
+}
+```
+
+## Guardrails
+
+- 모든 call에 `label`을 넣으면 제품 trace를 읽기 쉬워집니다.
+- Timeout과 명시적인 fallback을 함께 둡니다.
+- Prompt가 tool을 쓰면 안 되는 작업일 때만 `permissionMode: "bypassPermissions"`를 쓰면 안전합니다.
+- User가 명시적으로 요청한 출력이 아니라면 one-shot 결과를 user conversation에 넣지 않는 쪽이 낫습니다.
+- 반복되는 background work는 provider를 hardcode하지 않고 runtime/model registry를 통해 model을 고릅니다.

--- a/apps/docs/content/docs/cookbook/one-shot-jobs.mdx
+++ b/apps/docs/content/docs/cookbook/one-shot-jobs.mdx
@@ -1,0 +1,167 @@
+---
+title: One-shot jobs
+description: Product patterns for completion, runOnce, and runOnceStream calls.
+icon: Zap
+---
+
+Loom uses one-shot calls for work that should not become part of a user's long-lived chat thread: session titles, query parsing, retrieval filtering, runtime health checks, and small background decisions.
+
+## Choose the smallest surface
+
+| Job shape | API | Why |
+| --- | --- | --- |
+| Text transform, classification, JSON extraction | `agent.completion()` | Fastest path; no temporary session lifecycle. |
+| Agent can use tools or needs provider-specific agent behavior | `agent.runOnce()` | Creates a temporary session, waits for completion, then cleans up. |
+| Browser/Electron UI needs live progress for a one-shot | `agent.runOnceStream()` | HTTP SSE stream; no long-lived chat session. |
+
+Keep one-shot prompts narrow. They are product plumbing, not open-ended conversations.
+
+## Text-only utility with `completion`
+
+This pattern is useful for title generation, intent classification, and small parser calls.
+
+```ts
+import type { SnaClient } from "@sna-sdk/client";
+
+export async function generateSessionTitle(client: SnaClient, firstMessage: string) {
+  const result = await client.agent.completion({
+    // Keep the prompt single-purpose so failures are easy to diagnose.
+    prompt: `Create a 2-5 word title for this first user message:\n\n${firstMessage}`,
+
+    // Use a cheap/fast model chosen by your app's model registry.
+    model: "claude-haiku-4-5-20251001",
+
+    // Labels make traces and logs searchable by product feature.
+    label: "session-title",
+
+    // One-shot UX should fail quickly and fall back to a default title.
+    timeout: 30_000,
+
+    // Do not allow tools for pure text transforms.
+    permissionMode: "bypassPermissions",
+  });
+
+  if (!result.text?.trim()) return null;
+
+  // Strip quotes/newlines because titles are UI strings, not model prose.
+  return result.text.trim().replace(/^["']|["']$/g, "").split("\n")[0].slice(0, 50);
+}
+```
+
+## Structured extraction with a fallback
+
+Models sometimes wrap JSON in fences or return malformed output. Treat parsing failure as a normal branch.
+
+```ts
+type ParsedQuery = {
+  subject: string | null;
+  predicate: string | null;
+  object: string | null;
+  mode: "exact" | "broad";
+};
+
+const FALLBACK_QUERY: ParsedQuery = {
+  subject: null,
+  predicate: null,
+  object: null,
+  mode: "broad",
+};
+
+export async function parseQuery(client: SnaClient, userText: string): Promise<ParsedQuery> {
+  const result = await client.agent.completion({
+    // Include the schema in the prompt, but keep it short enough to inspect in logs.
+    prompt: [
+      "Return ONLY JSON matching this TypeScript type:",
+      "{ subject: string|null; predicate: string|null; object: string|null; mode: 'exact'|'broad' }",
+      "",
+      userText,
+    ].join("\n"),
+    model: "claude-haiku-4-5-20251001",
+    label: "query-parse",
+    timeout: 30_000,
+    permissionMode: "bypassPermissions",
+  });
+
+  if (!result.text) return FALLBACK_QUERY;
+
+  // Accept common fenced output without silently accepting arbitrary prose.
+  const cleaned = result.text
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```\s*$/i, "")
+    .trim();
+
+  try {
+    const parsed = JSON.parse(cleaned);
+    return {
+      subject: typeof parsed.subject === "string" ? parsed.subject : null,
+      predicate: typeof parsed.predicate === "string" ? parsed.predicate : null,
+      object: typeof parsed.object === "string" ? parsed.object : null,
+      mode: parsed.mode === "exact" ? "exact" : "broad",
+    };
+  } catch {
+    // A malformed one-shot result should degrade the feature, not crash the app.
+    return FALLBACK_QUERY;
+  }
+}
+```
+
+## Runtime health check with `runOnce`
+
+Use `runOnce` when you need the real runtime path and agent bootstrap to execute. Apply the selected CLI path in the host settings or SNA launcher environment first; `runOnce` then verifies that the configured runtime can actually answer.
+
+```ts
+export async function testRuntime(client: SnaClient, runtimeId: string) {
+  const result = await client.agent.runOnce({
+    provider: runtimeId,
+
+    // Use an isolated cwd so runtime caches or project files do not pollute dev mode.
+    cwd: `/tmp/my-app-runtime-tests/${runtimeId}`,
+
+    // Health checks should not prompt for permissions or call tools.
+    permissionMode: "bypassPermissions",
+    systemPrompt: "Reply exactly APP_RUNTIME_OK and do not use tools.",
+    message: "Reply exactly: APP_RUNTIME_OK",
+
+    // Runtime first-run setup can be slow; keep a cap but give it enough room.
+    timeout: 120_000,
+  });
+
+  if (!result.result?.includes("APP_RUNTIME_OK")) {
+    return { ok: false, reason: "unexpected-response", response: result.result };
+  }
+  return { ok: true };
+}
+```
+
+## Streaming one-shot UI
+
+Use `runOnceStream` when a UI wants live progress but the work should not attach to an existing session.
+
+```ts
+export async function previewPlan(client: SnaClient, request: string, append: (text: string) => void) {
+  for await (const event of client.agent.runOnceStream({
+    // This is still a temporary one-shot run; no session is kept afterward.
+    message: request,
+    provider: "codex",
+    model: "gpt-5.4-mini",
+    permissionMode: "bypassPermissions",
+    timeout: 60_000,
+  })) {
+    if (event.type === "assistant_delta") {
+      // Render token deltas as they arrive.
+      append(String(event.delta ?? ""));
+    }
+    if (event.type === "error") {
+      throw new Error(String(event.error ?? "runOnceStream failed"));
+    }
+  }
+}
+```
+
+## Guardrails
+
+- Give every call a `label`; product traces are much easier to read.
+- Set a timeout and write an explicit fallback.
+- Use `permissionMode: "bypassPermissions"` only when the prompt is not allowed to use tools.
+- Keep one-shot results out of the user conversation unless the user explicitly asked for that output.
+- For repeated background work, route model choice through your runtime/model registry instead of hardcoding one provider.

--- a/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
@@ -1,0 +1,261 @@
+---
+title: Runtime setup
+description: runtime 検出、CLI path 保存、model 登録、install test の pattern。
+icon: Settings2
+---
+
+Agentic product には、runtime settings flow が必要になることがよくあります。Loom では runtime setup を 2 つの関心事に分けています。
+
+- **Path detection** は、ユーザーの machine 上にある実際の CLI binary を見つけます。
+- **Runtime registration** は、product UI にどの runtime と model を出すかを決めます。
+
+この 2 つを分けておくと settings 画面を扱いやすくなります。Auto-detection はよい初期値を入れ、ユーザーは registered model list を自分で管理できます。
+
+## Detection と registration を分ける
+
+Runtime は検出済みでも disabled のままにできます。Model も catalog には存在するが、まだ product に登録していない状態にできます。Product state では、この 2 つを別々に持つ形が扱いやすいです。
+
+```ts
+type RuntimeId = "claude-code" | "codex" | "opencode" | "grok" | "cursor";
+
+type RegisteredModel = {
+  // Product 内で使う安定した id です。Compound id にすると selector の衝突を避けやすくなります。
+  id: `${RuntimeId}/${string}`;
+
+  // SNA startAgent/runOnce に戻して渡す runtime-native model slug です。
+  modelSlug: string;
+
+  // Settings UI と model picker に出す、人が読みやすい label です。
+  label: string;
+
+  // Provider family は grouping、attribution、billing view に使いやすいです。
+  provider: "anthropic" | "openai" | "oss" | string;
+};
+
+type RuntimeSlot = {
+  // ユーザーは検出済み runtime を off にできますが、config は残せます。
+  enabled: boolean;
+
+  config: {
+    // CLI runtime は cliPath を使います。Hosted/local API runtime は baseUrl/apiKey を持てます。
+    cliPath?: string;
+    baseUrl?: string;
+    apiKey?: string;
+  };
+
+  // この curated list は app が所有します。SNA model catalog から seed できます。
+  models: RegisteredModel[];
+};
+```
+
+## CLI path は予測しやすい順序で resolve する
+
+Loom は CLI path を次の順序で resolve しています。
+
+1. Settings で保存した user override。
+2. 以前の detection が残した cache entry。
+3. 新しい filesystem scan。
+
+この優先順位にしておくと、ユーザーが手で直した値は安定して残り、初回ユーザーにも自動の初期値を出せます。
+
+```ts
+const RUNTIME_ENV: Record<RuntimeId, string> = {
+  "claude-code": "SNA_CLAUDE_COMMAND",
+  codex: "SNA_CODEX_COMMAND",
+  opencode: "SNA_OPENCODE_COMMAND",
+  grok: "SNA_GROK_COMMAND",
+  cursor: "SNA_CURSOR_COMMAND",
+};
+
+async function resolveRuntimePath(runtimeId: RuntimeId): Promise<string | null> {
+  // 1. ユーザーが入力した値は auto-detected path より優先すると扱いやすいです。
+  const override = await settingsDb.get(`runtime:${runtimeId}:path`);
+  if (override) return override;
+
+  // 2. Cache を読むと、app boot のたびに shell probe を走らせずに済みます。
+  const cached = await pathCache.read(runtimeId);
+  if (cached) return cached;
+
+  // 3. Fresh detection では static install location と login-shell PATH を見られます。
+  const detected = await detectCliOnDisk(runtimeId);
+  if (detected) await pathCache.write(runtimeId, detected);
+  return detected;
+}
+
+async function setRuntimePath(runtimeId: RuntimeId, cliPath: string) {
+  // 保存前に validate しておくと、typo で次の agent launch が壊れるリスクを下げられます。
+  await validateExecutable(cliPath);
+
+  // ユーザーが選んだ値は cache ではなく override として保存します。
+  await settingsDb.set(`runtime:${runtimeId}:path`, cliPath);
+
+  // SNA を同じ process に embed している場合、process.env mirror で次の provider spawn が同じ path を見ます。
+  process.env[RUNTIME_ENV[runtimeId]] = cliPath;
+}
+```
+
+## SNA launcher に runtime path を渡す
+
+Electron から SNA を起動するときに、resolve 済み runtime path を startup option として渡しておくとよいです。SNA はこの値を runtime resolver が読む provider environment variable に mapping します。
+
+```ts
+import { startSnaServerInProcess } from "@sna-sdk/core/electron";
+
+const runtimePaths = {
+  // Settings layer が resolve した path を使います。見つからない値は省略できます。
+  claudeCode: (await resolveRuntimePath("claude-code")) ?? undefined,
+  codex: (await resolveRuntimePath("codex")) ?? undefined,
+  opencode: (await resolveRuntimePath("opencode")) ?? undefined,
+  grok: (await resolveRuntimePath("grok")) ?? undefined,
+  cursor: (await resolveRuntimePath("cursor")) ?? undefined,
+};
+
+const sna = await startSnaServerInProcess({
+  port: 3099,
+  dbPath: appPaths.snaDb,
+
+  // runtimePaths は SNA_CLAUDE_COMMAND、SNA_CODEX_COMMAND などの env に変換されます。
+  runtimePaths,
+
+  // env は runtimePaths のあとに merge されるため、最後の escape hatch として使えます。
+  env: {
+    SNA_MAX_SESSIONS: "20",
+  },
+});
+```
+
+Forked standalone SNA server では、path change を launch 前に反映するか、SNA を再起動する構成が扱いやすいです。In-process SNA では provider が同じ process 内で path を resolve するため、host が `process.env.SNA_*_COMMAND` を更新すると以後の spawn に反映できます。
+
+## `runOnce` で実 runtime を test する
+
+Settings screen では、file の存在だけでなく、実際の CLI path と agent bootstrap を一緒に test すると信頼しやすくなります。次の health check は、path がすでに host settings に保存され、SNA launch environment に mirror されている前提です。
+
+```ts
+const HEALTH_MODELS: Partial<Record<RuntimeId, string>> = {
+  "claude-code": "haiku",
+  codex: "gpt-5.4-mini",
+  grok: "grok-build",
+  cursor: "auto",
+};
+
+async function testRuntime(client: SnaClient, runtimeId: RuntimeId) {
+  const result = await client.agent.runOnce({
+    provider: runtimeId,
+    model: HEALTH_MODELS[runtimeId],
+
+    // Setup probe がユーザーの project directory を汚さないように cwd を分けます。
+    cwd: `/tmp/my-app-runtime-tests/${runtimeId}`,
+
+    // Health check は sentinel だけ返して終わる小さな call にすると判定しやすいです。
+    permissionMode: "bypassPermissions",
+    systemPrompt: "Reply exactly APP_RUNTIME_OK and do not use tools.",
+    message: "Reply exactly: APP_RUNTIME_OK",
+
+    // First-run auth や CLI bootstrap は通常 turn より遅いことがあります。
+    timeout: 120_000,
+  });
+
+  const text = result.result.trim();
+  return {
+    ok: text.includes("APP_RUNTIME_OK"),
+    response: text.slice(0, 500),
+  };
+}
+```
+
+この形は単なる path check より強い確認になります。SNA が runtime を spawn し、prompt を渡し、output を受け取り、one-shot session を完了できるかを見るためです。
+
+## Model は list してから register する
+
+`agent.listModels(runtime, config?)` は catalog call です。`config.cliPath` は Codex や OpenCode のように CLI を inspect する runtime の model listing にだけ影響します。通常の agent spawn path を変える場合は launcher `runtimePaths` または `SNA_*_COMMAND` 側を使います。
+
+```ts
+async function refreshCatalog(client: SnaClient, runtimeId: RuntimeId, cliPath?: string) {
+  const catalog = await client.agent.listModels(runtimeId, {
+    // Settings で CLI path を編集した直後の catalog probe に便利です。
+    cliPath,
+
+    // ユーザーが refresh button を押した場合は provider-side cache を bypass します。
+    refresh: true,
+  });
+
+  if (catalog.error) {
+    // UI は fallback model を表示できますが、partial warning も見せると親切です。
+    toast.warning(`Model catalog was partial: ${catalog.error}`);
+  }
+
+  return catalog.models;
+}
+
+async function registerModel(runtimeId: RuntimeId, model: RuntimeModelInfo) {
+  // Registration は product decision です。SNA model id は runtime-native slug として保存し、
+  // app selector では app-owned compound id を使います。
+  await settingsDb.addModel(runtimeId, {
+    id: `${runtimeId}/${model.id}`,
+    modelSlug: model.id,
+    label: model.label,
+    provider: model.provider,
+  });
+}
+```
+
+この two-step flow にしておくと、ユーザーは catalog を見て必要な entry だけ追加できます。Runtime をあとで disabled にしても model list 自体は保持できます。
+
+## React settings flow
+
+Settings UI は host API の上に薄い shell として置くと扱いやすいです。Filesystem validation、env mirroring、SNA health check は host process が担当し、renderer は user intent の調整に集中できます。
+
+```tsx
+function RuntimeSetupPanel({ runtimeId }: { runtimeId: RuntimeId }) {
+  const [cliPath, setCliPath] = useState("");
+  const [models, setModels] = useState<RuntimeModelInfo[]>([]);
+  const [testing, setTesting] = useState(false);
+
+  async function redetect() {
+    // Host code は login-shell lookup、static candidates、cache write を使えます。
+    const path = await window.appRuntime.redetect(runtimeId);
+    if (path) setCliPath(path);
+  }
+
+  async function saveAndTest() {
+    setTesting(true);
+    try {
+      // 先に persist すると、SNA provider が runOnce 中にこの path を resolve できます。
+      await window.appRuntime.setPath(runtimeId, cliPath);
+
+      // これは fake ping ではなく、SNA 経由の実 runtime invocation です。
+      const result = await window.appRuntime.test(runtimeId);
+      if (!result.ok) throw new Error(result.response || "Runtime test failed");
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  async function refreshModels() {
+    // CLI path は catalog probing に役立ちます。通常の agent spawn は setPath/startup runtimePaths の path を使います。
+    const catalog = await window.appRuntime.listModels(runtimeId, { cliPath, refresh: true });
+    setModels(catalog.models);
+  }
+
+  async function addModel(model: RuntimeModelInfo) {
+    // Product picker に実際に出す model だけ保存します。
+    await window.appRuntime.registerModel(runtimeId, model);
+  }
+
+  return (
+    <section>
+      <input value={cliPath} onChange={(event) => setCliPath(event.target.value)} />
+      <button onClick={redetect}>Redetect</button>
+      <button onClick={saveAndTest} disabled={testing}>Test runtime</button>
+      <button onClick={refreshModels}>Refresh models</button>
+      {models.map((model) => (
+        <button key={model.id} onClick={() => addModel(model)}>
+          Add {model.label}
+        </button>
+      ))}
+    </section>
+  );
+}
+```
+
+ここで大事な product boundary は、renderer が SNA runtime environment を推測して直接変えないことです。Renderer は host に save、test、list、register を依頼し、host が実際の environment mutation を受け持つ構造が安定します。

--- a/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
@@ -1,0 +1,261 @@
+---
+title: Runtime setup
+description: 런타임 감지, CLI 경로 저장, 모델 등록, 설치 테스트를 다루는 패턴입니다.
+icon: Settings2
+---
+
+Agentic product에는 보통 runtime settings flow가 필요합니다. Loom은 runtime setup을 두 가지 관심사로 나눠서 다룹니다.
+
+- **Path detection**은 사용자 machine에 있는 실제 CLI binary를 찾습니다.
+- **Runtime registration**은 product UI에 어떤 runtime과 model을 노출할지 결정합니다.
+
+이 둘을 분리해두면 settings 화면을 다루기 쉬워집니다. Auto-detection은 좋은 기본값을 채워주고, 사용자는 registered model list를 직접 관리할 수 있습니다.
+
+## Detection과 registration을 분리하기
+
+Runtime은 감지되었지만 disabled 상태일 수 있습니다. Model도 catalog에는 있지만 아직 product에 등록되지 않았을 수 있습니다. Product state에 두 정보를 따로 두면 설정 흐름이 깔끔해집니다.
+
+```ts
+type RuntimeId = "claude-code" | "codex" | "opencode" | "grok" | "cursor";
+
+type RegisteredModel = {
+  // Product 안에서 쓰는 안정적인 id입니다. Compound id를 쓰면 selector에서 충돌이 줄어듭니다.
+  id: `${RuntimeId}/${string}`;
+
+  // SNA startAgent/runOnce에 다시 넘기는 runtime-native model slug입니다.
+  modelSlug: string;
+
+  // Settings UI와 model picker에 보여줄 사람이 읽기 좋은 label입니다.
+  label: string;
+
+  // Provider family는 grouping, attribution, billing view에 유용합니다.
+  provider: "anthropic" | "openai" | "oss" | string;
+};
+
+type RuntimeSlot = {
+  // 사용자는 감지된 runtime을 끌 수 있지만, config는 남겨둘 수 있습니다.
+  enabled: boolean;
+
+  config: {
+    // CLI runtime은 cliPath를 씁니다. Hosted/local API runtime은 baseUrl/apiKey를 쓸 수 있습니다.
+    cliPath?: string;
+    baseUrl?: string;
+    apiKey?: string;
+  };
+
+  // 이 curated list는 app이 소유합니다. SNA model catalog에서 seed할 수 있습니다.
+  models: RegisteredModel[];
+};
+```
+
+## CLI path는 예측 가능한 순서로 resolve하기
+
+Loom은 CLI path를 다음 순서로 resolve합니다.
+
+1. Settings에서 저장한 user override.
+2. 이전 detection이 남긴 cache entry.
+3. 새 filesystem scan.
+
+이 우선순서를 쓰면 사용자가 직접 고친 값은 안정적으로 유지되고, 첫 실행 사용자에게도 자동 기본값을 줄 수 있습니다.
+
+```ts
+const RUNTIME_ENV: Record<RuntimeId, string> = {
+  "claude-code": "SNA_CLAUDE_COMMAND",
+  codex: "SNA_CODEX_COMMAND",
+  opencode: "SNA_OPENCODE_COMMAND",
+  grok: "SNA_GROK_COMMAND",
+  cursor: "SNA_CURSOR_COMMAND",
+};
+
+async function resolveRuntimePath(runtimeId: RuntimeId): Promise<string | null> {
+  // 1. 사용자가 직접 입력한 값은 auto-detected path보다 우선하도록 둡니다.
+  const override = await settingsDb.get(`runtime:${runtimeId}:path`);
+  if (override) return override;
+
+  // 2. Cache를 읽으면 app boot 때마다 shell probe를 하지 않아도 됩니다.
+  const cached = await pathCache.read(runtimeId);
+  if (cached) return cached;
+
+  // 3. Fresh detection에서는 static install location과 login-shell PATH를 함께 볼 수 있습니다.
+  const detected = await detectCliOnDisk(runtimeId);
+  if (detected) await pathCache.write(runtimeId, detected);
+  return detected;
+}
+
+async function setRuntimePath(runtimeId: RuntimeId, cliPath: string) {
+  // 저장하기 전에 validate하면 typo 때문에 다음 agent launch가 깨지는 일을 줄일 수 있습니다.
+  await validateExecutable(cliPath);
+
+  // 사용자가 고른 값은 cache가 아니라 override로 저장합니다.
+  await settingsDb.set(`runtime:${runtimeId}:path`, cliPath);
+
+  // SNA를 같은 process에 embed했다면, process.env mirror로 다음 provider spawn이 바로 같은 path를 보게 됩니다.
+  process.env[RUNTIME_ENV[runtimeId]] = cliPath;
+}
+```
+
+## SNA launcher에 runtime path 넘기기
+
+Electron에서 SNA를 띄울 때 resolve된 runtime path를 startup option으로 넘겨두는 패턴이 가장 단순합니다. SNA는 이 값을 runtime resolver가 읽는 provider environment variable로 매핑합니다.
+
+```ts
+import { startSnaServerInProcess } from "@sna-sdk/core/electron";
+
+const runtimePaths = {
+  // Settings layer가 resolve한 path를 사용합니다. 찾지 못한 값은 생략해도 됩니다.
+  claudeCode: (await resolveRuntimePath("claude-code")) ?? undefined,
+  codex: (await resolveRuntimePath("codex")) ?? undefined,
+  opencode: (await resolveRuntimePath("opencode")) ?? undefined,
+  grok: (await resolveRuntimePath("grok")) ?? undefined,
+  cursor: (await resolveRuntimePath("cursor")) ?? undefined,
+};
+
+const sna = await startSnaServerInProcess({
+  port: 3099,
+  dbPath: appPaths.snaDb,
+
+  // runtimePaths는 SNA_CLAUDE_COMMAND, SNA_CODEX_COMMAND 같은 env로 변환됩니다.
+  runtimePaths,
+
+  // env는 runtimePaths 뒤에 merge되므로 마지막 escape hatch로 쓸 수 있습니다.
+  env: {
+    SNA_MAX_SESSIONS: "20",
+  },
+});
+```
+
+Forked standalone SNA server에서는 path change를 launch 전에 반영하거나 SNA를 재시작하는 구성이 보통 다루기 쉽습니다. In-process SNA에서는 provider가 같은 process 안에서 path를 resolve하므로, host가 `process.env.SNA_*_COMMAND`를 갱신하면 이후 spawn에 반영될 수 있습니다.
+
+## `runOnce`로 실제 runtime 테스트하기
+
+Settings screen에서는 파일 존재 여부만 확인하기보다 실제 CLI path와 agent bootstrap을 같이 테스트하는 쪽이 실제 동작에 가깝습니다. 아래 health check는 path가 이미 host settings에 저장되고 SNA launch environment에 mirror된 상태를 전제로 합니다.
+
+```ts
+const HEALTH_MODELS: Partial<Record<RuntimeId, string>> = {
+  "claude-code": "haiku",
+  codex: "gpt-5.4-mini",
+  grok: "grok-build",
+  cursor: "auto",
+};
+
+async function testRuntime(client: SnaClient, runtimeId: RuntimeId) {
+  const result = await client.agent.runOnce({
+    provider: runtimeId,
+    model: HEALTH_MODELS[runtimeId],
+
+    // Setup probe가 사용자 project directory를 오염시키지 않도록 cwd를 분리합니다.
+    cwd: `/tmp/my-app-runtime-tests/${runtimeId}`,
+
+    // Health check는 sentinel만 반환하고 끝나는 단순한 call로 두면 결과 판정이 쉽습니다.
+    permissionMode: "bypassPermissions",
+    systemPrompt: "Reply exactly APP_RUNTIME_OK and do not use tools.",
+    message: "Reply exactly: APP_RUNTIME_OK",
+
+    // First-run auth나 CLI bootstrap은 일반 turn보다 느릴 수 있습니다.
+    timeout: 120_000,
+  });
+
+  const text = result.result.trim();
+  return {
+    ok: text.includes("APP_RUNTIME_OK"),
+    response: text.slice(0, 500),
+  };
+}
+```
+
+이 방식은 단순 path check보다 더 강한 신뢰를 줍니다. SNA가 runtime을 spawn하고, prompt를 넘기고, output을 받고, one-shot session을 정상 완료할 수 있는지 확인하기 때문입니다.
+
+## Model은 list한 뒤 등록하기
+
+`agent.listModels(runtime, config?)`는 catalog call입니다. `config.cliPath`는 Codex나 OpenCode처럼 CLI를 inspect하는 runtime의 model listing에만 영향을 줍니다. 일반 agent spawn 경로를 바꾸려면 launcher `runtimePaths` 또는 `SNA_*_COMMAND` 쪽을 써야 합니다.
+
+```ts
+async function refreshCatalog(client: SnaClient, runtimeId: RuntimeId, cliPath?: string) {
+  const catalog = await client.agent.listModels(runtimeId, {
+    // Settings에서 CLI path를 막 수정한 직후 catalog probe에 유용합니다.
+    cliPath,
+
+    // 사용자가 refresh button을 누른 경우 provider-side cache를 우회합니다.
+    refresh: true,
+  });
+
+  if (catalog.error) {
+    // UI는 fallback model을 보여줄 수 있지만, partial warning을 같이 표시하면 디버깅이 쉬워집니다.
+    toast.warning(`Model catalog was partial: ${catalog.error}`);
+  }
+
+  return catalog.models;
+}
+
+async function registerModel(runtimeId: RuntimeId, model: RuntimeModelInfo) {
+  // Registration은 product decision입니다. SNA model id는 runtime-native slug로 저장하고,
+  // app selector에서는 app-owned compound id를 씁니다.
+  await settingsDb.addModel(runtimeId, {
+    id: `${runtimeId}/${model.id}`,
+    modelSlug: model.id,
+    label: model.label,
+    provider: model.provider,
+  });
+}
+```
+
+이 two-step flow를 쓰면 사용자가 catalog를 보고 원하는 entry만 추가할 수 있습니다. Runtime을 나중에 disabled로 바꿔도 model list 자체는 유지할 수 있습니다.
+
+## React settings flow
+
+Settings UI는 host API 위의 얇은 shell로 두면 다루기 쉽습니다. Filesystem validation, env mirroring, SNA health check는 host process가 맡고, renderer는 사용자 intent를 조율합니다.
+
+```tsx
+function RuntimeSetupPanel({ runtimeId }: { runtimeId: RuntimeId }) {
+  const [cliPath, setCliPath] = useState("");
+  const [models, setModels] = useState<RuntimeModelInfo[]>([]);
+  const [testing, setTesting] = useState(false);
+
+  async function redetect() {
+    // Host code는 login-shell lookup, static candidates, cache write를 사용할 수 있습니다.
+    const path = await window.appRuntime.redetect(runtimeId);
+    if (path) setCliPath(path);
+  }
+
+  async function saveAndTest() {
+    setTesting(true);
+    try {
+      // 먼저 persist해야 SNA provider가 runOnce 중 이 path를 resolve할 수 있습니다.
+      await window.appRuntime.setPath(runtimeId, cliPath);
+
+      // 이것은 fake ping이 아니라 SNA를 통한 실제 runtime invocation입니다.
+      const result = await window.appRuntime.test(runtimeId);
+      if (!result.ok) throw new Error(result.response || "Runtime test failed");
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  async function refreshModels() {
+    // CLI path는 catalog probing에 도움을 줍니다. 일반 agent spawn은 setPath/startup runtimePaths가 저장한 path를 씁니다.
+    const catalog = await window.appRuntime.listModels(runtimeId, { cliPath, refresh: true });
+    setModels(catalog.models);
+  }
+
+  async function addModel(model: RuntimeModelInfo) {
+    // Product picker에 실제로 보여줄 model만 저장합니다.
+    await window.appRuntime.registerModel(runtimeId, model);
+  }
+
+  return (
+    <section>
+      <input value={cliPath} onChange={(event) => setCliPath(event.target.value)} />
+      <button onClick={redetect}>Redetect</button>
+      <button onClick={saveAndTest} disabled={testing}>Test runtime</button>
+      <button onClick={refreshModels}>Refresh models</button>
+      {models.map((model) => (
+        <button key={model.id} onClick={() => addModel(model)}>
+          Add {model.label}
+        </button>
+      ))}
+    </section>
+  );
+}
+```
+
+여기서 중요한 product boundary는 renderer가 SNA runtime environment를 직접 추측해서 바꾸지 않는 점입니다. Renderer는 host에게 save, test, list, register를 요청하고, host가 실제 environment mutation을 책임지는 구조가 안정적입니다.

--- a/apps/docs/content/docs/cookbook/runtime-setup.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.mdx
@@ -1,0 +1,263 @@
+---
+title: Runtime setup
+description: Detect runtimes, persist CLI paths, register models, and test installs.
+icon: Settings2
+---
+
+Agentic products usually need a settings flow around runtimes. Loom treats runtime setup as two separate concerns:
+
+- **Path detection** finds the real CLI binary on the user's machine.
+- **Runtime registration** decides which runtimes and models the product exposes in its UI.
+
+Keeping those concerns separate makes settings screens easier to reason about. Auto-detection can prefill good defaults, while users still control the registered model list.
+
+## Detection is not registration
+
+A runtime can be detected without being enabled. A model can be listed without being registered. The product should keep both pieces of state.
+
+```ts
+type RuntimeId = "claude-code" | "codex" | "opencode" | "grok" | "cursor";
+
+type RegisteredModel = {
+  // Stable app-level id. A compound id keeps model selectors unambiguous.
+  id: `${RuntimeId}/${string}`;
+
+  // Runtime-native model slug passed back to SNA on startAgent/runOnce.
+  modelSlug: string;
+
+  // Human label shown in the settings UI and model picker.
+  label: string;
+
+  // Provider family is useful for grouping, attribution, and billing views.
+  provider: "anthropic" | "openai" | "oss" | string;
+};
+
+type RuntimeSlot = {
+  // The user can toggle a detected runtime off without losing its config.
+  enabled: boolean;
+
+  config: {
+    // CLI runtimes use cliPath. Hosted or local API runtimes may use baseUrl/apiKey.
+    cliPath?: string;
+    baseUrl?: string;
+    apiKey?: string;
+  };
+
+  // The app owns this curated list. It may be seeded from SNA's model catalog.
+  models: RegisteredModel[];
+};
+```
+
+## Resolve CLI paths in a predictable order
+
+Loom resolves CLI paths in this order:
+
+1. A user override saved from settings.
+2. A cache entry written by earlier detection.
+3. A fresh filesystem scan.
+
+That priority keeps user edits stable, but still gives first-run users a working default.
+
+```ts
+const RUNTIME_ENV: Record<RuntimeId, string> = {
+  "claude-code": "SNA_CLAUDE_COMMAND",
+  codex: "SNA_CODEX_COMMAND",
+  opencode: "SNA_OPENCODE_COMMAND",
+  grok: "SNA_GROK_COMMAND",
+  cursor: "SNA_CURSOR_COMMAND",
+};
+
+async function resolveRuntimePath(runtimeId: RuntimeId): Promise<string | null> {
+  // 1. A value typed by the user should win over every auto-detected path.
+  const override = await settingsDb.get(`runtime:${runtimeId}:path`);
+  if (override) return override;
+
+  // 2. Cache avoids shell probes on every app boot.
+  const cached = await pathCache.read(runtimeId);
+  if (cached) return cached;
+
+  // 3. Fresh detection can check static install locations and login-shell PATH.
+  const detected = await detectCliOnDisk(runtimeId);
+  if (detected) await pathCache.write(runtimeId, detected);
+  return detected;
+}
+
+async function setRuntimePath(runtimeId: RuntimeId, cliPath: string) {
+  // Validate before saving so a typo does not break future agent launches.
+  await validateExecutable(cliPath);
+
+  // Save the user's choice as an override, not as a cache entry.
+  await settingsDb.set(`runtime:${runtimeId}:path`, cliPath);
+
+  // If SNA is embedded in the same process, mirroring to process.env lets
+  // future provider spawns resolve the same path immediately.
+  process.env[RUNTIME_ENV[runtimeId]] = cliPath;
+}
+```
+
+## Pass runtime paths to the SNA launcher
+
+When launching SNA from Electron, pass the resolved runtime paths at startup. SNA maps these values to the provider environment variables used by runtime resolvers.
+
+```ts
+import { startSnaServerInProcess } from "@sna-sdk/core/electron";
+
+const runtimePaths = {
+  // Use the paths your settings layer resolved. Omit values that were not found.
+  claudeCode: (await resolveRuntimePath("claude-code")) ?? undefined,
+  codex: (await resolveRuntimePath("codex")) ?? undefined,
+  opencode: (await resolveRuntimePath("opencode")) ?? undefined,
+  grok: (await resolveRuntimePath("grok")) ?? undefined,
+  cursor: (await resolveRuntimePath("cursor")) ?? undefined,
+};
+
+const sna = await startSnaServerInProcess({
+  port: 3099,
+  dbPath: appPaths.snaDb,
+
+  // runtimePaths becomes SNA_CLAUDE_COMMAND, SNA_CODEX_COMMAND, and siblings.
+  runtimePaths,
+
+  // env is merged after runtimePaths, so it works as a final escape hatch.
+  env: {
+    SNA_MAX_SESSIONS: "20",
+  },
+});
+```
+
+For a forked standalone SNA server, path changes should usually be applied before launch or by restarting SNA. For in-process SNA, updating `process.env.SNA_*_COMMAND` in the host can affect later spawns because the providers resolve paths inside the same process.
+
+## Test the real runtime with `runOnce`
+
+A setup screen should test the real CLI path and agent bootstrap, not only check whether a file exists. The health check below assumes the path was already saved into the host settings and mirrored to the SNA launch environment.
+
+```ts
+const HEALTH_MODELS: Partial<Record<RuntimeId, string>> = {
+  "claude-code": "haiku",
+  codex: "gpt-5.4-mini",
+  grok: "grok-build",
+  cursor: "auto",
+};
+
+async function testRuntime(client: SnaClient, runtimeId: RuntimeId) {
+  const result = await client.agent.runOnce({
+    provider: runtimeId,
+    model: HEALTH_MODELS[runtimeId],
+
+    // Keep setup probes out of the user's project directory.
+    cwd: `/tmp/my-app-runtime-tests/${runtimeId}`,
+
+    // This call is a health check, so it should return a sentinel and stop.
+    permissionMode: "bypassPermissions",
+    systemPrompt: "Reply exactly APP_RUNTIME_OK and do not use tools.",
+    message: "Reply exactly: APP_RUNTIME_OK",
+
+    // First-run auth or CLI bootstrap can be slower than a normal turn.
+    timeout: 120_000,
+  });
+
+  const text = result.result.trim();
+  return {
+    ok: text.includes("APP_RUNTIME_OK"),
+    response: text.slice(0, 500),
+  };
+}
+```
+
+This gives you stronger confidence than a path check: the app verified that SNA can spawn the runtime, pass a prompt, receive output, and complete the one-shot session.
+
+## List models before registering them
+
+`agent.listModels(runtime, config?)` is a catalog call. `config.cliPath` only affects model listing for runtimes that inspect their CLI, such as Codex and OpenCode. It does not replace launcher `runtimePaths` for normal agent spawns.
+
+```ts
+async function refreshCatalog(client: SnaClient, runtimeId: RuntimeId, cliPath?: string) {
+  const catalog = await client.agent.listModels(runtimeId, {
+    // Useful when the user just edited a CLI path in settings.
+    cliPath,
+
+    // Bypass provider-side cache for an explicit refresh button.
+    refresh: true,
+  });
+
+  if (catalog.error) {
+    // The UI can still render fallback models, but should surface the warning.
+    toast.warning(`Model catalog was partial: ${catalog.error}`);
+  }
+
+  return catalog.models;
+}
+
+async function registerModel(runtimeId: RuntimeId, model: RuntimeModelInfo) {
+  // Registration is a product decision. The model id from SNA becomes the
+  // runtime-native slug; the app stores a compound id for its own selectors.
+  await settingsDb.addModel(runtimeId, {
+    id: `${runtimeId}/${model.id}`,
+    modelSlug: model.id,
+    label: model.label,
+    provider: model.provider,
+  });
+}
+```
+
+This two-step flow is useful for product UX: users can inspect a catalog, add only the entries they want, and later disable a runtime without deleting its model list.
+
+## React settings flow
+
+The settings UI can be a thin shell over host APIs. Keep filesystem validation, env mirroring, and SNA health checks in the host process; the renderer only coordinates user intent.
+
+```tsx
+function RuntimeSetupPanel({ runtimeId }: { runtimeId: RuntimeId }) {
+  const [cliPath, setCliPath] = useState("");
+  const [models, setModels] = useState<RuntimeModelInfo[]>([]);
+  const [testing, setTesting] = useState(false);
+
+  async function redetect() {
+    // Host code can use login-shell lookup, static candidates, and cache writes.
+    const path = await window.appRuntime.redetect(runtimeId);
+    if (path) setCliPath(path);
+  }
+
+  async function saveAndTest() {
+    setTesting(true);
+    try {
+      // Persist first so the SNA provider resolves this path during runOnce.
+      await window.appRuntime.setPath(runtimeId, cliPath);
+
+      // This is a real runtime invocation through SNA, not only a fake ping.
+      const result = await window.appRuntime.test(runtimeId);
+      if (!result.ok) throw new Error(result.response || "Runtime test failed");
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  async function refreshModels() {
+    // The CLI path helps catalog probing. Normal agent spawn still uses the
+    // path saved through setPath/startup runtimePaths.
+    const catalog = await window.appRuntime.listModels(runtimeId, { cliPath, refresh: true });
+    setModels(catalog.models);
+  }
+
+  async function addModel(model: RuntimeModelInfo) {
+    // Store only models the user actually wants in the product picker.
+    await window.appRuntime.registerModel(runtimeId, model);
+  }
+
+  return (
+    <section>
+      <input value={cliPath} onChange={(event) => setCliPath(event.target.value)} />
+      <button onClick={redetect}>Redetect</button>
+      <button onClick={saveAndTest} disabled={testing}>Test runtime</button>
+      <button onClick={refreshModels}>Refresh models</button>
+      {models.map((model) => (
+        <button key={model.id} onClick={() => addModel(model)}>
+          Add {model.label}
+        </button>
+      ))}
+    </section>
+  );
+}
+```
+
+The key product boundary is that the renderer never guesses how to mutate SNA's runtime environment. It asks the host to save, test, list, and register.


### PR DESCRIPTION
## Summary
- Add Loom-inspired Cookbook pages for one-shot jobs and runtime setup.
- Expand agentic app hosting examples with commented React/SNA integration snippets.
- Link the new pages from EN/KO/JA cookbook indexes and navigation metadata.

## Verification
- git diff --check
- pnpm --filter docs types:check
- pnpm --filter docs build