### PR TITLE
docs: generalize cookbook, runtime guide, and 0.16 refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ app, pin exact package versions in `package.json` instead of relying on a
 floating range.
 
 ```bash
-pnpm add @sna-sdk/core@0.15.0 @sna-sdk/client@0.15.0
-pnpm add @sna-sdk/react@0.15.0
+pnpm add @sna-sdk/core@0.16.0 @sna-sdk/client@0.16.0
+pnpm add @sna-sdk/react@0.16.0
 ```
 
 If you find a bug or have a feature request, please open an issue:

--- a/apps/docs/content/docs/api/endpoints/meta.ja.json
+++ b/apps/docs/content/docs/api/endpoints/meta.ja.json
@@ -3,7 +3,6 @@
   "description": "OpenAPI からレンダリングした HTTP エンドポイントリファレンスです。",
   "icon": "Route",
   "pages": [
-    "index",
     "---システム---",
     "health/get",
     "api/sna-port/get",

--- a/apps/docs/content/docs/api/endpoints/meta.json
+++ b/apps/docs/content/docs/api/endpoints/meta.json
@@ -3,7 +3,6 @@
   "description": "OpenAPI-rendered HTTP endpoint reference.",
   "icon": "Route",
   "pages": [
-    "index",
     "---System---",
     "health/get",
     "api/sna-port/get",

--- a/apps/docs/content/docs/api/endpoints/meta.ko.json
+++ b/apps/docs/content/docs/api/endpoints/meta.ko.json
@@ -3,7 +3,6 @@
   "description": "OpenAPI에서 렌더링한 HTTP 엔드포인트 레퍼런스입니다.",
   "icon": "Route",
   "pages": [
-    "index",
     "---시스템---",
     "health/get",
     "api/sna-port/get",

--- a/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
@@ -1,10 +1,10 @@
 ---
-title: Agentic app hosting
-description: 実アプリに SNA を組み込むときに Loom で使っている product integration pattern。
+title: アプリに SNA を組み込む
+description: 実アプリに SNA を組み込むときの product integration pattern。
 icon: AppWindow
 ---
 
-Loom は SNA を一回限りの chat endpoint としてではなく、local / cloud 対応の agent runtime としてアプリ内に組み込んでいます。Product が project、tab、document、permission、background workflow を agent の周辺に持つ場合、次の pattern が役立ちます。
+SNA は一回限りの chat endpoint としてだけでなく、local / cloud 対応の agent runtime としてアプリ内に組み込めます。Product が project、tab、document、permission、background workflow を agent の周辺に持つ場合、次の pattern が役立ちます。
 
 ## 1. App session と SNA session を分ける
 
@@ -97,7 +97,7 @@ export function onAgentEventAll(listener: (event: unknown) => void) {
 
 ## 3. Command は host 経由、event は SNA から直接受ける
 
-Loom は path を分けています。
+Product app では、path を次のように分けると扱いやすいです。
 
 | Path | Route | 理由 |
 | --- | --- | --- |

--- a/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
@@ -1,10 +1,10 @@
 ---
-title: Agentic app hosting
-description: 실제 앱 안에 SNA를 내장할 때 Loom에서 쓰는 제품 통합 패턴입니다.
+title: 앱에 SNA 내장하기
+description: 실제 앱 안에 SNA를 내장할 때 쓰는 제품 통합 패턴입니다.
 icon: AppWindow
 ---
 
-Loom은 SNA를 일회성 chat endpoint로 쓰지 않고, local/cloud agent runtime으로 앱 안에 내장합니다. 제품이 project, tab, document, permission, background workflow를 agent 주변에 가지고 있을 때 아래 패턴이 유용합니다.
+SNA는 일회성 chat endpoint가 아니라 local/cloud agent runtime으로 앱 안에 내장할 수 있습니다. 제품이 project, tab, document, permission, background workflow를 agent 주변에 가지고 있을 때 아래 패턴이 유용합니다.
 
 ## 1. 앱 세션과 SNA 세션을 분리하기
 
@@ -97,7 +97,7 @@ export function onAgentEventAll(listener: (event: unknown) => void) {
 
 ## 3. Command는 host를 통하고 event는 SNA로 직접 받기
 
-Loom은 경로를 분리합니다.
+제품 앱에서는 보통 경로를 이렇게 분리하면 다루기 쉽습니다.
 
 | Path | Route | 이유 |
 | --- | --- | --- |

--- a/apps/docs/content/docs/cookbook/agentic-apps.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.mdx
@@ -1,10 +1,10 @@
 ---
-title: Agentic app hosting
-description: Product integration patterns from Loom for embedding SNA inside a real app.
+title: Embedding SNA in an app
+description: Product integration patterns for embedding SNA inside a real app.
 icon: AppWindow
 ---
 
-Loom embeds SNA as a local and cloud-capable agent runtime rather than treating it as a throwaway chat endpoint. These patterns are useful when a product owns projects, tabs, documents, permissions, and background workflows around an agent.
+SNA can be embedded as a local and cloud-capable agent runtime rather than treated as a throwaway chat endpoint. These patterns are useful when a product owns projects, tabs, documents, permissions, and background workflows around an agent.
 
 ## 1. Keep app sessions separate from SNA sessions
 
@@ -97,7 +97,7 @@ The important part is that UI components subscribe to the app-level aggregator, 
 
 ## 3. Route commands through the host, events through SNA
 
-Loom uses a split path:
+A common product architecture uses a split path:
 
 | Path | Route | Why |
 | --- | --- | --- |

--- a/apps/docs/content/docs/cookbook/index.ja.mdx
+++ b/apps/docs/content/docs/cookbook/index.ja.mdx
@@ -10,7 +10,7 @@ icon: LayoutGrid
   <Card title="ストリーミング completion" href="/ja/docs/cookbook/streaming" description="単発プロンプトのトークン単位 UX。" />
   <Card title="権限フロー" href="/ja/docs/cookbook/permissions" description="承認 UI の接続と safe-tool allowlist。" />
   <Card title="マルチランタイムセッション" href="/ja/docs/cookbook/multi-provider" description="履歴を保ったままスレッド途中でランタイムを切り替え。" />
-  <Card title="Agentic app hosting" href="/ja/docs/cookbook/agentic-apps" description="Loom で使っている SNA 組み込みアプリのパターン。" />
+  <Card title="アプリに SNA を組み込む" href="/ja/docs/cookbook/agentic-apps" description="Product に SNA を組み込む pattern。" />
   <Card title="One-shot jobs" href="/ja/docs/cookbook/one-shot-jobs" description="completion、runOnce、runOnceStream で product task を処理。" />
   <Card title="Runtime setup" href="/ja/docs/cookbook/runtime-setup" description="runtime 検出、path 保存、model 登録、install test。" />
 </Cards>

--- a/apps/docs/content/docs/cookbook/index.ko.mdx
+++ b/apps/docs/content/docs/cookbook/index.ko.mdx
@@ -10,7 +10,7 @@ icon: LayoutGrid
   <Card title="스트리밍 completion" href="/ko/docs/cookbook/streaming" description="단발 프롬프트의 토큰 단위 UX." />
   <Card title="권한 흐름" href="/ko/docs/cookbook/permissions" description="승인 UI 연결과 safe-tool allowlist." />
   <Card title="멀티 런타임 세션" href="/ko/docs/cookbook/multi-provider" description="히스토리를 유지한 채 스레드 도중 런타임 교체." />
-  <Card title="Agentic app hosting" href="/ko/docs/cookbook/agentic-apps" description="Loom에서 쓰는 SNA 내장 앱 패턴." />
+  <Card title="앱에 SNA 내장하기" href="/ko/docs/cookbook/agentic-apps" description="제품 안에 SNA를 내장하는 패턴." />
   <Card title="One-shot jobs" href="/ko/docs/cookbook/one-shot-jobs" description="completion, runOnce, runOnceStream으로 제품 작업 처리." />
   <Card title="Runtime setup" href="/ko/docs/cookbook/runtime-setup" description="런타임 감지, 경로 저장, 모델 등록, 설치 테스트." />
 </Cards>

--- a/apps/docs/content/docs/cookbook/index.mdx
+++ b/apps/docs/content/docs/cookbook/index.mdx
@@ -10,7 +10,7 @@ Task-shaped recipes for the patterns we get asked about most.
   <Card title="Streaming completions" href="/docs/cookbook/streaming" description="Token-by-token UX for one-shot prompts and runOnce." />
   <Card title="Permission flows" href="/docs/cookbook/permissions" description="Wiring approval UIs and safe-tool allowlists." />
   <Card title="Multi-runtime sessions" href="/docs/cookbook/multi-provider" description="Switch runtimes mid-thread without losing history." />
-  <Card title="Agentic app hosting" href="/docs/cookbook/agentic-apps" description="Patterns from Loom for embedding SNA inside a product." />
+  <Card title="Embedding SNA in an app" href="/docs/cookbook/agentic-apps" description="Patterns for embedding SNA inside a product." />
   <Card title="One-shot jobs" href="/docs/cookbook/one-shot-jobs" description="Use completion, runOnce, and runOnceStream for product tasks." />
   <Card title="Runtime setup" href="/docs/cookbook/runtime-setup" description="Detect runtimes, persist paths, register models, and test installs." />
 </Cards>

--- a/apps/docs/content/docs/cookbook/one-shot-jobs.ja.mdx
+++ b/apps/docs/content/docs/cookbook/one-shot-jobs.ja.mdx
@@ -4,7 +4,7 @@ description: completion、runOnce、runOnceStream call を product feature に�
 icon: Zap
 ---
 
-Loom は、ユーザーの長期 chat thread に入れたくない作業に one-shot call を使います。例: session title、query parsing、retrieval filtering、runtime health check、小さな background decision。
+ユーザーの長期 chat thread に入れたくない作業には、one-shot call がよく合います。例: session title、query parsing、retrieval filtering、runtime health check、小さな background decision。
 
 ## 最小の surface を選ぶ
 

--- a/apps/docs/content/docs/cookbook/one-shot-jobs.ko.mdx
+++ b/apps/docs/content/docs/cookbook/one-shot-jobs.ko.mdx
@@ -4,7 +4,7 @@ description: completion, runOnce, runOnceStream 호출을 제품 기능에 쓰�
 icon: Zap
 ---
 
-Loom은 사용자 장기 chat thread에 들어가면 안 되는 작업에 one-shot 호출을 씁니다. 예: session title, query parsing, retrieval filtering, runtime health check, 작은 background decision.
+사용자 장기 chat thread에 들어가면 안 되는 작업에는 one-shot 호출을 쓰는 구조가 잘 맞습니다. 예: session title, query parsing, retrieval filtering, runtime health check, 작은 background decision.
 
 ## 가장 작은 surface 선택하기
 

--- a/apps/docs/content/docs/cookbook/one-shot-jobs.mdx
+++ b/apps/docs/content/docs/cookbook/one-shot-jobs.mdx
@@ -4,7 +4,7 @@ description: Product patterns for completion, runOnce, and runOnceStream calls.
 icon: Zap
 ---
 
-Loom uses one-shot calls for work that should not become part of a user's long-lived chat thread: session titles, query parsing, retrieval filtering, runtime health checks, and small background decisions.
+Use one-shot calls for work that should not become part of a user's long-lived chat thread: session titles, query parsing, retrieval filtering, runtime health checks, and small background decisions.
 
 ## Choose the smallest surface
 

--- a/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
@@ -4,7 +4,7 @@ description: runtime 検出、CLI path 保存、model 登録、install test の 
 icon: Settings2
 ---
 
-Agentic product には、runtime settings flow が必要になることがよくあります。Loom では runtime setup を 2 つの関心事に分けています。
+Agentic product には、runtime settings flow が必要になることがよくあります。Runtime setup は 2 つの関心事に分けると理解しやすくなります。
 
 - **Path detection** は、ユーザーの machine 上にある実際の CLI binary を見つけます。
 - **Runtime registration** は、product UI にどの runtime と model を出すかを決めます。
@@ -50,7 +50,7 @@ type RuntimeSlot = {
 
 ## CLI path は予測しやすい順序で resolve する
 
-Loom は CLI path を次の順序で resolve しています。
+CLI path は次の順序で resolve すると扱いやすいです。
 
 1. Settings で保存した user override。
 2. 以前の detection が残した cache entry。

--- a/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
@@ -4,7 +4,7 @@ description: 런타임 감지, CLI 경로 저장, 모델 등록, 설치 테스�
 icon: Settings2
 ---
 
-Agentic product에는 보통 runtime settings flow가 필요합니다. Loom은 runtime setup을 두 가지 관심사로 나눠서 다룹니다.
+Agentic product에는 보통 runtime settings flow가 필요합니다. Runtime setup은 두 가지 관심사로 나눠서 다루면 이해하기 쉽습니다.
 
 - **Path detection**은 사용자 machine에 있는 실제 CLI binary를 찾습니다.
 - **Runtime registration**은 product UI에 어떤 runtime과 model을 노출할지 결정합니다.
@@ -50,7 +50,7 @@ type RuntimeSlot = {
 
 ## CLI path는 예측 가능한 순서로 resolve하기
 
-Loom은 CLI path를 다음 순서로 resolve합니다.
+CLI path는 다음 순서로 resolve하는 패턴이 다루기 쉽습니다.
 
 1. Settings에서 저장한 user override.
 2. 이전 detection이 남긴 cache entry.

--- a/apps/docs/content/docs/cookbook/runtime-setup.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.mdx
@@ -4,7 +4,7 @@ description: Detect runtimes, persist CLI paths, register models, and test insta
 icon: Settings2
 ---
 
-Agentic products usually need a settings flow around runtimes. Loom treats runtime setup as two separate concerns:
+Agentic products usually need a settings flow around runtimes. It helps to treat runtime setup as two separate concerns:
 
 - **Path detection** finds the real CLI binary on the user's machine.
 - **Runtime registration** decides which runtimes and models the product exposes in its UI.
@@ -50,7 +50,7 @@ type RuntimeSlot = {
 
 ## Resolve CLI paths in a predictable order
 
-Loom resolves CLI paths in this order:
+Resolve CLI paths in this order:
 
 1. A user override saved from settings.
 2. A cache entry written by earlier detection.

--- a/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ja.mdx
@@ -23,7 +23,7 @@ SNA のすべての機能は同じ `AgentProvider` インターフェースを�
 
 | 能力 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
 |---|---|---|---|---|---|
-| ワイヤプロトコル | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio | `agent acp` ACP JSON-RPC stdio |
+| ワイヤプロトコル | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio | `cursor-agent acp` ACP JSON-RPC stdio |
 | `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ | ✗ |
 | `supportsCwdPerThread` | 該当なし | ✓ | ✗ | 該当なし | 該当なし |
 | 公開標準プロトコル | ✗ ベンダ | ✗ ベンダ | ✗ ベンダ | ✓ [ACP](https://agentclientprotocol.com) | ✓ [ACP](https://agentclientprotocol.com) |
@@ -45,9 +45,9 @@ Claude Code、Grok Build、Cursor は呼び出しまたはセッション単位�
 | 同じセッションの継続 | ✓ 同じ stream-json プロセス | ✓ 同じ Codex thread | ✓ 同じ OpenCode session | ✓ 同じ ACP session | ✓ 同じ ACP session |
 | turn 中の `interrupt()` | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) | ✓ (ACP `session/cancel`) |
 | `kill()` / `closeThread()` | ✓ | ✓ (プール refcount 認識) | ✓ (プール refcount 認識) | ✓ | ✓ |
-| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) | ✓ (`agent -p`) |
+| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) | ✓ (`cursor-agent -p`) |
 | `complete()` `onDelta` ストリーミング | ✓ stream-json | ✓ `item/agentMessage/delta` | ✓ `prompt_async` SSE テキスト delta | ✓ streaming-json text イベント | ✓ stream-json `assistant` チャンク (`model_call_id` なし) |
-| `listModels()` | ✓ static catalog | ✓ `codex debug models` プローブ + static fallback | ✓ `opencode` CLI プローブ | ✓ static (単一: `grok-build`) | ✓ `agent models` テキストパース + static fallback |
+| `listModels()` | ✓ static catalog | ✓ `codex debug models` プローブ + static fallback | ✓ `opencode` CLI プローブ | ✓ static (単一: `grok-build`) | ✓ `cursor-agent models` テキストパース + static fallback |
 
 「同じセッションの継続」は、通常のチャット経路です。同じ SNA セッションに
 もう一度 `agent.send` を呼びます。`resumeSessionId` と正規化履歴の再投入は

--- a/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.ko.mdx
@@ -22,7 +22,7 @@ icon: TableProperties
 
 | 능력 | Claude Code | Codex | OpenCode | Grok Build | Cursor |
 |---|---|---|---|---|---|
-| 와이어 프로토콜 | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio | `agent acp` ACP JSON-RPC stdio |
+| 와이어 프로토콜 | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio | `cursor-agent acp` ACP JSON-RPC stdio |
 | `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ | ✗ |
 | `supportsCwdPerThread` | 해당 없음 | ✓ | ✗ | 해당 없음 | 해당 없음 |
 | 공개 표준 프로토콜 | ✗ 벤더 | ✗ 벤더 | ✗ 벤더 | ✓ [ACP](https://agentclientprotocol.com) | ✓ [ACP](https://agentclientprotocol.com) |
@@ -44,9 +44,9 @@ ACP를 사용하는 두 런타임(Grok Build, Cursor)은
 | 같은 세션 이어가기 | ✓ 같은 stream-json 프로세스 | ✓ 같은 Codex thread | ✓ 같은 OpenCode session | ✓ 같은 ACP session | ✓ 같은 ACP session |
 | turn 중간 `interrupt()` | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) | ✓ (ACP `session/cancel`) |
 | `kill()` / `closeThread()` | ✓ | ✓ (풀 refcount 인식) | ✓ (풀 refcount 인식) | ✓ | ✓ |
-| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) | ✓ (`agent -p`) |
+| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) | ✓ (`cursor-agent -p`) |
 | `complete()` `onDelta` 스트리밍 | ✓ stream-json | ✓ `item/agentMessage/delta` | ✓ `prompt_async` SSE 텍스트 델타 | ✓ streaming-json text 이벤트 | ✓ stream-json `assistant` 청크 (`model_call_id` 없음) |
-| `listModels()` | ✓ static catalog | ✓ `codex debug models` 프로브 + static fallback | ✓ `opencode` CLI 프로브 | ✓ static (`grok-build` 단일 항목) | ✓ `agent models` 텍스트 파싱 + static fallback |
+| `listModels()` | ✓ static catalog | ✓ `codex debug models` 프로브 + static fallback | ✓ `opencode` CLI 프로브 | ✓ static (`grok-build` 단일 항목) | ✓ `cursor-agent models` 텍스트 파싱 + static fallback |
 
 "같은 세션 이어가기"는 기본 채팅 경로입니다. 같은 SNA 세션에 다시
 `agent.send`를 호출하면 됩니다. `resumeSessionId`와 정규화 히스토리 재주입은

--- a/apps/docs/content/docs/introduction/feature-matrix.mdx
+++ b/apps/docs/content/docs/introduction/feature-matrix.mdx
@@ -22,7 +22,7 @@ native surface.
 
 | Capability | Claude Code | Codex | OpenCode | Grok Build | Cursor |
 |---|---|---|---|---|---|
-| Wire protocol | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio | `agent acp` ACP JSON-RPC stdio |
+| Wire protocol | `claude -p` stream-json / `--resume` JSONL | `codex app-server` JSON-RPC stdio | `opencode serve` HTTP + SDK | `grok agent stdio` ACP JSON-RPC stdio | `cursor-agent acp` ACP JSON-RPC stdio |
 | `supportsRuntimePooling` | ✗ | ✓ | ✓ | ✗ | ✗ |
 | `supportsCwdPerThread` | n/a | ✓ | ✗ | n/a | n/a |
 | Public-standard protocol | ✗ vendor | ✗ vendor | ✗ vendor | ✓ [ACP](https://agentclientprotocol.com) | ✓ [ACP](https://agentclientprotocol.com) |
@@ -45,9 +45,9 @@ directories on a single pooled daemon. The two ACP-speaking runtimes
 | Active same-session continuation | ✓ same stream-json process | ✓ same Codex thread | ✓ same OpenCode session | ✓ same ACP session | ✓ same ACP session |
 | `interrupt()` mid-turn | ✓ | ✓ | ✓ | ✓ (ACP `session/cancel`) | ✓ (ACP `session/cancel`) |
 | `kill()` / `closeThread()` | ✓ | ✓ (pool refcount aware) | ✓ (pool refcount aware) | ✓ | ✓ |
-| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) | ✓ (`agent -p`) |
+| `complete(opts)` one-shot | ✓ | ✓ | ✓ | ✓ (`grok -p`) | ✓ (`cursor-agent -p`) |
 | `complete()` `onDelta` streaming | ✓ stream-json | ✓ `item/agentMessage/delta` | ✓ `prompt_async` SSE text deltas | ✓ streaming-json text events | ✓ stream-json `assistant` chunks (no `model_call_id`) |
-| `listModels()` | ✓ static catalog | ✓ probes `codex debug models` + static fallback | ✓ probes `opencode` CLI | ✓ static (single entry: `grok-build`) | ✓ parses `agent models` (plain text) + static fallback |
+| `listModels()` | ✓ static catalog | ✓ probes `codex debug models` + static fallback | ✓ probes `opencode` CLI | ✓ static (single entry: `grok-build`) | ✓ parses `cursor-agent models` (plain text) + static fallback |
 
 The "same-session continuation" row is the default chat path: call
 `agent.send` again on the same SNA session. `resumeSessionId` and

--- a/apps/docs/content/docs/introduction/index.ja.mdx
+++ b/apps/docs/content/docs/introduction/index.ja.mdx
@@ -62,7 +62,7 @@ SNA server  ──spawn──►  claude | codex | opencode
 ## 1. インストール
 
 ```bash
-pnpm add @sna-sdk/core@0.15.0 @sna-sdk/client@0.15.0
+pnpm add @sna-sdk/core@0.16.0 @sna-sdk/client@0.16.0
 ```
 
 SNA はまだ `0.x.x` 系です。アプリで使う場合は、正確なパッケージ

--- a/apps/docs/content/docs/introduction/index.ko.mdx
+++ b/apps/docs/content/docs/introduction/index.ko.mdx
@@ -61,7 +61,7 @@ SNA server  ──spawn──►  claude | codex | opencode
 ## 1. 설치
 
 ```bash
-pnpm add @sna-sdk/core@0.15.0 @sna-sdk/client@0.15.0
+pnpm add @sna-sdk/core@0.16.0 @sna-sdk/client@0.16.0
 ```
 
 SNA는 아직 `0.x.x` 버전대라 앱에서 사용할 때는 정확한 패키지 버전을

--- a/apps/docs/content/docs/introduction/index.mdx
+++ b/apps/docs/content/docs/introduction/index.mdx
@@ -61,7 +61,7 @@ history, runtime swaps, attribution), read **[What is SNA?](/docs/introduction/w
 ## 1. Install
 
 ```bash
-pnpm add @sna-sdk/core@0.15.0 @sna-sdk/client@0.15.0
+pnpm add @sna-sdk/core@0.16.0 @sna-sdk/client@0.16.0
 ```
 
 SNA is still in the `0.x.x` line, so pin exact package versions in apps

--- a/apps/docs/content/docs/introduction/install.ja.mdx
+++ b/apps/docs/content/docs/introduction/install.ja.mdx
@@ -28,9 +28,9 @@ floating range に頼らず、`package.json` で正確なバージョンを固�
 ## アプリへ追加する
 
 ```bash
-pnpm add @sna-sdk/core@0.15.0 @sna-sdk/client@0.15.0
+pnpm add @sna-sdk/core@0.16.0 @sna-sdk/client@0.16.0
 # React アプリの場合
-pnpm add @sna-sdk/react@0.15.0
+pnpm add @sna-sdk/react@0.16.0
 ```
 
 ## モノレポで作業する

--- a/apps/docs/content/docs/introduction/install.ko.mdx
+++ b/apps/docs/content/docs/introduction/install.ko.mdx
@@ -27,9 +27,9 @@ range에 의존하지 말고 `package.json`에 정확한 버전을 고정하십�
 ## 앱에 추가하기
 
 ```bash
-pnpm add @sna-sdk/core@0.15.0 @sna-sdk/client@0.15.0
+pnpm add @sna-sdk/core@0.16.0 @sna-sdk/client@0.16.0
 # React 앱이라면
-pnpm add @sna-sdk/react@0.15.0
+pnpm add @sna-sdk/react@0.16.0
 ```
 
 ## 모노레포에서 작업하기

--- a/apps/docs/content/docs/introduction/install.mdx
+++ b/apps/docs/content/docs/introduction/install.mdx
@@ -27,9 +27,9 @@ If you find a bug or have a feature request, please open an issue on
 ## In a consumer app
 
 ```bash
-pnpm add @sna-sdk/core@0.15.0 @sna-sdk/client@0.15.0
+pnpm add @sna-sdk/core@0.16.0 @sna-sdk/client@0.16.0
 # React app?
-pnpm add @sna-sdk/react@0.15.0
+pnpm add @sna-sdk/react@0.16.0
 ```
 
 ## From the monorepo

--- a/apps/docs/content/docs/introduction/meta.ja.json
+++ b/apps/docs/content/docs/introduction/meta.ja.json
@@ -17,6 +17,8 @@
     "feature-matrix",
     "permissions",
     "---哲学---",
-    "philosophy"
+    "philosophy/origin",
+    "philosophy/actor-kind",
+    "philosophy/acp"
   ]
 }

--- a/apps/docs/content/docs/introduction/meta.json
+++ b/apps/docs/content/docs/introduction/meta.json
@@ -17,6 +17,8 @@
     "feature-matrix",
     "permissions",
     "---Philosophy---",
-    "philosophy"
+    "philosophy/origin",
+    "philosophy/actor-kind",
+    "philosophy/acp"
   ]
 }

--- a/apps/docs/content/docs/introduction/meta.ko.json
+++ b/apps/docs/content/docs/introduction/meta.ko.json
@@ -17,6 +17,8 @@
     "feature-matrix",
     "permissions",
     "---철학---",
-    "philosophy"
+    "philosophy/origin",
+    "philosophy/actor-kind",
+    "philosophy/acp"
   ]
 }

--- a/apps/docs/content/docs/introduction/providers.ja.mdx
+++ b/apps/docs/content/docs/introduction/providers.ja.mdx
@@ -9,6 +9,23 @@ icon: Boxes
 ACP を話すランタイム (Grok Build と Cursor) は `core/providers/acp/base.ts`
 を共有します。
 
+## 対応ランタイム概要
+
+SNA は、product が 1 つの CLI に固定されず、workflow に合う runtime を
+選べるように設計されています。次の表は product 観点の概要です。細かな
+機能対応は **[機能 × ランタイムマトリクス](/ja/docs/introduction/feature-matrix)**
+で確認できます。
+
+| ランタイム | 向いている用途 | 強み | Tradeoff |
+|------------|----------------|------|----------|
+| **Claude Code** | Anthropic model と安定した local coding session、豊かな permission behavior が必要な場合。 | CLI behavior が成熟していて、tool-use UX が良いです。Thinking/tool input delta streaming と token/cost metadata が詳しいです。 | 呼び出し/セッションごとに stateless なので daemon pooling はありません。Permission approval は SNA との双方向通信ではなく hook ベースです。 |
+| **Codex** | 多数の session、one-shot job、頻繁な runtime reuse が必要な low-latency product integration。 | `RuntimePool` で daemon を再利用し、thread ごとの cwd 変更をサポートします。Item lifecycle event と shell output delta が豊富です。 | Codex native config shape が別にあり、Claude Code の stream-json のような tool input delta は露出しません。 |
+| **OpenCode** | OpenCode をすでに使っている app、または OpenCode model/provider 設定を HTTP daemon として使いたい app。 | Pooled daemon と SDK-backed HTTP path を使えます。1 つの cwd で repeated prompt を処理しやすいです。 | Daemon は single-cwd で、一部 runtime mutation は respawn が必要です。Event detail は OpenCode stream が出す範囲に依存します。 |
+| **Grok Build** | Grok Build と公開 protocol surface である ACP を使いたい session。 | SNA の shared ACP adapter を使い、bidirectional permission request と単純な stateless session lifecycle を持ちます。 | Runtime pooling はなく、model/cwd 変更には respawn が必要です。Token/tool detail metadata は Claude/Codex より薄めです。 |
+| **Cursor** | Cursor を主な作業環境として使い、Cursor subscription-backed headless CLI を SNA から動かしたい場合。 | `cursor-agent` と既存の Cursor login を使います。ACP permission、Cursor model selection、model-id reasoning variant を利用できます。 | Daemon pooling はなく、model/cwd 変更には respawn が必要です。Setup はユーザーの Cursor CLI 認証状態に依存します。 |
+
+以下では、この product-level choice の裏側にある adapter 内部構造を説明します。
+
 ## AgentProvider
 
 ```ts
@@ -44,7 +61,7 @@ interface AgentProcess {
 | **codex** | `codex app-server` デーモン、stdio 上の JSON-RPC | 永続デーモン、マルチスレッド | はい |
 | **opencode** | `opencode serve` デーモン + SDK HTTP | 永続デーモン、single-cwd | はい |
 | **grok** | `grok agent stdio` (stdio 上の Agent Client Protocol — Grok Build CLI) | セッションごとに stateless | いいえ |
-| **cursor** | `agent acp` (stdio 上の Agent Client Protocol — Cursor CLI) | セッションごとに stateless | いいえ |
+| **cursor** | `cursor-agent acp` (stdio 上の Agent Client Protocol — Cursor CLI) | セッションごとに stateless | いいえ |
 
 Codex と OpenCode ランタイムアダプタは `RuntimePool` 経由でデーモンを共有
 します。セッションを開くとき、プールが `(provider, cwd, config)` で
@@ -69,7 +86,7 @@ content block として埋め込む方式で扱います — 機能マトリク�
 [ランタイム間 history replay](/ja/docs/introduction/feature-matrix)
 にまとめています。
 
-Cursor はユーザーがすでに済ませた `agent login` をそのまま使います
+Cursor はユーザーがすでに済ませた `cursor-agent login` をそのまま使います
 (macOS Keychain の `cursor-access-token` / `cursor-refresh-token` →
 Cursor サブスクリプションを利用)。`CURSOR_API_KEY` を別途発行する必要は
 ありません。SNA は spawn の環境変数をそのまま渡し、子プロセスは

--- a/apps/docs/content/docs/introduction/providers.ko.mdx
+++ b/apps/docs/content/docs/introduction/providers.ko.mdx
@@ -9,6 +9,23 @@ icon: Boxes
 ACP로 말하는 런타임(Grok Build, Cursor)은 `core/providers/acp/base.ts`를
 공유합니다.
 
+## 지원 런타임 개요
+
+SNA는 제품이 하나의 CLI에 고정되지 않고, workflow에 맞는 runtime을 고를 수
+있도록 설계되어 있습니다. 아래 표는 제품 관점의 개요입니다. 세부 기능 대응은
+**[기능 × 런타임 매트릭스](/ko/docs/introduction/feature-matrix)** 에서
+확인할 수 있습니다.
+
+| 런타임 | 잘 맞는 경우 | 장점 | Tradeoff |
+|--------|--------------|------|----------|
+| **Claude Code** | Anthropic model과 안정적인 local coding session, 풍부한 permission behavior가 필요한 경우. | CLI behavior가 성숙했고, tool-use UX가 좋습니다. Thinking/tool input delta streaming과 token/cost metadata가 자세합니다. | 호출/세션 단위 stateless 구조라 daemon pooling은 없습니다. Permission approval은 SNA와 양방향으로 주고받는 방식이 아니라 hook 기반입니다. |
+| **Codex** | 여러 session, one-shot job, 잦은 runtime reuse가 필요한 low-latency 제품 통합. | `RuntimePool`로 daemon을 재사용하고, thread별 cwd 변경을 지원합니다. Item lifecycle event와 shell output delta가 풍부합니다. | Codex native config shape가 따로 있고, Claude Code의 stream-json처럼 tool input delta를 노출하지는 않습니다. |
+| **OpenCode** | 이미 OpenCode를 쓰거나 OpenCode model/provider 설정을 HTTP daemon으로 활용하고 싶은 앱. | Pooled daemon과 SDK-backed HTTP path를 쓸 수 있고, 하나의 cwd에서 반복 prompt를 처리하기 좋습니다. | Daemon이 single-cwd이며, 일부 runtime mutation은 respawn이 필요합니다. Event detail은 OpenCode stream이 제공하는 범위에 좌우됩니다. |
+| **Grok Build** | Grok Build와 공개 protocol surface인 ACP를 쓰고 싶은 session. | SNA의 shared ACP adapter를 쓰고, bidirectional permission request와 단순한 stateless session lifecycle을 제공합니다. | Runtime pooling은 없고, model/cwd 변경은 respawn이 필요합니다. Token/tool detail metadata는 Claude/Codex보다 얇습니다. |
+| **Cursor** | Cursor를 주 작업 환경으로 쓰고, Cursor subscription-backed headless CLI를 SNA에서 구동하고 싶은 경우. | `cursor-agent`와 기존 Cursor login을 사용합니다. ACP permission, Cursor model selection, model-id reasoning variant를 활용할 수 있습니다. | Daemon pooling은 없고, model/cwd 변경은 respawn이 필요합니다. 사용자의 Cursor CLI 인증 상태에 setup이 의존합니다. |
+
+아래 내용은 이 product-level 선택지 뒤에 있는 adapter 내부 구조를 설명합니다.
+
 ## AgentProvider
 
 ```ts
@@ -44,7 +61,7 @@ respawn-with-history-replay가 필요한지 결정합니다.
 | **codex** | `codex app-server` 데몬, stdio 위 JSON-RPC | 영구 데몬, 멀티 스레드 | 예 |
 | **opencode** | `opencode serve` 데몬 + SDK HTTP | 영구 데몬, single-cwd | 예 |
 | **grok** | `grok agent stdio` (stdio 위 Agent Client Protocol — Grok Build CLI) | 세션 단위 무상태 | 아니오 |
-| **cursor** | `agent acp` (stdio 위 Agent Client Protocol — Cursor CLI) | 세션 단위 무상태 | 아니오 |
+| **cursor** | `cursor-agent acp` (stdio 위 Agent Client Protocol — Cursor CLI) | 세션 단위 무상태 | 아니오 |
 
 Codex와 OpenCode 런타임 어댑터는 `RuntimePool`을 통해 데몬을 공유합니다.
 세션이 열릴 때 `(provider, cwd, config)` 키로 풀이 조회되고, 호환되는
@@ -68,7 +85,7 @@ spawn 인자, 선택적 인증 단계(Cursor의 `authenticate({methodId:"cursor_
 [런타임 간 history replay](/ko/docs/introduction/feature-matrix)
 항목에 정리되어 있습니다.
 
-Cursor는 사용자가 이미 끝낸 `agent login`을 그대로 씁니다(macOS Keychain의
+Cursor는 사용자가 이미 끝낸 `cursor-agent login`을 그대로 씁니다(macOS Keychain의
 `cursor-access-token` / `cursor-refresh-token` 항목 → Cursor 구독 사용).
 `CURSOR_API_KEY` 같은 추가 발급이 필요 없습니다. SNA는 spawn 환경변수를
 그대로 통과시키고, 자식 프로세스는 사용자가 인터랙티브하게 쓸 때와 동일한

--- a/apps/docs/content/docs/introduction/providers.mdx
+++ b/apps/docs/content/docs/introduction/providers.mdx
@@ -9,6 +9,24 @@ Each runtime is implemented as a class behind a common
 `core/providers/{claude-code,codex,opencode,grok,cursor}.ts`.
 ACP-speaking runtimes (Grok Build, Cursor) share `core/providers/acp/base.ts`.
 
+## Supported runtimes
+
+SNA is designed to let a product choose the runtime that fits the workflow
+instead of baking in one CLI forever. The table below is a product-level
+overview; for exact feature support, see the
+**[Feature × runtime matrix](/docs/introduction/feature-matrix)**.
+
+| Runtime | Best fit | Strengths | Tradeoffs |
+|---------|----------|-----------|-----------|
+| **Claude Code** | Reliable local coding sessions with Anthropic models and rich permission behavior. | Mature CLI behavior, good tool-use UX, detailed token/cost metadata, strong streaming for thinking and tool input deltas. | Stateless per call/session, so there is no daemon pooling. Permission approval is hook-based rather than bidirectional over SNA. |
+| **Codex** | Low-latency product integrations that need many sessions, one-shot jobs, or frequent runtime reuse. | `RuntimePool` reuses a daemon, supports cwd changes per thread, emits rich item lifecycle events and shell output deltas. | Codex-specific configuration has its own native shape; tool input deltas are not exposed like Claude Code's stream-json path. |
+| **OpenCode** | Apps that already use OpenCode or want an HTTP daemon with OpenCode model/provider configuration. | Pooled daemon, SDK-backed HTTP path, good fit for repeated prompts in one cwd. | Daemon is single-cwd, some runtime mutations require respawn, and event detail depends on what OpenCode's stream exposes. |
+| **Grok Build** | ACP-based sessions with Grok Build and a public protocol surface. | Shares the SNA ACP adapter, has bidirectional permission requests, straightforward stateless session lifecycle. | No runtime pooling, model/cwd changes require respawn, and metadata is thinner than Claude/Codex for token and tool detail. |
+| **Cursor** | Users who already live in Cursor and want SNA to drive the Cursor subscription-backed headless CLI. | Uses `cursor-agent` with existing Cursor login, ACP permissions, Cursor model selection, and model-id reasoning variants. | No daemon pooling, model/cwd changes require respawn, and setup depends on the user's Cursor CLI authentication state. |
+
+The rest of this page describes the adapter internals behind that
+product-facing choice.
+
 ## AgentProvider
 
 ```ts
@@ -44,7 +62,7 @@ apply in-place vs which require a respawn-with-history-replay.
 | **codex** | `codex app-server` daemon, JSON-RPC over stdio | persistent daemon, multi-thread | yes |
 | **opencode** | `opencode serve` daemon plus SDK HTTP | persistent daemon, single-cwd | yes |
 | **grok** | `grok agent stdio` (Agent Client Protocol over stdio — Grok Build CLI) | stateless per session | no |
-| **cursor** | `agent acp` (Agent Client Protocol over stdio — Cursor CLI) | stateless per session | no |
+| **cursor** | `cursor-agent acp` (Agent Client Protocol over stdio — Cursor CLI) | stateless per session | no |
 
 The Codex and OpenCode runtime adapters share daemons through `RuntimePool`.
 When a session opens, the pool is queried by `(provider, cwd, config)`
@@ -68,7 +86,7 @@ SNA's canonical history into a single ACP `resource` block on the first
 [Cross-runtime history replay](/docs/introduction/feature-matrix)
 on the feature matrix page.
 
-Cursor uses the user's existing `agent login` (macOS Keychain entries
+Cursor uses the user's existing `cursor-agent login` (macOS Keychain entries
 `cursor-access-token` / `cursor-refresh-token`) — and therefore the
 Cursor subscription. No `CURSOR_API_KEY` is required; SNA passes the
 spawn's environment through unchanged, and the child process picks up

--- a/apps/docs/content/docs/sdks/client.ja.mdx
+++ b/apps/docs/content/docs/sdks/client.ja.mdx
@@ -11,7 +11,7 @@ React 以外で使う場合や、独自 UI フレームワークの下位レイ�
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/client@0.15.0
+pnpm add @sna-sdk/client@0.16.0
 ~~~
 
 ## Public surfaces

--- a/apps/docs/content/docs/sdks/client.ko.mdx
+++ b/apps/docs/content/docs/sdks/client.ko.mdx
@@ -11,7 +11,7 @@ React 밖에서 사용하거나 자체 UI 프레임워크의 하위 계층으로
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/client@0.15.0
+pnpm add @sna-sdk/client@0.16.0
 ~~~
 
 ## Public surfaces

--- a/apps/docs/content/docs/sdks/client.mdx
+++ b/apps/docs/content/docs/sdks/client.mdx
@@ -11,7 +11,7 @@ Use this package outside React or underneath custom UI frameworks.
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/client@0.15.0
+pnpm add @sna-sdk/client@0.16.0
 ~~~
 
 ## Public surfaces

--- a/apps/docs/content/docs/sdks/core.ja.mdx
+++ b/apps/docs/content/docs/sdks/core.ja.mdx
@@ -11,7 +11,7 @@ Core は React もブラウザクライアントも前提にしません。設�
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/core@0.15.0
+pnpm add @sna-sdk/core@0.16.0
 ~~~
 
 Host application 側にも `better-sqlite3` をインストールしてください。Electron app では runtime に合わせて native binding を rebuild することが多いため、この dependency は peer dependency として扱っています。

--- a/apps/docs/content/docs/sdks/core.ko.mdx
+++ b/apps/docs/content/docs/sdks/core.ko.mdx
@@ -11,7 +11,7 @@ Core는 React를 가정하지 않으며 브라우저 클라이언트도 필요�
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/core@0.15.0
+pnpm add @sna-sdk/core@0.16.0
 ~~~
 
 Host application에는 `better-sqlite3`도 설치해야 합니다. Electron app은 native binding을 runtime에 맞게 다시 빌드해야 하는 경우가 많기 때문에 이 dependency는 peer dependency로 둡니다.

--- a/apps/docs/content/docs/sdks/core.mdx
+++ b/apps/docs/content/docs/sdks/core.mdx
@@ -11,7 +11,7 @@ Core does not assume React and does not require the browser client. It owns the 
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/core@0.15.0
+pnpm add @sna-sdk/core@0.16.0
 ~~~
 
 Install `better-sqlite3` in the host application as well. The package is a peer dependency because Electron apps often need a native binding rebuilt for their runtime.

--- a/apps/docs/content/docs/sdks/react.ja.mdx
+++ b/apps/docs/content/docs/sdks/react.ja.mdx
@@ -11,7 +11,7 @@ Runtime 検出、セッションスコープ、チャットパネル状態、age
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/react@0.15.0
+pnpm add @sna-sdk/react@0.16.0
 ~~~
 
 ## Public surfaces

--- a/apps/docs/content/docs/sdks/react.ko.mdx
+++ b/apps/docs/content/docs/sdks/react.ko.mdx
@@ -11,7 +11,7 @@ Runtime 탐색, 세션 스코프, 채팅 패널 상태, agent streaming을 React
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/react@0.15.0
+pnpm add @sna-sdk/react@0.16.0
 ~~~
 
 ## Public surfaces

--- a/apps/docs/content/docs/sdks/react.mdx
+++ b/apps/docs/content/docs/sdks/react.mdx
@@ -11,7 +11,7 @@ The package keeps runtime discovery, session scoping, chat panel state, and agen
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/react@0.15.0
+pnpm add @sna-sdk/react@0.16.0
 ~~~
 
 ## Public surfaces

--- a/apps/docs/content/docs/sdks/testing.ja.mdx
+++ b/apps/docs/content/docs/sdks/testing.ja.mdx
@@ -11,7 +11,7 @@ description: "決定的な SNA 統合テストのための mock LLM API、実 ru
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/testing@0.15.0
+pnpm add @sna-sdk/testing@0.16.0
 ~~~
 
 ## Public surfaces

--- a/apps/docs/content/docs/sdks/testing.ko.mdx
+++ b/apps/docs/content/docs/sdks/testing.ko.mdx
@@ -11,7 +11,7 @@ description: "결정적인 SNA 통합 테스트를 위한 mock LLM API, 실제 �
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/testing@0.15.0
+pnpm add @sna-sdk/testing@0.16.0
 ~~~
 
 ## Public surfaces

--- a/apps/docs/content/docs/sdks/testing.mdx
+++ b/apps/docs/content/docs/sdks/testing.mdx
@@ -11,7 +11,7 @@ Use it for smoke tests, runtime-adapter tests, mock-attached CLI contract tests,
 ## Install
 
 ~~~bash
-pnpm add @sna-sdk/testing@0.15.0
+pnpm add @sna-sdk/testing@0.16.0
 ~~~
 
 ## Public surfaces

--- a/apps/docs/openapi/sna.ja.json
+++ b/apps/docs/openapi/sna.ja.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "SNA SDK API",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "Skills-Native Application SDK — AI agent provider (Claude Code、Codex、OpenCode) を backend process として spawn し、通信するための HTTP API です。"
   },
   "components": {

--- a/apps/docs/openapi/sna.json
+++ b/apps/docs/openapi/sna.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "SNA SDK API",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "Skills-Native Application SDK — HTTP API for spawning and communicating with AI agent providers (Claude Code, Codex, OpenCode)."
   },
   "components": {

--- a/apps/docs/openapi/sna.ko.json
+++ b/apps/docs/openapi/sna.ko.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "SNA SDK API",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "Skills-Native Application SDK — AI agent provider(Claude Code, Codex, OpenCode)를 backend process로 spawn하고 통신하기 위한 HTTP API입니다."
   },
   "components": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ Every running agent is a `Session` owned by `SessionManager`. Each session has:
 
 - `process` — the spawned `AgentProcess` (Claude Code, Codex, or OpenCode), or `null` when idle
 - `eventBuffer` + `eventCounter` — append-only stream consumed by subscribers via `since`
-- `cwd`, `label`, `meta` — metadata persisted to `chat_sessions` so the SDK can be shared across apps. Use `meta.app: "loom"` (for example) to isolate sessions per consumer.
+- `cwd`, `label`, `meta` — metadata persisted to `chat_sessions` so the SDK can be shared across apps. Use `meta.app: "my-app"` (for example) to isolate sessions per consumer.
 - `config` — `SessionConfig` (`{ provider, modelProvider, model, cwd, permissionMode, providerOptions, ... }`), used by `agent.restart` to bring the same config back. The legacy field name was `lastStartConfig`; the type alias `StartConfig` is kept for one release.
 - `state` — `idle` | `processing` | `waiting` | `permission`
 - `ccSessionId` — the runtime's own session id, captured from the `init` event so `--resume` works
@@ -298,7 +298,7 @@ Supported `SnaServerOptions`: `port`, `dbPath`, `cwd`, `maxSessions`, `permissio
 | `SNA_CODEX_COMMAND` | Override the Codex binary |
 | `SNA_OPENCODE_COMMAND` | Override the OpenCode binary |
 | `SNA_GROK_COMMAND` | Override the Grok binary |
-| `SNA_CURSOR_COMMAND` | Override the Cursor headless agent binary |
+| `SNA_CURSOR_COMMAND` | Override the Cursor headless `cursor-agent` binary |
 
 Embedded hosts should prefer `startSnaServer({ runtimePaths })`, which maps to
 the same `SNA_*_COMMAND` variables while keeping runtime path registration in

--- a/packages/core/src/core/providers/cursor.ts
+++ b/packages/core/src/core/providers/cursor.ts
@@ -2,8 +2,7 @@
  * Cursor provider — ACP-over-stdio adapter, second provider on the shared
  * `AcpStdioProcess` base.
  *
- * Backed by Cursor's `agent acp` subcommand (the headless CLI shipped at
- * `~/.local/bin/agent` on macOS/Linux). The wire protocol is the standard
+ * Backed by Cursor's `cursor-agent acp` subcommand. The wire protocol is the standard
  * Agent Client Protocol (https://agentclientprotocol.com), so the bulk of
  * the work lives in `acp/base.ts` shared with Grok Build. This file is
  * the Cursor-specific subclass + provider entry: CLI path resolution,
@@ -12,12 +11,12 @@
  * drop, the `tool_call.<kind>ToolCall` wrapper unwrap (Cursor nests every
  * tool call under a per-tool variant key like `shellToolCall` /
  * `writeToolCall` / `readToolCall` / `createPlanToolCall`), and the
- * headless `agent -p` path used by `complete()`.
+ * headless `cursor-agent -p` path used by `complete()`.
  *
  * Design decisions specific to Cursor (the shared ACP decisions live at
  * the top of `acp/base.ts`):
  *
- *   • Authentication relies on the user's existing `agent login` —
+ *   • Authentication relies on the user's existing `cursor-agent login` —
  *     credentials live in the macOS Keychain (`cursor-access-token` /
  *     `cursor-refresh-token` under account `cursor-user`) and the
  *     Cursor subscription billing is used. We never touch
@@ -74,16 +73,16 @@ import {
 // ── CLI discovery ────────────────────────────────────────────────────────────
 
 /**
- * Resolve the path to the `agent` CLI (Cursor's headless binary).
+ * Resolve the path to the `cursor-agent` CLI (Cursor's headless binary).
  * Env override → static common locations → PATH lookup.
  */
 export function resolveCursorPath(_cwd: string = process.cwd()): string {
   if (process.env.SNA_CURSOR_COMMAND) return process.env.SNA_CURSOR_COMMAND;
   const home = process.env.HOME ?? "";
   const candidates = [
-    `${home}/.local/bin/agent`,
-    "/usr/local/bin/agent",
-    "/opt/homebrew/bin/agent",
+    `${home}/.local/bin/cursor-agent`,
+    "/usr/local/bin/cursor-agent",
+    "/opt/homebrew/bin/cursor-agent",
   ];
   for (const p of candidates) {
     try {
@@ -93,7 +92,7 @@ export function resolveCursorPath(_cwd: string = process.cwd()): string {
       // try next
     }
   }
-  return "agent";
+  return "cursor-agent";
 }
 
 // ── Cursor tool_call wrapper variants ───────────────────────────────────────
@@ -148,7 +147,7 @@ export class CursorProcess extends AcpStdioProcess {
   protected get vendorNotificationPrefix(): string { return "cursor/"; }
 
   protected resolveSpawn(options: SpawnOptions): AcpSpawnDescriptor {
-    // `agent acp` is the only subcommand for ACP mode. Unlike Grok, Cursor
+    // `cursor-agent acp` is the only subcommand for ACP mode. Unlike Grok, Cursor
     // doesn't accept top-level model/effort/permission flags on this path —
     // reasoning is encoded into the model id itself (composed by the
     // caller via applyCursorReasoning), and permissions are negotiated
@@ -172,7 +171,7 @@ export class CursorProcess extends AcpStdioProcess {
   /**
    * Cursor requires an explicit `authenticate({methodId: "cursor_login"})`
    * step between `initialize` and `session/new`. The actual credential
-   * comes from the macOS Keychain (populated by `agent login`); we never
+   * comes from the macOS Keychain (populated by `cursor-agent login`); we never
    * pass it inline — that would force per-token billing rather than the
    * user's Cursor subscription.
    */
@@ -183,7 +182,7 @@ export class CursorProcess extends AcpStdioProcess {
       // If the user is already authenticated, Cursor returns an error like
       // "already authenticated". That's not fatal — session/new will work.
       // Anything else, surface as a real failure so the consumer knows
-      // they need to run `agent login`.
+      // they need to run `cursor-agent login`.
       const msg = err instanceof Error ? err.message : String(err);
       if (!/already authenticated|already logged in/i.test(msg)) {
         throw err;
@@ -385,7 +384,7 @@ export class CursorProvider implements AgentProvider {
   }
 
   async complete(options: CompleteOptions): Promise<CompletionResult> {
-    // One-shot path uses `agent -p` headless mode (stream-json or json),
+    // One-shot path uses `cursor-agent -p` headless mode (stream-json or json),
     // not ACP. The wire format is Anthropic-shape so we mostly mirror
     // Claude Code's complete() — including the streaming-json delta
     // shape (`{type:"assistant",message:{content:[{type:"text",text}]}}`).
@@ -563,7 +562,7 @@ export class CursorProvider implements AgentProvider {
   }
 
   async listModels(_config?: ListModelsConfig): Promise<ListModelsResult> {
-    // Cursor's `agent models` prints a human-readable list (`<id> - <label>`,
+    // Cursor's `cursor-agent models` prints a human-readable list (`<id> - <label>`,
     // newline-separated). No `--json` flag exists today, so we parse the
     // text. On failure, fall back to a hard-coded subset of widely-available
     // ids observed at the time of writing.
@@ -583,7 +582,7 @@ export class CursorProvider implements AgentProvider {
           source: "cli",
         });
       }
-      if (models.length === 0) throw new Error("agent models returned no parseable entries");
+      if (models.length === 0) throw new Error("cursor-agent models returned no parseable entries");
       return { models, source: "cli", fetchedAt: Date.now() };
     } catch (err) {
       logger.log(

--- a/packages/core/test/runtime-path-registration.test.ts
+++ b/packages/core/test/runtime-path-registration.test.ts
@@ -49,13 +49,13 @@ describe("runtime path registration", () => {
       codex: "/bin/codex",
       opencode: "/bin/opencode",
       grok: "/bin/grok",
-      cursor: "/bin/agent",
+      cursor: "/bin/cursor-agent",
     }), {
       SNA_CLAUDE_COMMAND: "/bin/claude",
       SNA_CODEX_COMMAND: "/bin/codex",
       SNA_OPENCODE_COMMAND: "/bin/opencode",
       SNA_GROK_COMMAND: "/bin/grok",
-      SNA_CURSOR_COMMAND: "/bin/agent",
+      SNA_CURSOR_COMMAND: "/bin/cursor-agent",
     });
   });
 
@@ -72,7 +72,7 @@ describe("runtime path registration", () => {
         codex: "/runtime/codex",
         opencode: "/runtime/opencode",
         grok: "/runtime/grok",
-        cursor: "/runtime/agent",
+        cursor: "/runtime/cursor-agent",
       },
       env: {
         SNA_CLAUDE_COMMAND: "/env/claude",
@@ -84,7 +84,7 @@ describe("runtime path registration", () => {
       assert.equal(process.env.SNA_CODEX_COMMAND, "/runtime/codex");
       assert.equal(process.env.SNA_OPENCODE_COMMAND, "/runtime/opencode");
       assert.equal(process.env.SNA_GROK_COMMAND, "/runtime/grok");
-      assert.equal(process.env.SNA_CURSOR_COMMAND, "/runtime/agent");
+      assert.equal(process.env.SNA_CURSOR_COMMAND, "/runtime/cursor-agent");
     } finally {
       await handle.stop();
     }


### PR DESCRIPTION
## Summary
- Generalize the new Cookbook pages so they describe SNA product patterns instead of a Loom-specific implementation.
- Update install snippets and generated OpenAPI docs from 0.15.0 to 0.16.0.
- Add a product-level supported-runtimes overview with strengths/tradeoffs and link detailed compatibility to the feature matrix.
- Change Cursor default discovery/docs from generic `agent` to `cursor-agent`.
- Reduce duplicate sidebar entries for Philosophy and Endpoint Reference sections.

## Verification
- git diff --check
- pnpm --filter @sna-sdk/core exec node --import tsx --test test/runtime-path-registration.test.ts
- pnpm --filter @sna-sdk/core build
- pnpm --filter docs types:check
- pnpm --filter docs build
