### PR TITLE
[codex] secure local SNA server access

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,7 @@ const sna = await startSnaServer({
   },
 });
 
-const client = new SnaClient({
-  baseUrl: sna.baseUrl,
-  authToken: sna.authToken,
-  ws: true,
-  http: true,
-});
+const client = new SnaClient(sna.connection);
 client.connect();
 
 const { sessionId } = await client.sessions.create({ label: "research" });
@@ -105,7 +100,7 @@ client.disconnect();
 sna.stop();
 ```
 
-> Launchers bind to `127.0.0.1` by default, generate an auth token, and tag sessions with `appId`. Pass `sna.authToken` to `SnaClient` or `SnaProvider`. Direct standalone server usage is intended for development/debugging and must set `SNA_AUTH_TOKEN` explicitly.
+> Launchers bind to `127.0.0.1` by default, generate an auth token, and tag sessions with `appId`. SDK clients should pass the returned `sna.connection` object instead of handling the token separately. Direct standalone server usage is intended for development/debugging and must set `SNA_AUTH_TOKEN` explicitly.
 
 ### As a React app
 
@@ -113,7 +108,7 @@ sna.stop();
 import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 import { SnaChatUI } from "@sna-sdk/react/components/sna-chat-ui";
 
-<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
+<SnaProvider connection={sna.connection}>
   <SnaChatUI dangerouslySkipPermissions>
     <YourApp />
   </SnaChatUI>

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ if (claude.source === "fallback") {
 }
 
 const sna = await startSnaServer({
+  appId: "my-app",
   port: 3099,
   dbPath: "./data/sna.db",
   runtimePaths: {
@@ -69,7 +70,12 @@ const sna = await startSnaServer({
   },
 });
 
-const client = new SnaClient({ baseUrl: "localhost:3099", ws: true, http: true });
+const client = new SnaClient({
+  baseUrl: sna.baseUrl,
+  authToken: sna.authToken,
+  ws: true,
+  http: true,
+});
 client.connect();
 
 const { sessionId } = await client.sessions.create({ label: "research" });
@@ -99,7 +105,7 @@ client.disconnect();
 sna.stop();
 ```
 
-> The running server publishes its own live OpenAPI 3.1 spec — open `http://localhost:3099/docs` for Swagger UI, `http://localhost:3099/openapi.json` for the raw JSON, or `http://localhost:3099/spec` for a plain-text view.
+> Launchers bind to `127.0.0.1` by default, generate an auth token, and tag sessions with `appId`. Pass `sna.authToken` to `SnaClient` or `SnaProvider`. Direct standalone server usage is intended for development/debugging and must set `SNA_AUTH_TOKEN` explicitly.
 
 ### As a React app
 
@@ -107,7 +113,7 @@ sna.stop();
 import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 import { SnaChatUI } from "@sna-sdk/react/components/sna-chat-ui";
 
-<SnaProvider snaUrl="http://localhost:3099">
+<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
   <SnaChatUI dangerouslySkipPermissions>
     <YourApp />
   </SnaChatUI>

--- a/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
@@ -54,6 +54,12 @@ import { SnaClient } from "@sna-sdk/client";
 // Instance id ごとに client を 1 つだけ作り、WebSocket の重複接続を避けます。
 const clients = new Map<string, SnaClient>();
 
+type SnaConnection = {
+  // Local embedded SNA では startSnaServer() が返した値を使います。
+  baseUrl: string;
+  authToken: string;
+};
+
 // UI は特定 client ではなく app-level listener set に subscribe します。
 const eventListeners = new Set<(event: unknown) => void>();
 const permissionListeners = new Set<(event: unknown) => void>();
@@ -70,13 +76,17 @@ function installAggregator(client: SnaClient) {
   });
 }
 
-export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
+export function snaFor(instanceId: string, connection: SnaConnection): SnaClient {
   // すでに接続済みの instance なら同じ client を再利用します。
   const existing = clients.get(instanceId);
   if (existing) return existing;
-  if (!baseUrl) throw new Error(`baseUrl required for ${instanceId}`);
 
-  const client = new SnaClient({ baseUrl, ws: true, http: true });
+  const client = new SnaClient({
+    baseUrl: connection.baseUrl,
+    authToken: connection.authToken,
+    ws: true,
+    http: true,
+  });
   clients.set(instanceId, client);
   installAggregator(client);
 
@@ -102,7 +112,7 @@ Product app では、path を次のように分けると扱いやすいです。
 | Path | Route | 理由 |
 | --- | --- | --- |
 | Lifecycle command | renderer → app host HTTP → SNA HTTP | Host が app DB から config を作り、cloud instance を起こし、model selection を reconcile し、product context を注入できます。 |
-| Event stream | renderer → SNA WebSocket | すべての token を app server 経由にせず、UI が低 latency で runtime event を受け取れます。 |
+| Event stream | renderer → SNA WebSocket | すべての token を app server 経由にせず、UI が低 latency で runtime event を受け取れます。SNA auth token は host の信頼できるチャネルで渡します。 |
 
 Renderer には raw SNA call ではなく domain wrapper を公開します。
 
@@ -145,6 +155,7 @@ Start-vs-resume の判断は host が持つと責任範囲が明確になりま�
 ```ts
 async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
   // Product session を基準に local/cloud SNA instance を選びます。
+  // `instance` は SnaClient connection を包む host-owned wrapper です。
   const instance = snaForAppSession(appSessionId);
   await wakeIfCloudInstance(instance);
 

--- a/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ja.mdx
@@ -81,12 +81,7 @@ export function snaFor(instanceId: string, connection: SnaConnection): SnaClient
   const existing = clients.get(instanceId);
   if (existing) return existing;
 
-  const client = new SnaClient({
-    baseUrl: connection.baseUrl,
-    authToken: connection.authToken,
-    ws: true,
-    http: true,
-  });
+  const client = new SnaClient(connection);
   clients.set(instanceId, client);
   installAggregator(client);
 

--- a/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
@@ -54,6 +54,12 @@ import { SnaClient } from "@sna-sdk/client";
 // Instance id마다 client를 하나만 만듭니다. WebSocket 중복 연결을 막는 역할입니다.
 const clients = new Map<string, SnaClient>();
 
+type SnaConnection = {
+  // Local embedded SNA라면 startSnaServer()가 반환한 값을 사용합니다.
+  baseUrl: string;
+  authToken: string;
+};
+
 // UI는 특정 client가 아니라 app-level listener set에 subscribe합니다.
 const eventListeners = new Set<(event: unknown) => void>();
 const permissionListeners = new Set<(event: unknown) => void>();
@@ -70,13 +76,17 @@ function installAggregator(client: SnaClient) {
   });
 }
 
-export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
+export function snaFor(instanceId: string, connection: SnaConnection): SnaClient {
   // 이미 연결된 instance라면 같은 client를 재사용합니다.
   const existing = clients.get(instanceId);
   if (existing) return existing;
-  if (!baseUrl) throw new Error(`baseUrl required for ${instanceId}`);
 
-  const client = new SnaClient({ baseUrl, ws: true, http: true });
+  const client = new SnaClient({
+    baseUrl: connection.baseUrl,
+    authToken: connection.authToken,
+    ws: true,
+    http: true,
+  });
   clients.set(instanceId, client);
   installAggregator(client);
 
@@ -102,7 +112,7 @@ export function onAgentEventAll(listener: (event: unknown) => void) {
 | Path | Route | 이유 |
 | --- | --- | --- |
 | Lifecycle command | renderer → app host HTTP → SNA HTTP | Host가 앱 DB에서 config를 만들고, cloud instance를 깨우고, model selection을 reconcile하고, 제품 context를 주입할 수 있습니다. |
-| Event stream | renderer → SNA WebSocket | 모든 token을 앱 서버로 proxy하지 않고 UI가 낮은 latency로 runtime event를 받습니다. |
+| Event stream | renderer → SNA WebSocket | 모든 token을 앱 서버로 proxy하지 않고 UI가 낮은 latency로 runtime event를 받습니다. SNA auth token은 host의 신뢰할 수 있는 채널로 전달합니다. |
 
 Renderer에는 raw SNA call보다 domain wrapper를 노출하는 식으로 경계를 잡습니다.
 
@@ -145,6 +155,7 @@ Start-vs-resume 판단은 host가 소유하게 두면 흐름이 단순해집니�
 ```ts
 async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
   // App session을 기준으로 local/cloud SNA instance를 고릅니다.
+  // `instance`는 SnaClient connection을 감싼 host-owned wrapper입니다.
   const instance = snaForAppSession(appSessionId);
   await wakeIfCloudInstance(instance);
 

--- a/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.ko.mdx
@@ -81,12 +81,7 @@ export function snaFor(instanceId: string, connection: SnaConnection): SnaClient
   const existing = clients.get(instanceId);
   if (existing) return existing;
 
-  const client = new SnaClient({
-    baseUrl: connection.baseUrl,
-    authToken: connection.authToken,
-    ws: true,
-    http: true,
-  });
+  const client = new SnaClient(connection);
   clients.set(instanceId, client);
   installAggregator(client);
 

--- a/apps/docs/content/docs/cookbook/agentic-apps.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.mdx
@@ -81,12 +81,7 @@ export function snaFor(instanceId: string, connection: SnaConnection): SnaClient
   const existing = clients.get(instanceId);
   if (existing) return existing;
 
-  const client = new SnaClient({
-    baseUrl: connection.baseUrl,
-    authToken: connection.authToken,
-    ws: true,
-    http: true,
-  });
+  const client = new SnaClient(connection);
   clients.set(instanceId, client);
   installAggregator(client);
 
@@ -112,7 +107,7 @@ A common product architecture uses a split path:
 | Path | Route | Why |
 | --- | --- | --- |
 | Lifecycle commands | renderer → app host HTTP → SNA HTTP | The host can build config from app DB, wake cloud instances, reconcile model selection, and inject product context. |
-| Event stream | renderer → SNA WebSocket | The UI receives low-latency runtime events without proxying every token through the app server. Pass the SNA auth token through a trusted host channel. |
+| Event stream | renderer → SNA WebSocket | The UI receives low-latency runtime events without proxying every token through the app server. Pass the SDK launcher `connection` through a trusted host channel. |
 
 In the renderer, expose a domain wrapper rather than raw SNA calls:
 

--- a/apps/docs/content/docs/cookbook/agentic-apps.mdx
+++ b/apps/docs/content/docs/cookbook/agentic-apps.mdx
@@ -54,6 +54,12 @@ import { SnaClient } from "@sna-sdk/client";
 // One client per instance prevents duplicate WebSocket connections.
 const clients = new Map<string, SnaClient>();
 
+type SnaConnection = {
+  // For local embedded SNA, use the values returned by startSnaServer().
+  baseUrl: string;
+  authToken: string;
+};
+
 // UI subscribes to the app-level listener set, not to a specific client.
 const eventListeners = new Set<(event: unknown) => void>();
 const permissionListeners = new Set<(event: unknown) => void>();
@@ -70,13 +76,17 @@ function installAggregator(client: SnaClient) {
   });
 }
 
-export function snaFor(instanceId: string, baseUrl?: string): SnaClient {
+export function snaFor(instanceId: string, connection: SnaConnection): SnaClient {
   // Reuse the existing client if this instance is already connected.
   const existing = clients.get(instanceId);
   if (existing) return existing;
-  if (!baseUrl) throw new Error(`baseUrl required for ${instanceId}`);
 
-  const client = new SnaClient({ baseUrl, ws: true, http: true });
+  const client = new SnaClient({
+    baseUrl: connection.baseUrl,
+    authToken: connection.authToken,
+    ws: true,
+    http: true,
+  });
   clients.set(instanceId, client);
   installAggregator(client);
 
@@ -102,7 +112,7 @@ A common product architecture uses a split path:
 | Path | Route | Why |
 | --- | --- | --- |
 | Lifecycle commands | renderer → app host HTTP → SNA HTTP | The host can build config from app DB, wake cloud instances, reconcile model selection, and inject product context. |
-| Event stream | renderer → SNA WebSocket | The UI receives low-latency runtime events without proxying every token through the app server. |
+| Event stream | renderer → SNA WebSocket | The UI receives low-latency runtime events without proxying every token through the app server. Pass the SNA auth token through a trusted host channel. |
 
 In the renderer, expose a domain wrapper rather than raw SNA calls:
 
@@ -145,6 +155,7 @@ The host should own start-vs-resume. The UI should not decide whether a runtime 
 ```ts
 async function ensureAgent({ appSessionId, requestedSnaId, isNewSession }) {
   // Pick local or cloud SNA from the product session, not from UI state.
+  // `instance` is the host-owned wrapper around the SnaClient connection.
   const instance = snaForAppSession(appSessionId);
   await wakeIfCloudInstance(instance);
 

--- a/apps/docs/content/docs/cookbook/meta.ja.json
+++ b/apps/docs/content/docs/cookbook/meta.ja.json
@@ -1,6 +1,6 @@
 {
   "title": "Cookbook",
-  "description": "ストリーミング、権限 UI、マルチプロバイダ、runtime setup、アプリホストのパターン。",
+  "description": "ストリーミング、権限 UI、マルチランタイムセッション、runtime setup、アプリホストのパターン。",
   "icon": "ChefHat",
   "root": true,
   "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps", "one-shot-jobs", "runtime-setup"]

--- a/apps/docs/content/docs/cookbook/meta.json
+++ b/apps/docs/content/docs/cookbook/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Cookbook",
-  "description": "Recipes for streaming, permissions, multi-provider, runtime setup, and app hosting patterns.",
+  "description": "Recipes for streaming, permissions, multi-runtime sessions, runtime setup, and app hosting patterns.",
   "icon": "ChefHat",
   "root": true,
   "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps", "one-shot-jobs", "runtime-setup"]

--- a/apps/docs/content/docs/cookbook/meta.ko.json
+++ b/apps/docs/content/docs/cookbook/meta.ko.json
@@ -1,6 +1,6 @@
 {
   "title": "Cookbook",
-  "description": "스트리밍, 권한 UI, 멀티 프로바이더, 런타임 설정, 앱 호스팅 패턴.",
+  "description": "스트리밍, 권한 UI, 멀티 런타임 세션, 런타임 설정, 앱 호스팅 패턴.",
   "icon": "ChefHat",
   "root": true,
   "pages": ["index", "streaming", "permissions", "multi-provider", "agentic-apps", "one-shot-jobs", "runtime-setup"]

--- a/apps/docs/content/docs/cookbook/multi-provider.ja.mdx
+++ b/apps/docs/content/docs/cookbook/multi-provider.ja.mdx
@@ -22,11 +22,11 @@ await client.agent.start(sessionId, {
 // ...ターンが進行し、履歴が積み上がり...
 
 // 会話を保ったまま Codex に切り替え
-await client.agent.patch(sessionId, { provider: "codex", model: "gpt-5.4" });
+await client.agent.restart(sessionId, { provider: "codex", model: "gpt-5.4" });
 ```
 
-`provider` フィールドを持つ `PATCH /agent/session` は現在のプロセス
-を終了し、新ランタイムで respawn し、正規化履歴を新ランタイムのネイティブ
+`provider` フィールドに新しい runtime id を渡した `agent.restart()` は
+現在のプロセスを終了し、新ランタイムで respawn し、正規化履歴を新ランタイムのネイティブ
 形に replay します。セッションレコード、イベントカーソル、runtime chain
 はすべて維持されます。
 
@@ -36,10 +36,11 @@ await client.agent.patch(sessionId, { provider: "codex", model: "gpt-5.4" });
 |------|----------|------|
 | `restart` | 同じ設定で respawn | replay しない (warm restart) |
 | `resume` | 同じ設定で respawn | 再構築して再注入 |
-| `patch` (ランタイム変更) | 新設定で respawn | 新ランタイム用に再構築 |
+| `restart` (ランタイム変更) | 新設定で respawn | 新ランタイム用に再構築 |
 
 長いアイドル後やランタイムが終了したときは `resume` を使います。
-アプリがランタイム切り替えを必要とするときは `patch` を使います。
+アプリがランタイム切り替えを必要とするときは、`provider` フィールドに
+新しい runtime id を渡して `restart` します。
 
 ## なぜ重要か
 

--- a/apps/docs/content/docs/cookbook/multi-provider.ko.mdx
+++ b/apps/docs/content/docs/cookbook/multi-provider.ko.mdx
@@ -21,11 +21,11 @@ await client.agent.start(sessionId, {
 // ...턴들이 진행되고 히스토리가 쌓이고...
 
 // 대화 보존하면서 Codex로 전환
-await client.agent.patch(sessionId, { provider: "codex", model: "gpt-5.4" });
+await client.agent.restart(sessionId, { provider: "codex", model: "gpt-5.4" });
 ```
 
-`provider` 필드가 있는 `PATCH /agent/session`은 현재 프로세스를
-종료하고 새 런타임으로 respawn해서 정규화 히스토리를 새 런타임의
+`provider` 필드에 새 runtime id를 넘긴 `agent.restart()`는 현재
+프로세스를 종료하고 새 런타임으로 respawn해서 정규화 히스토리를 새 런타임의
 네이티브 포맷으로 replay합니다. 세션 레코드, 이벤트 커서, runtime chain
 모두 유지됩니다.
 
@@ -35,10 +35,10 @@ await client.agent.patch(sessionId, { provider: "codex", model: "gpt-5.4" });
 |------|---------|---------|
 | `restart` | 같은 설정으로 respawn | replay하지 않음 (warm restart) |
 | `resume` | 같은 설정으로 respawn | 재구성해서 다시 주입 |
-| `patch` (런타임 변경) | 새 설정으로 respawn | 새 런타임용으로 재구성 |
+| `restart` (런타임 변경) | 새 설정으로 respawn | 새 런타임용으로 재구성 |
 
 긴 유휴 후나 런타임이 죽었을 때는 `resume`을 사용합니다. 앱이 런타임
-교체를 원할 때는 `patch`를 사용합니다.
+교체를 원할 때는 `provider` 필드에 새 runtime id를 넘긴 `restart`를 사용합니다.
 
 ## 왜 이게 중요한가
 

--- a/apps/docs/content/docs/cookbook/multi-provider.mdx
+++ b/apps/docs/content/docs/cookbook/multi-provider.mdx
@@ -21,11 +21,11 @@ await client.agent.start(sessionId, {
 // ...some turns happen, history grows...
 
 // Switch to Codex while preserving the conversation
-await client.agent.patch(sessionId, { provider: "codex", model: "gpt-5.4" });
+await client.agent.restart(sessionId, { provider: "codex", model: "gpt-5.4" });
 ```
 
-`PATCH /agent/session` with a `provider` field tears down the current
-process and respawns under the new runtime, replaying canonical
+`agent.restart()` with a different runtime id in the `provider` field
+tears down the current process and respawns under the new runtime, replaying canonical
 history into the new runtime's native format. The session record,
 event cursor, and runtime chain all survive.
 
@@ -35,10 +35,10 @@ event cursor, and runtime chain all survive.
 |-----------|---------|---------|
 | `restart` | respawn with same config | not replayed (warm restart) |
 | `resume` | respawn with same config | rebuilt + fed back in |
-| `patch` (runtime change) | respawn under new config | rebuilt for new runtime |
+| `restart` (runtime change) | respawn under new config | rebuilt for new runtime |
 
 Use `resume` after long idle periods or when the runtime crashed.
-Use `patch` when the consumer wants a runtime swap.
+Use `restart` with a new runtime id in the `provider` field when the consumer wants a runtime swap.
 
 ## Why this matters
 

--- a/apps/docs/content/docs/cookbook/one-shot-jobs.ja.mdx
+++ b/apps/docs/content/docs/cookbook/one-shot-jobs.ja.mdx
@@ -11,7 +11,7 @@ icon: Zap
 | Job shape | API | 理由 |
 | --- | --- | --- |
 | Text transform, classification, JSON extraction | `agent.completion()` | 最速 path。temporary session lifecycle がありません。 |
-| Agent が tool を使う、または provider 固有の agent behavior が必要 | `agent.runOnce()` | temporary session を作成し、完了を待ってから cleanup します。 |
+| Agent が tool を使う、または runtime 固有の behavior が必要 | `agent.runOnce()` | temporary session を作成し、完了を待ってから cleanup します。 |
 | Browser/Electron UI が one-shot の進捗を live 表示する | `agent.runOnceStream()` | HTTP SSE stream。長期 chat session は作りません。 |
 
 One-shot prompt は狭く保つと扱いやすいです。これは product plumbing であり、open-ended conversation ではありません。
@@ -164,4 +164,4 @@ export async function previewPlan(client: SnaClient, request: string, append: (t
 - Timeout と明示的な fallback を用意しておくと運用しやすいです。
 - Prompt が tool を使わない作業のときだけ `permissionMode: "bypassPermissions"` を使うと安全です。
 - User が明示的に求めた output でない限り、one-shot result を user conversation に入れない方が扱いやすいです。
-- 繰り返し実行される background work は provider を hardcode せず、runtime/model registry から model を選ぶ構成が便利です。
+- 繰り返し実行される background work は runtime を hardcode せず、runtime/model registry から model を選ぶ構成が便利です。

--- a/apps/docs/content/docs/cookbook/one-shot-jobs.ko.mdx
+++ b/apps/docs/content/docs/cookbook/one-shot-jobs.ko.mdx
@@ -11,7 +11,7 @@ icon: Zap
 | 작업 형태 | API | 이유 |
 | --- | --- | --- |
 | Text transform, classification, JSON extraction | `agent.completion()` | 가장 빠른 경로입니다. 임시 session lifecycle이 없습니다. |
-| Agent가 tool을 쓰거나 provider별 agent behavior가 필요함 | `agent.runOnce()` | 임시 session을 만들고 완료를 기다린 뒤 정리합니다. |
+| Agent가 tool을 쓰거나 runtime별 behavior가 필요함 | `agent.runOnce()` | 임시 session을 만들고 완료를 기다린 뒤 정리합니다. |
 | Browser/Electron UI가 one-shot 진행 상황을 live로 보여줘야 함 | `agent.runOnceStream()` | HTTP SSE stream입니다. 장기 chat session은 만들지 않습니다. |
 
 One-shot prompt는 좁게 유지합니다. 이것은 제품 plumbing이지 open-ended conversation이 아닙니다.
@@ -164,4 +164,4 @@ export async function previewPlan(client: SnaClient, request: string, append: (t
 - Timeout과 명시적인 fallback을 함께 둡니다.
 - Prompt가 tool을 쓰면 안 되는 작업일 때만 `permissionMode: "bypassPermissions"`를 쓰면 안전합니다.
 - User가 명시적으로 요청한 출력이 아니라면 one-shot 결과를 user conversation에 넣지 않는 쪽이 낫습니다.
-- 반복되는 background work는 provider를 hardcode하지 않고 runtime/model registry를 통해 model을 고릅니다.
+- 반복되는 background work는 runtime을 hardcode하지 않고 runtime/model registry를 통해 model을 고릅니다.

--- a/apps/docs/content/docs/cookbook/one-shot-jobs.mdx
+++ b/apps/docs/content/docs/cookbook/one-shot-jobs.mdx
@@ -11,7 +11,7 @@ Use one-shot calls for work that should not become part of a user's long-lived c
 | Job shape | API | Why |
 | --- | --- | --- |
 | Text transform, classification, JSON extraction | `agent.completion()` | Fastest path; no temporary session lifecycle. |
-| Agent can use tools or needs provider-specific agent behavior | `agent.runOnce()` | Creates a temporary session, waits for completion, then cleans up. |
+| Agent can use tools or needs runtime-specific behavior | `agent.runOnce()` | Creates a temporary session, waits for completion, then cleans up. |
 | Browser/Electron UI needs live progress for a one-shot | `agent.runOnceStream()` | HTTP SSE stream; no long-lived chat session. |
 
 Keep one-shot prompts narrow. They are product plumbing, not open-ended conversations.
@@ -164,4 +164,4 @@ export async function previewPlan(client: SnaClient, request: string, append: (t
 - Set a timeout and write an explicit fallback.
 - Use `permissionMode: "bypassPermissions"` only when the prompt is not allowed to use tools.
 - Keep one-shot results out of the user conversation unless the user explicitly asked for that output.
-- For repeated background work, route model choice through your runtime/model registry instead of hardcoding one provider.
+- For repeated background work, route model choice through your runtime/model registry instead of hardcoding one runtime.

--- a/apps/docs/content/docs/cookbook/permissions.ja.mdx
+++ b/apps/docs/content/docs/cookbook/permissions.ja.mdx
@@ -23,11 +23,11 @@ await client.agent.start(sessionId, {
 ## 購読と応答
 
 ```ts
-await client.permissions.subscribe();
+await client.agent.subscribePermissions();
 
-client.permissions.onRequest(async ({ session, tool, input, decisionId }) => {
-  const approved = await showApprovalDialog({ tool, input });
-  await client.permissions.respond(session, approved, { decisionId });
+client.agent.onPermissionRequest(async ({ session, request }) => {
+  const approved = await showApprovalDialog(request);
+  await client.agent.respondPermission(session, approved);
 });
 ```
 
@@ -60,22 +60,21 @@ await client.agent.start(sessionId, {
 ```tsx
 function PermissionGuard({ children }: React.PropsWithChildren) {
   const [pending, setPending] = useState(null);
+  const client = getSnaClient();
 
   useEffect(() => {
-    const client = getSnaClient();
-    client.permissions.subscribe();
-    return client.permissions.onRequest(setPending);
-  }, []);
+    client.agent.subscribePermissions().catch(() => {});
+    return client.agent.onPermissionRequest(setPending);
+  }, [client]);
 
   return (
     <>
       {children}
       {pending && (
         <Dialog
-          tool={pending.tool}
-          input={pending.input}
-          onApprove={() => respond(true)}
-          onDeny={() => respond(false)}
+          request={pending.request}
+          onApprove={() => client.agent.respondPermission(pending.session, true)}
+          onDeny={() => client.agent.respondPermission(pending.session, false)}
         />
       )}
     </>

--- a/apps/docs/content/docs/cookbook/permissions.ko.mdx
+++ b/apps/docs/content/docs/cookbook/permissions.ko.mdx
@@ -22,11 +22,11 @@ await client.agent.start(sessionId, {
 ## 구독과 응답
 
 ```ts
-await client.permissions.subscribe();
+await client.agent.subscribePermissions();
 
-client.permissions.onRequest(async ({ session, tool, input, decisionId }) => {
-  const approved = await showApprovalDialog({ tool, input });
-  await client.permissions.respond(session, approved, { decisionId });
+client.agent.onPermissionRequest(async ({ session, request }) => {
+  const approved = await showApprovalDialog(request);
+  await client.agent.respondPermission(session, approved);
 });
 ```
 
@@ -59,22 +59,21 @@ await client.agent.start(sessionId, {
 ```tsx
 function PermissionGuard({ children }: React.PropsWithChildren) {
   const [pending, setPending] = useState(null);
+  const client = getSnaClient();
 
   useEffect(() => {
-    const client = getSnaClient();
-    client.permissions.subscribe();
-    return client.permissions.onRequest(setPending);
-  }, []);
+    client.agent.subscribePermissions().catch(() => {});
+    return client.agent.onPermissionRequest(setPending);
+  }, [client]);
 
   return (
     <>
       {children}
       {pending && (
         <Dialog
-          tool={pending.tool}
-          input={pending.input}
-          onApprove={() => respond(true)}
-          onDeny={() => respond(false)}
+          request={pending.request}
+          onApprove={() => client.agent.respondPermission(pending.session, true)}
+          onDeny={() => client.agent.respondPermission(pending.session, false)}
         />
       )}
     </>

--- a/apps/docs/content/docs/cookbook/permissions.mdx
+++ b/apps/docs/content/docs/cookbook/permissions.mdx
@@ -23,11 +23,11 @@ await client.agent.start(sessionId, {
 ## Subscribe + respond
 
 ```ts
-await client.permissions.subscribe();
+await client.agent.subscribePermissions();
 
-client.permissions.onRequest(async ({ session, tool, input, decisionId }) => {
-  const approved = await showApprovalDialog({ tool, input });
-  await client.permissions.respond(session, approved, { decisionId });
+client.agent.onPermissionRequest(async ({ session, request }) => {
+  const approved = await showApprovalDialog(request);
+  await client.agent.respondPermission(session, approved);
 });
 ```
 
@@ -60,22 +60,21 @@ automatically. For custom UI:
 ```tsx
 function PermissionGuard({ children }: React.PropsWithChildren) {
   const [pending, setPending] = useState(null);
+  const client = getSnaClient();
 
   useEffect(() => {
-    const client = getSnaClient();
-    client.permissions.subscribe();
-    return client.permissions.onRequest(setPending);
-  }, []);
+    client.agent.subscribePermissions().catch(() => {});
+    return client.agent.onPermissionRequest(setPending);
+  }, [client]);
 
   return (
     <>
       {children}
       {pending && (
         <Dialog
-          tool={pending.tool}
-          input={pending.input}
-          onApprove={() => respond(true)}
-          onDeny={() => respond(false)}
+          request={pending.request}
+          onApprove={() => client.agent.respondPermission(pending.session, true)}
+          onDeny={() => client.agent.respondPermission(pending.session, false)}
         />
       )}
     </>

--- a/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
@@ -28,8 +28,9 @@ type RegisteredModel = {
   // Settings UI と model picker に出す、人が読みやすい label です。
   label: string;
 
-  // Provider family は grouping、attribution、billing view に使いやすいです。
-  provider: "anthropic" | "openai" | "oss" | string;
+  // Inference backend family です。SNA catalog では `provider` と呼びますが、
+  // app state では `modelProvider` にすると SNA runtime id と混同しにくくなります。
+  modelProvider: "anthropic" | "openai" | "oss" | string;
 };
 
 type RuntimeSlot = {
@@ -37,10 +38,12 @@ type RuntimeSlot = {
   enabled: boolean;
 
   config: {
-    // CLI runtime は cliPath を使います。Hosted/local API runtime は baseUrl/apiKey を持てます。
+    // SNA runtime は agentic CLI です。Runtime path override には cliPath を使います。
     cliPath?: string;
-    baseUrl?: string;
-    apiKey?: string;
+
+    // OpenRouter や local OpenAI-compatible API は Codex の native
+    // model_providers.* 設定を providerOptions.config で渡して構成します。
+    codexConfig?: Record<string, string>;
   };
 
   // この curated list は app が所有します。SNA model catalog から seed できます。
@@ -89,14 +92,14 @@ async function setRuntimePath(runtimeId: RuntimeId, cliPath: string) {
   // ユーザーが選んだ値は cache ではなく override として保存します。
   await settingsDb.set(`runtime:${runtimeId}:path`, cliPath);
 
-  // SNA を同じ process に embed している場合、process.env mirror で次の provider spawn が同じ path を見ます。
+  // SNA を同じ process に embed している場合、process.env mirror で次の runtime spawn が同じ path を見ます。
   process.env[RUNTIME_ENV[runtimeId]] = cliPath;
 }
 ```
 
 ## SNA launcher に runtime path を渡す
 
-Electron から SNA を起動するときに、resolve 済み runtime path を startup option として渡しておくとよいです。SNA はこの値を runtime resolver が読む provider environment variable に mapping します。
+Electron から SNA を起動するときに、resolve 済み runtime path を startup option として渡しておくとよいです。SNA はこの値を runtime resolver が読む environment variable に mapping します。
 
 ```ts
 import { startSnaServerInProcess } from "@sna-sdk/core/electron";
@@ -111,20 +114,27 @@ const runtimePaths = {
 };
 
 const sna = await startSnaServerInProcess({
+  appId: "my-app",
   port: 3099,
   dbPath: appPaths.snaDb,
+  allowedOrigins: ["http://localhost:5173"],
 
   // runtimePaths は SNA_CLAUDE_COMMAND、SNA_CODEX_COMMAND などの env に変換されます。
   runtimePaths,
 
-  // env は runtimePaths のあとに merge されるため、最後の escape hatch として使えます。
+  // env は runtimePaths のあとに merge されるため、runtime command 変数や
+  // runtime-specific escape hatch として使えます。Auth/identity は launcher option が最終値です。
   env: {
     SNA_MAX_SESSIONS: "20",
   },
 });
 ```
 
-Forked standalone SNA server では、path change を launch 前に反映するか、SNA を再起動する構成が扱いやすいです。In-process SNA では provider が同じ process 内で path を resolve するため、host が `process.env.SNA_*_COMMAND` を更新すると以後の spawn に反映できます。
+`sna.baseUrl` と `sna.authToken` は `SnaClient` または `SnaProvider` に
+渡します。Token はこの server process のために生成される値なので、長期間
+残るユーザー設定として保存しないでください。
+
+Forked standalone SNA server では、path change を launch 前に反映するか、SNA を再起動する構成が扱いやすいです。In-process SNA では runtime adapter が同じ process 内で path を resolve するため、host が `process.env.SNA_*_COMMAND` を更新すると以後の spawn に反映できます。
 
 ## `runOnce` で実 runtime を test する
 
@@ -175,7 +185,7 @@ async function refreshCatalog(client: SnaClient, runtimeId: RuntimeId, cliPath?:
     // Settings で CLI path を編集した直後の catalog probe に便利です。
     cliPath,
 
-    // ユーザーが refresh button を押した場合は provider-side cache を bypass します。
+    // ユーザーが refresh button を押した場合は runtime-side cache を bypass します。
     refresh: true,
   });
 
@@ -194,7 +204,7 @@ async function registerModel(runtimeId: RuntimeId, model: RuntimeModelInfo) {
     id: `${runtimeId}/${model.id}`,
     modelSlug: model.id,
     label: model.label,
-    provider: model.provider,
+    modelProvider: model.provider,
   });
 }
 ```
@@ -220,7 +230,7 @@ function RuntimeSetupPanel({ runtimeId }: { runtimeId: RuntimeId }) {
   async function saveAndTest() {
     setTesting(true);
     try {
-      // 先に persist すると、SNA provider が runOnce 中にこの path を resolve できます。
+      // 先に persist すると、SNA runtime adapter が runOnce 中にこの path を resolve できます。
       await window.appRuntime.setPath(runtimeId, cliPath);
 
       // これは fake ping ではなく、SNA 経由の実 runtime invocation です。

--- a/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
@@ -130,9 +130,9 @@ const sna = await startSnaServerInProcess({
 });
 ```
 
-`sna.baseUrl` と `sna.authToken` は `SnaClient` または `SnaProvider` に
-渡します。Token はこの server process のために生成される値なので、長期間
-残るユーザー設定として保存しないでください。
+`sna.connection` を `SnaClient` または `SnaProvider` に渡します。Token は
+この server process のために生成され、connection object と一緒に扱われる
+値なので、長期間残るユーザー設定として保存しないでください。
 
 Forked standalone SNA server では、path change を launch 前に反映するか、SNA を再起動する構成が扱いやすいです。In-process SNA では runtime adapter が同じ process 内で path を resolve するため、host が `process.env.SNA_*_COMMAND` を更新すると以後の spawn に反映できます。
 

--- a/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
@@ -28,8 +28,9 @@ type RegisteredModel = {
   // Settings UI와 model picker에 보여줄 사람이 읽기 좋은 label입니다.
   label: string;
 
-  // Provider family는 grouping, attribution, billing view에 유용합니다.
-  provider: "anthropic" | "openai" | "oss" | string;
+  // Inference backend family입니다. SNA catalog에서는 `provider`라고 부르지만,
+  // app state에는 `modelProvider`로 저장하면 SNA runtime id와 덜 헷갈립니다.
+  modelProvider: "anthropic" | "openai" | "oss" | string;
 };
 
 type RuntimeSlot = {
@@ -37,10 +38,12 @@ type RuntimeSlot = {
   enabled: boolean;
 
   config: {
-    // CLI runtime은 cliPath를 씁니다. Hosted/local API runtime은 baseUrl/apiKey를 쓸 수 있습니다.
+    // SNA runtime은 agentic CLI입니다. Runtime path override에는 cliPath를 씁니다.
     cliPath?: string;
-    baseUrl?: string;
-    apiKey?: string;
+
+    // OpenRouter나 local OpenAI-compatible API는 Codex의 native
+    // model_providers.* 설정을 providerOptions.config로 넘겨 구성합니다.
+    codexConfig?: Record<string, string>;
   };
 
   // 이 curated list는 app이 소유합니다. SNA model catalog에서 seed할 수 있습니다.
@@ -89,14 +92,14 @@ async function setRuntimePath(runtimeId: RuntimeId, cliPath: string) {
   // 사용자가 고른 값은 cache가 아니라 override로 저장합니다.
   await settingsDb.set(`runtime:${runtimeId}:path`, cliPath);
 
-  // SNA를 같은 process에 embed했다면, process.env mirror로 다음 provider spawn이 바로 같은 path를 보게 됩니다.
+  // SNA를 같은 process에 embed했다면, process.env mirror로 다음 runtime spawn이 바로 같은 path를 보게 됩니다.
   process.env[RUNTIME_ENV[runtimeId]] = cliPath;
 }
 ```
 
 ## SNA launcher에 runtime path 넘기기
 
-Electron에서 SNA를 띄울 때 resolve된 runtime path를 startup option으로 넘겨두는 패턴이 가장 단순합니다. SNA는 이 값을 runtime resolver가 읽는 provider environment variable로 매핑합니다.
+Electron에서 SNA를 띄울 때 resolve된 runtime path를 startup option으로 넘겨두는 패턴이 가장 단순합니다. SNA는 이 값을 runtime resolver가 읽는 environment variable로 매핑합니다.
 
 ```ts
 import { startSnaServerInProcess } from "@sna-sdk/core/electron";
@@ -111,20 +114,27 @@ const runtimePaths = {
 };
 
 const sna = await startSnaServerInProcess({
+  appId: "my-app",
   port: 3099,
   dbPath: appPaths.snaDb,
+  allowedOrigins: ["http://localhost:5173"],
 
   // runtimePaths는 SNA_CLAUDE_COMMAND, SNA_CODEX_COMMAND 같은 env로 변환됩니다.
   runtimePaths,
 
-  // env는 runtimePaths 뒤에 merge되므로 마지막 escape hatch로 쓸 수 있습니다.
+  // env는 runtimePaths 뒤에 merge되므로 runtime command 변수나 기타
+  // runtime-specific escape hatch로 쓸 수 있습니다. Auth/identity는 launcher option이 최종값입니다.
   env: {
     SNA_MAX_SESSIONS: "20",
   },
 });
 ```
 
-Forked standalone SNA server에서는 path change를 launch 전에 반영하거나 SNA를 재시작하는 구성이 보통 다루기 쉽습니다. In-process SNA에서는 provider가 같은 process 안에서 path를 resolve하므로, host가 `process.env.SNA_*_COMMAND`를 갱신하면 이후 spawn에 반영될 수 있습니다.
+`sna.baseUrl`과 `sna.authToken`은 `SnaClient`나 `SnaProvider`에 그대로
+넘깁니다. Token은 이 server process를 위해 생성된 값이므로 긴 수명의
+사용자 설정으로 저장하지 마십시오.
+
+Forked standalone SNA server에서는 path change를 launch 전에 반영하거나 SNA를 재시작하는 구성이 보통 다루기 쉽습니다. In-process SNA에서는 runtime adapter가 같은 process 안에서 path를 resolve하므로, host가 `process.env.SNA_*_COMMAND`를 갱신하면 이후 spawn에 반영될 수 있습니다.
 
 ## `runOnce`로 실제 runtime 테스트하기
 
@@ -175,7 +185,7 @@ async function refreshCatalog(client: SnaClient, runtimeId: RuntimeId, cliPath?:
     // Settings에서 CLI path를 막 수정한 직후 catalog probe에 유용합니다.
     cliPath,
 
-    // 사용자가 refresh button을 누른 경우 provider-side cache를 우회합니다.
+    // 사용자가 refresh button을 누른 경우 runtime-side cache를 우회합니다.
     refresh: true,
   });
 
@@ -194,7 +204,7 @@ async function registerModel(runtimeId: RuntimeId, model: RuntimeModelInfo) {
     id: `${runtimeId}/${model.id}`,
     modelSlug: model.id,
     label: model.label,
-    provider: model.provider,
+    modelProvider: model.provider,
   });
 }
 ```
@@ -220,7 +230,7 @@ function RuntimeSetupPanel({ runtimeId }: { runtimeId: RuntimeId }) {
   async function saveAndTest() {
     setTesting(true);
     try {
-      // 먼저 persist해야 SNA provider가 runOnce 중 이 path를 resolve할 수 있습니다.
+      // 먼저 persist해야 SNA runtime adapter가 runOnce 중 이 path를 resolve할 수 있습니다.
       await window.appRuntime.setPath(runtimeId, cliPath);
 
       // 이것은 fake ping이 아니라 SNA를 통한 실제 runtime invocation입니다.

--- a/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
@@ -130,9 +130,9 @@ const sna = await startSnaServerInProcess({
 });
 ```
 
-`sna.baseUrl`과 `sna.authToken`은 `SnaClient`나 `SnaProvider`에 그대로
-넘깁니다. Token은 이 server process를 위해 생성된 값이므로 긴 수명의
-사용자 설정으로 저장하지 마십시오.
+`sna.connection`을 `SnaClient`나 `SnaProvider`에 넘깁니다. Token은 이
+server process를 위해 생성되고 connection object와 함께 묶여 있으므로
+긴 수명의 사용자 설정으로 저장하지 마십시오.
 
 Forked standalone SNA server에서는 path change를 launch 전에 반영하거나 SNA를 재시작하는 구성이 보통 다루기 쉽습니다. In-process SNA에서는 runtime adapter가 같은 process 안에서 path를 resolve하므로, host가 `process.env.SNA_*_COMMAND`를 갱신하면 이후 spawn에 반영될 수 있습니다.
 

--- a/apps/docs/content/docs/cookbook/runtime-setup.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.mdx
@@ -132,9 +132,9 @@ const sna = await startSnaServerInProcess({
 });
 ```
 
-Pass `sna.baseUrl` and `sna.authToken` to `SnaClient` or `SnaProvider`.
-The token is generated for this server process; do not store it as a
-long-lived user setting.
+Pass `sna.connection` to `SnaClient` or `SnaProvider`. The token is generated
+for this server process and stays paired with that connection object; do not
+store it as a long-lived user setting.
 
 For a forked standalone SNA server, path changes should usually be applied before launch or by restarting SNA. For in-process SNA, updating `process.env.SNA_*_COMMAND` in the host can affect later spawns because the runtime adapters resolve paths inside the same process.
 

--- a/apps/docs/content/docs/cookbook/runtime-setup.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.mdx
@@ -28,8 +28,9 @@ type RegisteredModel = {
   // Human label shown in the settings UI and model picker.
   label: string;
 
-  // Provider family is useful for grouping, attribution, and billing views.
-  provider: "anthropic" | "openai" | "oss" | string;
+  // Inference backend family. SNA's catalog calls this `provider`;
+  // storing it as `modelProvider` avoids confusing it with the SNA runtime id.
+  modelProvider: "anthropic" | "openai" | "oss" | string;
 };
 
 type RuntimeSlot = {
@@ -37,10 +38,12 @@ type RuntimeSlot = {
   enabled: boolean;
 
   config: {
-    // CLI runtimes use cliPath. Hosted or local API runtimes may use baseUrl/apiKey.
+    // SNA runtimes are agentic CLIs. Use cliPath for runtime path overrides.
     cliPath?: string;
-    baseUrl?: string;
-    apiKey?: string;
+
+    // For OpenRouter or local OpenAI-compatible APIs, configure Codex's
+    // native model_providers.* settings through providerOptions.config.
+    codexConfig?: Record<string, string>;
   };
 
   // The app owns this curated list. It may be seeded from SNA's model catalog.
@@ -90,14 +93,14 @@ async function setRuntimePath(runtimeId: RuntimeId, cliPath: string) {
   await settingsDb.set(`runtime:${runtimeId}:path`, cliPath);
 
   // If SNA is embedded in the same process, mirroring to process.env lets
-  // future provider spawns resolve the same path immediately.
+  // future runtime spawns resolve the same path immediately.
   process.env[RUNTIME_ENV[runtimeId]] = cliPath;
 }
 ```
 
 ## Pass runtime paths to the SNA launcher
 
-When launching SNA from Electron, pass the resolved runtime paths at startup. SNA maps these values to the provider environment variables used by runtime resolvers.
+When launching SNA from Electron, pass the resolved runtime paths at startup. SNA maps these values to the environment variables read by runtime resolvers.
 
 ```ts
 import { startSnaServerInProcess } from "@sna-sdk/core/electron";
@@ -112,20 +115,28 @@ const runtimePaths = {
 };
 
 const sna = await startSnaServerInProcess({
+  appId: "my-app",
   port: 3099,
   dbPath: appPaths.snaDb,
+  allowedOrigins: ["http://localhost:5173"],
 
   // runtimePaths becomes SNA_CLAUDE_COMMAND, SNA_CODEX_COMMAND, and siblings.
   runtimePaths,
 
-  // env is merged after runtimePaths, so it works as a final escape hatch.
+  // env is merged after runtimePaths for runtime command variables and other
+  // runtime-specific escape hatches. Launcher-owned auth/identity fields stay
+  // controlled by options.
   env: {
     SNA_MAX_SESSIONS: "20",
   },
 });
 ```
 
-For a forked standalone SNA server, path changes should usually be applied before launch or by restarting SNA. For in-process SNA, updating `process.env.SNA_*_COMMAND` in the host can affect later spawns because the providers resolve paths inside the same process.
+Pass `sna.baseUrl` and `sna.authToken` to `SnaClient` or `SnaProvider`.
+The token is generated for this server process; do not store it as a
+long-lived user setting.
+
+For a forked standalone SNA server, path changes should usually be applied before launch or by restarting SNA. For in-process SNA, updating `process.env.SNA_*_COMMAND` in the host can affect later spawns because the runtime adapters resolve paths inside the same process.
 
 ## Test the real runtime with `runOnce`
 
@@ -176,7 +187,7 @@ async function refreshCatalog(client: SnaClient, runtimeId: RuntimeId, cliPath?:
     // Useful when the user just edited a CLI path in settings.
     cliPath,
 
-    // Bypass provider-side cache for an explicit refresh button.
+    // Bypass runtime-side cache for an explicit refresh button.
     refresh: true,
   });
 
@@ -195,7 +206,7 @@ async function registerModel(runtimeId: RuntimeId, model: RuntimeModelInfo) {
     id: `${runtimeId}/${model.id}`,
     modelSlug: model.id,
     label: model.label,
-    provider: model.provider,
+    modelProvider: model.provider,
   });
 }
 ```
@@ -221,7 +232,7 @@ function RuntimeSetupPanel({ runtimeId }: { runtimeId: RuntimeId }) {
   async function saveAndTest() {
     setTesting(true);
     try {
-      // Persist first so the SNA provider resolves this path during runOnce.
+      // Persist first so the SNA runtime adapter resolves this path during runOnce.
       await window.appRuntime.setPath(runtimeId, cliPath);
 
       // This is a real runtime invocation through SNA, not only a fake ping.

--- a/apps/docs/content/docs/introduction/embedding.ja.mdx
+++ b/apps/docs/content/docs/introduction/embedding.ja.mdx
@@ -20,6 +20,7 @@ Electron 用エントリポイントは asar-unpacked パスを解決し、
 
 ```ts
 const sna = await startSnaServer({
+  appId: "my-electron-app",
   port: 3099,
   dbPath: path.join(app.getPath("userData"), "sna.db"),
   maxSessions: 20,
@@ -32,8 +33,16 @@ const sna = await startSnaServer({
 
 // sna.process : spawn された ChildProcess
 // sna.port    : 実際のポート (自動選択後)
+// sna.appId   : このサーバが作る session に付く owner ID
+// sna.baseUrl : client に渡す HTTP URL
+// sna.authToken : client に渡す bearer token
 // sna.stop()  : graceful SIGTERM
 ```
+
+Forked mode では、親プロセスとの IPC 接続が切れると child server も
+終了します。Token はその server process の寿命に紐づくものです。
+長期間残るユーザー設定に保存せず、返された `sna.authToken` を app 内の
+信頼できるチャネルで renderer/client に渡してください。
 
 ## Electron チェックリスト
 
@@ -58,7 +67,8 @@ const sna = await startSnaServer({
 import { SnaClient } from "@sna-sdk/client";
 
 const client = new SnaClient({
-  baseUrl: `localhost:${snaPort}`,
+  baseUrl: sna.baseUrl,
+  authToken: sna.authToken,
   http: true,
   ws: true,
 });
@@ -66,4 +76,6 @@ const client = new SnaClient({
 
 `<SnaProvider>` はヘルパーエンドポイント `GET /api/sna-port` を
 自動的に使います。そのため、React アプリでは IPC なしでレンダラが
-ポートを検出できます。
+ポートを検出できます。ただし auth token はこの endpoint では自動検出
+しません。Host process から信頼できる app 内部チャネルで renderer に
+渡してください。

--- a/apps/docs/content/docs/introduction/embedding.ja.mdx
+++ b/apps/docs/content/docs/introduction/embedding.ja.mdx
@@ -34,15 +34,14 @@ const sna = await startSnaServer({
 // sna.process : spawn された ChildProcess
 // sna.port    : 実際のポート (自動選択後)
 // sna.appId   : このサーバが作る session に付く owner ID
-// sna.baseUrl : client に渡す HTTP URL
-// sna.authToken : client に渡す bearer token
+// sna.connection : SDK client に渡す connection object
 // sna.stop()  : graceful SIGTERM
 ```
 
 Forked mode では、親プロセスとの IPC 接続が切れると child server も
 終了します。Token はその server process の寿命に紐づくものです。
-長期間残るユーザー設定に保存せず、返された `sna.authToken` を app 内の
-信頼できるチャネルで renderer/client に渡してください。
+長期間残るユーザー設定に保存せず、`sna.connection` の中で server handle と
+一緒に渡してください。
 
 ## Electron チェックリスト
 
@@ -66,16 +65,11 @@ Forked mode では、親プロセスとの IPC 接続が切れると child serve
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
-const client = new SnaClient({
-  baseUrl: sna.baseUrl,
-  authToken: sna.authToken,
-  http: true,
-  ws: true,
-});
+const client = new SnaClient(sna.connection);
 ```
 
 `<SnaProvider>` はヘルパーエンドポイント `GET /api/sna-port` を
 自動的に使います。そのため、React アプリでは IPC なしでレンダラが
-ポートを検出できます。ただし auth token はこの endpoint では自動検出
-しません。Host process から信頼できる app 内部チャネルで renderer に
-渡してください。
+ポートを検出できます。Host が同じ信頼済み app endpoint から
+`{ baseUrl, authToken }` を返す場合、`SnaProvider` はその値を connection
+として自動的に使います。

--- a/apps/docs/content/docs/introduction/embedding.ko.mdx
+++ b/apps/docs/content/docs/introduction/embedding.ko.mdx
@@ -19,6 +19,7 @@ Electron 런타임에 맞게 리빌드한 `better-sqlite3` 바이너리를 찾�
 
 ```ts
 const sna = await startSnaServer({
+  appId: "my-electron-app",
   port: 3099,
   dbPath: path.join(app.getPath("userData"), "sna.db"),
   maxSessions: 20,
@@ -31,8 +32,16 @@ const sna = await startSnaServer({
 
 // sna.process : spawn된 ChildProcess
 // sna.port    : 실제 포트 (자동 선택 후)
+// sna.appId   : 이 서버가 만든 session에 붙는 owner ID
+// sna.baseUrl : client에 넘길 HTTP URL
+// sna.authToken : client에 넘길 bearer token
 // sna.stop()  : graceful SIGTERM
 ```
+
+Forked mode에서는 부모 프로세스와의 IPC 연결이 끊기면 child server도
+종료됩니다. Token은 이 server process의 수명에 묶입니다. 긴 수명의
+사용자 설정 파일에 넣지 말고, 반환된 `sna.authToken`을 앱 내부의 신뢰할
+수 있는 채널로 renderer/client에 전달하십시오.
 
 ## Electron 체크리스트
 
@@ -57,12 +66,14 @@ Renderer 프로세스는 임베드된 서버를 일반 HTTP/WS 호스트처럼 �
 import { SnaClient } from "@sna-sdk/client";
 
 const client = new SnaClient({
-  baseUrl: `localhost:${snaPort}`,
+  baseUrl: sna.baseUrl,
+  authToken: sna.authToken,
   http: true,
   ws: true,
 });
 ```
 
 `<SnaProvider>`는 `GET /api/sna-port` 헬퍼를 자동으로 사용합니다.
-따라서 React 앱에서는 IPC 없이도 renderer가 포트를 찾을 수
-있습니다.
+따라서 React 앱에서는 IPC 없이도 renderer가 포트를 찾을 수 있습니다.
+단, auth token은 이 endpoint로 자동 발견하지 않습니다. Host process가
+신뢰할 수 있는 app 내부 채널로 renderer에 전달해야 합니다.

--- a/apps/docs/content/docs/introduction/embedding.ko.mdx
+++ b/apps/docs/content/docs/introduction/embedding.ko.mdx
@@ -33,15 +33,14 @@ const sna = await startSnaServer({
 // sna.process : spawn된 ChildProcess
 // sna.port    : 실제 포트 (자동 선택 후)
 // sna.appId   : 이 서버가 만든 session에 붙는 owner ID
-// sna.baseUrl : client에 넘길 HTTP URL
-// sna.authToken : client에 넘길 bearer token
+// sna.connection : SDK client에 넘길 connection object
 // sna.stop()  : graceful SIGTERM
 ```
 
 Forked mode에서는 부모 프로세스와의 IPC 연결이 끊기면 child server도
 종료됩니다. Token은 이 server process의 수명에 묶입니다. 긴 수명의
-사용자 설정 파일에 넣지 말고, 반환된 `sna.authToken`을 앱 내부의 신뢰할
-수 있는 채널로 renderer/client에 전달하십시오.
+사용자 설정 파일에 넣지 말고 `sna.connection` 안에서 server handle과
+함께 전달하십시오.
 
 ## Electron 체크리스트
 
@@ -65,15 +64,10 @@ Renderer 프로세스는 임베드된 서버를 일반 HTTP/WS 호스트처럼 �
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
-const client = new SnaClient({
-  baseUrl: sna.baseUrl,
-  authToken: sna.authToken,
-  http: true,
-  ws: true,
-});
+const client = new SnaClient(sna.connection);
 ```
 
 `<SnaProvider>`는 `GET /api/sna-port` 헬퍼를 자동으로 사용합니다.
 따라서 React 앱에서는 IPC 없이도 renderer가 포트를 찾을 수 있습니다.
-단, auth token은 이 endpoint로 자동 발견하지 않습니다. Host process가
-신뢰할 수 있는 app 내부 채널로 renderer에 전달해야 합니다.
+Host가 같은 신뢰된 app endpoint에서 `{ baseUrl, authToken }`을 반환하면
+`SnaProvider`가 그 값을 connection으로 자동 사용합니다.

--- a/apps/docs/content/docs/introduction/embedding.mdx
+++ b/apps/docs/content/docs/introduction/embedding.mdx
@@ -33,15 +33,13 @@ const sna = await startSnaServer({
 // sna.process : the spawned ChildProcess
 // sna.port    : actual port (after auto-pick)
 // sna.appId   : owner ID tagged onto sessions created by this server
-// sna.baseUrl : HTTP URL to pass to clients
-// sna.authToken : bearer token to pass to clients
+// sna.connection : connection object to pass to SDK clients
 // sna.stop()  : graceful SIGTERM
 ```
 
 In forked mode, the child server also shuts down when the parent process
-disconnects. The token belongs to that server process; pass the returned
-`sna.authToken` through your trusted app channel instead of putting a
-long-lived token in user-managed config.
+disconnects. The token belongs to that server process; keep it paired with
+`sna.connection` instead of putting a long-lived token in user-managed config.
 
 ## Electron checklist
 
@@ -66,15 +64,10 @@ HTTP/WS host:
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
-const client = new SnaClient({
-  baseUrl: sna.baseUrl,
-  authToken: sna.authToken,
-  http: true,
-  ws: true,
-});
+const client = new SnaClient(sna.connection);
 ```
 
 A helper endpoint `GET /api/sna-port` is wired by `<SnaProvider>` for
-React apps so the renderer can auto-discover the port without IPC. The
-auth token is not discovered through that endpoint; pass it from the
-host process to the renderer through your app's trusted channel.
+React apps so the renderer can auto-discover the port without IPC. If your
+host exposes `{ baseUrl, authToken }` from that same trusted app endpoint,
+`SnaProvider` uses it as the connection automatically.

--- a/apps/docs/content/docs/introduction/embedding.mdx
+++ b/apps/docs/content/docs/introduction/embedding.mdx
@@ -19,6 +19,7 @@ consumer app's electron-rebuilt `better-sqlite3` binary.
 
 ```ts
 const sna = await startSnaServer({
+  appId: "my-electron-app",
   port: 3099,
   dbPath: path.join(app.getPath("userData"), "sna.db"),
   maxSessions: 20,
@@ -31,8 +32,16 @@ const sna = await startSnaServer({
 
 // sna.process : the spawned ChildProcess
 // sna.port    : actual port (after auto-pick)
+// sna.appId   : owner ID tagged onto sessions created by this server
+// sna.baseUrl : HTTP URL to pass to clients
+// sna.authToken : bearer token to pass to clients
 // sna.stop()  : graceful SIGTERM
 ```
+
+In forked mode, the child server also shuts down when the parent process
+disconnects. The token belongs to that server process; pass the returned
+`sna.authToken` through your trusted app channel instead of putting a
+long-lived token in user-managed config.
 
 ## Electron checklist
 
@@ -58,11 +67,14 @@ HTTP/WS host:
 import { SnaClient } from "@sna-sdk/client";
 
 const client = new SnaClient({
-  baseUrl: `localhost:${snaPort}`,
+  baseUrl: sna.baseUrl,
+  authToken: sna.authToken,
   http: true,
   ws: true,
 });
 ```
 
 A helper endpoint `GET /api/sna-port` is wired by `<SnaProvider>` for
-React apps so the renderer can auto-discover the port without IPC.
+React apps so the renderer can auto-discover the port without IPC. The
+auth token is not discovered through that endpoint; pass it from the
+host process to the renderer through your app's trusted channel.

--- a/apps/docs/content/docs/introduction/index.ja.mdx
+++ b/apps/docs/content/docs/introduction/index.ja.mdx
@@ -83,6 +83,7 @@ import { resolveClaudeCli, startSnaServer } from "@sna-sdk/core/node";
 const claude = resolveClaudeCli();
 
 const sna = await startSnaServer({
+  appId: "my-app",
   port: 3099,
   dbPath: "./data/sna.db",
   runtimePaths: {
@@ -92,7 +93,9 @@ const sna = await startSnaServer({
 ```
 
 SNA サーバは管理された子プロセスとして fork されます。`sna.port` には
-実際のバインドポートが入ります。`port` に `0` を指定した場合は
+実際のバインドポートが入ります。`sna.baseUrl` と `sna.authToken` は
+クライアントへそのまま渡します。`sna.appId` はこのサーバが作る
+session の owner metadata として付きます。`port` に `0` を指定した場合は
 自動割り当てになり、`sna.stop()` を呼ぶと SIGTERM でサーバを終了します。
 
 ## 3. クライアント接続
@@ -101,7 +104,8 @@ SNA サーバは管理された子プロセスとして fork されます。`sna
 import { SnaClient } from "@sna-sdk/client";
 
 const client = new SnaClient({
-  baseUrl: `localhost:${sna.port}`,
+  baseUrl: sna.baseUrl,
+  authToken: sna.authToken,
   http: true,   // POST /agent/* など
   ws: true,     // ライブイベントストリーム
 });

--- a/apps/docs/content/docs/introduction/index.ja.mdx
+++ b/apps/docs/content/docs/introduction/index.ja.mdx
@@ -93,22 +93,17 @@ const sna = await startSnaServer({
 ```
 
 SNA サーバは管理された子プロセスとして fork されます。`sna.port` には
-実際のバインドポートが入ります。`sna.baseUrl` と `sna.authToken` は
-クライアントへそのまま渡します。`sna.appId` はこのサーバが作る
-session の owner metadata として付きます。`port` に `0` を指定した場合は
-自動割り当てになり、`sna.stop()` を呼ぶと SIGTERM でサーバを終了します。
+実際のバインドポートが入ります。SDK client には `sna.connection` を
+渡します。`sna.appId` はこのサーバが作る session の owner metadata として
+付きます。`port` に `0` を指定した場合は自動割り当てになり、
+`sna.stop()` を呼ぶと SIGTERM でサーバを終了します。
 
 ## 3. クライアント接続
 
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
-const client = new SnaClient({
-  baseUrl: sna.baseUrl,
-  authToken: sna.authToken,
-  http: true,   // POST /agent/* など
-  ws: true,     // ライブイベントストリーム
-});
+const client = new SnaClient(sna.connection);
 client.connect();
 ```
 

--- a/apps/docs/content/docs/introduction/index.ko.mdx
+++ b/apps/docs/content/docs/introduction/index.ko.mdx
@@ -91,22 +91,17 @@ const sna = await startSnaServer({
 ```
 
 SNA 서버는 관리되는 자식 프로세스로 fork됩니다. `sna.port`에는 실제
-바인딩 포트가 들어갑니다. `sna.baseUrl`과 `sna.authToken`은
-클라이언트에 그대로 넘겨 사용합니다. `sna.appId`는 이 서버가 만든
-session의 owner metadata로 붙습니다. `port`를 `0`으로 지정하면 자동
-할당되며, `sna.stop()`을 호출하면 SIGTERM으로 서버를 종료합니다.
+바인딩 포트가 들어갑니다. SDK 클라이언트에는 `sna.connection`을 넘깁니다.
+`sna.appId`는 이 서버가 만든 session의 owner metadata로 붙습니다.
+`port`를 `0`으로 지정하면 자동 할당되며, `sna.stop()`을 호출하면
+SIGTERM으로 서버를 종료합니다.
 
 ## 3. 클라이언트 연결
 
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
-const client = new SnaClient({
-  baseUrl: sna.baseUrl,
-  authToken: sna.authToken,
-  http: true,   // POST /agent/* 등
-  ws: true,     // 라이브 이벤트 스트림
-});
+const client = new SnaClient(sna.connection);
 client.connect();
 ```
 

--- a/apps/docs/content/docs/introduction/index.ko.mdx
+++ b/apps/docs/content/docs/introduction/index.ko.mdx
@@ -81,6 +81,7 @@ import { resolveClaudeCli, startSnaServer } from "@sna-sdk/core/node";
 const claude = resolveClaudeCli();
 
 const sna = await startSnaServer({
+  appId: "my-app",
   port: 3099,
   dbPath: "./data/sna.db",
   runtimePaths: {
@@ -90,8 +91,10 @@ const sna = await startSnaServer({
 ```
 
 SNA 서버는 관리되는 자식 프로세스로 fork됩니다. `sna.port`에는 실제
-바인딩 포트가 들어갑니다. `port`를 `0`으로 지정하면 자동 할당되며,
-`sna.stop()`을 호출하면 SIGTERM으로 서버를 종료합니다.
+바인딩 포트가 들어갑니다. `sna.baseUrl`과 `sna.authToken`은
+클라이언트에 그대로 넘겨 사용합니다. `sna.appId`는 이 서버가 만든
+session의 owner metadata로 붙습니다. `port`를 `0`으로 지정하면 자동
+할당되며, `sna.stop()`을 호출하면 SIGTERM으로 서버를 종료합니다.
 
 ## 3. 클라이언트 연결
 
@@ -99,7 +102,8 @@ SNA 서버는 관리되는 자식 프로세스로 fork됩니다. `sna.port`에�
 import { SnaClient } from "@sna-sdk/client";
 
 const client = new SnaClient({
-  baseUrl: `localhost:${sna.port}`,
+  baseUrl: sna.baseUrl,
+  authToken: sna.authToken,
   http: true,   // POST /agent/* 등
   ws: true,     // 라이브 이벤트 스트림
 });

--- a/apps/docs/content/docs/introduction/index.mdx
+++ b/apps/docs/content/docs/introduction/index.mdx
@@ -82,6 +82,7 @@ import { resolveClaudeCli, startSnaServer } from "@sna-sdk/core/node";
 const claude = resolveClaudeCli();
 
 const sna = await startSnaServer({
+  appId: "my-app",
   port: 3099,
   dbPath: "./data/sna.db",
   runtimePaths: {
@@ -91,7 +92,9 @@ const sna = await startSnaServer({
 ```
 
 This forks the SNA server as a managed child process. `sna.port` holds
-the bound port (auto-allocated if `0`), `sna.stop()` sends SIGTERM.
+the bound port (auto-allocated if `0`), `sna.baseUrl` and `sna.authToken`
+are passed to clients, `sna.appId` is tagged onto sessions created by this
+server, and `sna.stop()` sends SIGTERM.
 
 ## 3. Connect a client
 
@@ -99,7 +102,8 @@ the bound port (auto-allocated if `0`), `sna.stop()` sends SIGTERM.
 import { SnaClient } from "@sna-sdk/client";
 
 const client = new SnaClient({
-  baseUrl: `localhost:${sna.port}`,
+  baseUrl: sna.baseUrl,
+  authToken: sna.authToken,
   http: true,   // POST /agent/* etc.
   ws: true,     // live event stream
 });

--- a/apps/docs/content/docs/introduction/index.mdx
+++ b/apps/docs/content/docs/introduction/index.mdx
@@ -92,21 +92,16 @@ const sna = await startSnaServer({
 ```
 
 This forks the SNA server as a managed child process. `sna.port` holds
-the bound port (auto-allocated if `0`), `sna.baseUrl` and `sna.authToken`
-are passed to clients, `sna.appId` is tagged onto sessions created by this
-server, and `sna.stop()` sends SIGTERM.
+the bound port (auto-allocated if `0`), `sna.connection` is passed to SDK
+clients, `sna.appId` is tagged onto sessions created by this server, and
+`sna.stop()` sends SIGTERM.
 
 ## 3. Connect a client
 
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
-const client = new SnaClient({
-  baseUrl: sna.baseUrl,
-  authToken: sna.authToken,
-  http: true,   // POST /agent/* etc.
-  ws: true,     // live event stream
-});
+const client = new SnaClient(sna.connection);
 client.connect();
 ```
 

--- a/apps/docs/content/docs/introduction/install.ja.mdx
+++ b/apps/docs/content/docs/introduction/install.ja.mdx
@@ -64,6 +64,7 @@ opencode --version
 
 ```ts
 await startSnaServer({
+  appId: "my-app",
   dbPath: "./data/sna.db",
   runtimePaths: {
     claudeCode: "/opt/homebrew/bin/claude",

--- a/apps/docs/content/docs/introduction/install.ko.mdx
+++ b/apps/docs/content/docs/introduction/install.ko.mdx
@@ -62,6 +62,7 @@ opencode --version
 
 ```ts
 await startSnaServer({
+  appId: "my-app",
   dbPath: "./data/sna.db",
   runtimePaths: {
     claudeCode: "/opt/homebrew/bin/claude",

--- a/apps/docs/content/docs/introduction/install.mdx
+++ b/apps/docs/content/docs/introduction/install.mdx
@@ -61,6 +61,7 @@ If a binary lives somewhere non-standard, register it when starting SNA:
 
 ```ts
 await startSnaServer({
+  appId: "my-app",
   dbPath: "./data/sna.db",
   runtimePaths: {
     claudeCode: "/opt/homebrew/bin/claude",

--- a/apps/docs/content/docs/sdks/client-transport.ja.mdx
+++ b/apps/docs/content/docs/sdks/client-transport.ja.mdx
@@ -14,6 +14,7 @@ description: "SnaClient constructor、connection lifecycle、low-level request/p
 ```ts
 const client = new SnaClient({
   baseUrl: string;
+  authToken?: string;
   ws: boolean;
   http: boolean;
   reconnect?: boolean;
@@ -27,6 +28,7 @@ const client = new SnaClient({
 | Field | Required | Default | Description |
 | --- | --- | --- | --- |
 | `baseUrl` | yes | none | SNA server のアドレスです。`localhost:3099`、`http://localhost:3099`、`https://example.com` を指定できます。 |
+| `authToken` | protected server で必要 | none | SNA server が発行した bearer token です。HTTP は `Authorization` header、WebSocket は browser 互換性のため `/ws?token=...` を使います。 |
 | `ws` | yes | none | WebSocket transport を有効にします。`agent.subscribe`、`onEvent`、permission push に必要です。 |
 | `http` | yes | none | HTTP transport を有効にします。session CRUD と agent lifecycle command に ordering guarantee を提供します。 |
 | `reconnect` | no | `true` | WebSocket 接続が切れたときに自動 reconnect を試みます。 |

--- a/apps/docs/content/docs/sdks/client-transport.ja.mdx
+++ b/apps/docs/content/docs/sdks/client-transport.ja.mdx
@@ -15,8 +15,8 @@ description: "SnaClient constructor、connection lifecycle、low-level request/p
 const client = new SnaClient({
   baseUrl: string;
   authToken?: string;
-  ws: boolean;
-  http: boolean;
+  ws?: boolean;
+  http?: boolean;
   reconnect?: boolean;
   reconnectDelay?: number;
   maxReconnectAttempts?: number;
@@ -28,9 +28,9 @@ const client = new SnaClient({
 | Field | Required | Default | Description |
 | --- | --- | --- | --- |
 | `baseUrl` | yes | none | SNA server のアドレスです。`localhost:3099`、`http://localhost:3099`、`https://example.com` を指定できます。 |
-| `authToken` | protected server で必要 | none | SNA server が発行した bearer token です。HTTP は `Authorization` header、WebSocket は browser 互換性のため `/ws?token=...` を使います。 |
-| `ws` | yes | none | WebSocket transport を有効にします。`agent.subscribe`、`onEvent`、permission push に必要です。 |
-| `http` | yes | none | HTTP transport を有効にします。session CRUD と agent lifecycle command に ordering guarantee を提供します。 |
+| `authToken` | no | none | SNA server が発行した bearer token です。HTTP は `Authorization` header、WebSocket は browser 互換性のため `/ws?token=...` を使います。SDK app では通常 `handle.connection` 経由で受け取ります。 |
+| `ws` | no | `true` | WebSocket transport を有効にします。`agent.subscribe`、`onEvent`、permission push に必要です。 |
+| `http` | no | `true` | HTTP transport を有効にします。session CRUD と agent lifecycle command に ordering guarantee を提供します。 |
 | `reconnect` | no | `true` | WebSocket 接続が切れたときに自動 reconnect を試みます。 |
 | `reconnectDelay` | no | `2000` | reconnect 試行間の待機時間です。単位は ms です。 |
 | `maxReconnectAttempts` | no | `0` | 最大 reconnect 回数です。`0` は無制限を意味します。 |

--- a/apps/docs/content/docs/sdks/client-transport.ko.mdx
+++ b/apps/docs/content/docs/sdks/client-transport.ko.mdx
@@ -14,6 +14,7 @@ description: "SnaClient 생성자, 연결 lifecycle, low-level request/push API.
 ```ts
 const client = new SnaClient({
   baseUrl: string;
+  authToken?: string;
   ws: boolean;
   http: boolean;
   reconnect?: boolean;
@@ -27,6 +28,7 @@ const client = new SnaClient({
 | Field | Required | Default | Description |
 | --- | --- | --- | --- |
 | `baseUrl` | yes | none | SNA server 주소입니다. `localhost:3099`, `http://localhost:3099`, `https://example.com` 형태를 지원합니다. |
+| `authToken` | protected server에서 필요 | none | SNA server가 발급한 bearer token입니다. HTTP는 `Authorization` header를 쓰고, WebSocket은 browser 호환성을 위해 `/ws?token=...`을 씁니다. |
 | `ws` | yes | none | WebSocket transport를 켭니다. `agent.subscribe`, `onEvent`, permission push에 필요합니다. |
 | `http` | yes | none | HTTP transport를 켭니다. session CRUD와 agent lifecycle 명령의 ordering guarantee를 제공합니다. |
 | `reconnect` | no | `true` | WebSocket이 끊겼을 때 자동 reconnect를 시도합니다. |
@@ -46,7 +48,8 @@ const client = new SnaClient({
 import { SnaClient } from "@sna-sdk/client";
 
 const client = new SnaClient({
-  baseUrl: "localhost:3099",
+  baseUrl: handle.baseUrl,
+  authToken: handle.authToken,
   http: true,
   ws: true,
 });

--- a/apps/docs/content/docs/sdks/client-transport.ko.mdx
+++ b/apps/docs/content/docs/sdks/client-transport.ko.mdx
@@ -15,8 +15,8 @@ description: "SnaClient 생성자, 연결 lifecycle, low-level request/push API.
 const client = new SnaClient({
   baseUrl: string;
   authToken?: string;
-  ws: boolean;
-  http: boolean;
+  ws?: boolean;
+  http?: boolean;
   reconnect?: boolean;
   reconnectDelay?: number;
   maxReconnectAttempts?: number;
@@ -28,9 +28,9 @@ const client = new SnaClient({
 | Field | Required | Default | Description |
 | --- | --- | --- | --- |
 | `baseUrl` | yes | none | SNA server 주소입니다. `localhost:3099`, `http://localhost:3099`, `https://example.com` 형태를 지원합니다. |
-| `authToken` | protected server에서 필요 | none | SNA server가 발급한 bearer token입니다. HTTP는 `Authorization` header를 쓰고, WebSocket은 browser 호환성을 위해 `/ws?token=...`을 씁니다. |
-| `ws` | yes | none | WebSocket transport를 켭니다. `agent.subscribe`, `onEvent`, permission push에 필요합니다. |
-| `http` | yes | none | HTTP transport를 켭니다. session CRUD와 agent lifecycle 명령의 ordering guarantee를 제공합니다. |
+| `authToken` | no | none | SNA server가 발급한 bearer token입니다. HTTP는 `Authorization` header를 쓰고, WebSocket은 browser 호환성을 위해 `/ws?token=...`을 씁니다. SDK 앱은 보통 `handle.connection`을 통해 받습니다. |
+| `ws` | no | `true` | WebSocket transport를 켭니다. `agent.subscribe`, `onEvent`, permission push에 필요합니다. |
+| `http` | no | `true` | HTTP transport를 켭니다. session CRUD와 agent lifecycle 명령의 ordering guarantee를 제공합니다. |
 | `reconnect` | no | `true` | WebSocket이 끊겼을 때 자동 reconnect를 시도합니다. |
 | `reconnectDelay` | no | `2000` | reconnect 사이 대기 시간입니다. 단위는 ms입니다. |
 | `maxReconnectAttempts` | no | `0` | 최대 reconnect 횟수입니다. `0`은 무제한입니다. |
@@ -47,12 +47,7 @@ const client = new SnaClient({
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
-const client = new SnaClient({
-  baseUrl: handle.baseUrl,
-  authToken: handle.authToken,
-  http: true,
-  ws: true,
-});
+const client = new SnaClient(handle.connection);
 ```
 
 ## `client.connect()`

--- a/apps/docs/content/docs/sdks/client-transport.mdx
+++ b/apps/docs/content/docs/sdks/client-transport.mdx
@@ -15,8 +15,8 @@ description: "SnaClient constructor, connection lifecycle, and low-level request
 const client = new SnaClient({
   baseUrl: string;
   authToken?: string;
-  ws: boolean;
-  http: boolean;
+  ws?: boolean;
+  http?: boolean;
   reconnect?: boolean;
   reconnectDelay?: number;
   maxReconnectAttempts?: number;
@@ -28,9 +28,9 @@ const client = new SnaClient({
 | Field | Required | Default | Description |
 | --- | --- | --- | --- |
 | `baseUrl` | yes | none | SNA server address. Supports `localhost:3099`, `http://localhost:3099`, and `https://example.com`. |
-| `authToken` | for protected servers | none | Bearer token issued by the SNA server. HTTP uses `Authorization`; WebSocket uses `/ws?token=...` for browser compatibility. |
-| `ws` | yes | none | Enables WebSocket transport. Required for `agent.subscribe`, `onEvent`, and permission pushes. |
-| `http` | yes | none | Enables HTTP transport. Provides ordering guarantees for session CRUD and agent lifecycle commands. |
+| `authToken` | no | none | Bearer token issued by the SNA server. HTTP uses `Authorization`; WebSocket uses `/ws?token=...` for browser compatibility. SDK apps normally receive it through `handle.connection`. |
+| `ws` | no | `true` | Enables WebSocket transport. Required for `agent.subscribe`, `onEvent`, and permission pushes. |
+| `http` | no | `true` | Enables HTTP transport. Provides ordering guarantees for session CRUD and agent lifecycle commands. |
 | `reconnect` | no | `true` | Automatically tries to reconnect when the WebSocket connection drops. |
 | `reconnectDelay` | no | `2000` | Delay between reconnect attempts, in milliseconds. |
 | `maxReconnectAttempts` | no | `0` | Maximum reconnect attempts. `0` means unlimited. |
@@ -47,12 +47,7 @@ const client = new SnaClient({
 ```ts
 import { SnaClient } from "@sna-sdk/client";
 
-const client = new SnaClient({
-  baseUrl: handle.baseUrl,
-  authToken: handle.authToken,
-  http: true,
-  ws: true,
-});
+const client = new SnaClient(handle.connection);
 ```
 
 ## `client.connect()`

--- a/apps/docs/content/docs/sdks/client-transport.mdx
+++ b/apps/docs/content/docs/sdks/client-transport.mdx
@@ -14,6 +14,7 @@ description: "SnaClient constructor, connection lifecycle, and low-level request
 ```ts
 const client = new SnaClient({
   baseUrl: string;
+  authToken?: string;
   ws: boolean;
   http: boolean;
   reconnect?: boolean;
@@ -27,6 +28,7 @@ const client = new SnaClient({
 | Field | Required | Default | Description |
 | --- | --- | --- | --- |
 | `baseUrl` | yes | none | SNA server address. Supports `localhost:3099`, `http://localhost:3099`, and `https://example.com`. |
+| `authToken` | for protected servers | none | Bearer token issued by the SNA server. HTTP uses `Authorization`; WebSocket uses `/ws?token=...` for browser compatibility. |
 | `ws` | yes | none | Enables WebSocket transport. Required for `agent.subscribe`, `onEvent`, and permission pushes. |
 | `http` | yes | none | Enables HTTP transport. Provides ordering guarantees for session CRUD and agent lifecycle commands. |
 | `reconnect` | no | `true` | Automatically tries to reconnect when the WebSocket connection drops. |
@@ -46,7 +48,8 @@ const client = new SnaClient({
 import { SnaClient } from "@sna-sdk/client";
 
 const client = new SnaClient({
-  baseUrl: "localhost:3099",
+  baseUrl: handle.baseUrl,
+  authToken: handle.authToken,
   http: true,
   ws: true,
 });

--- a/apps/docs/content/docs/sdks/core-launchers.ja.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.ja.mdx
@@ -109,12 +109,7 @@ const handle = await startSnaServer({
   },
 });
 
-const client = new SnaClient({
-  baseUrl: handle.baseUrl,
-  authToken: handle.authToken,
-  http: true,
-  ws: true,
-});
+const client = new SnaClient(handle.connection);
 
 handle.stop();
 ```
@@ -144,6 +139,7 @@ type SnaServerHandle = {
   appId: string;
   baseUrl: string;
   authToken: string;
+  connection: { baseUrl: string; authToken: string };
   stop(): void;
 };
 ```
@@ -162,6 +158,7 @@ type InProcessSnaServerHandle = {
   appId: string;
   baseUrl: string;
   authToken: string;
+  connection: { baseUrl: string; authToken: string };
   sessionManager: SessionManager;
   httpServer: http.Server;
   initLangfuse(config: { publicKey: string; secretKey: string; baseUrl?: string }): Promise<void>;

--- a/apps/docs/content/docs/sdks/core-launchers.ja.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.ja.mdx
@@ -22,6 +22,10 @@ Launcher handle は、サーバー停止と、検出された URL を `@sna-sdk/
 ```ts
 type SnaServerOptions = {
   port?: number;
+  host?: string;
+  appId?: string;
+  authToken?: string;
+  allowedOrigins?: string[];
   dbPath: string;
   cwd?: string;
   maxSessions?: number;
@@ -50,6 +54,10 @@ type RuntimePaths = {
 | Field | Default | 説明 |
 | --- | --- | --- |
 | `port` | `3099` | Server に渡す API port。 |
+| `host` | `127.0.0.1` | Bind host。Host app により強い transport boundary がない限り loopback を維持してください。 |
+| `appId` | `sna-sdk` | この server instance の owner ID。このサーバが作る session metadata に付きます。 |
+| `authToken` | generated | Protected HTTP route と WebSocket upgrade に必要な bearer token。 |
+| `allowedOrigins` | `[]` | Browser `Origin` request のうち許可する値。`Origin` を送らない native client は許可されます。 |
 | `dbPath` | required | Absolute SQLite path。`cwd` がない場合、launcher はこの path から `cwd` を計算します。 |
 | `cwd` | `dirname(dbPath)` | Server process と runtime session の working directory。 |
 | `maxSessions` | `5` | 同時に保持できる agent session 数。 |
@@ -57,7 +65,7 @@ type RuntimePaths = {
 | `model` | SDK default | Runtime call のデフォルト model。 |
 | `permissionTimeoutMs` | `0` | `0` の場合、permission prompt response は host が管理します。正の値なら timeout 後に自動 deny します。 |
 | `nativeBinding` | auto-detected | 明示的な `better-sqlite3` native binding path。Custom Electron build で使います。 |
-| `env` | `{}` | 追加環境変数。ここに置いたランタイムコマンド環境変数は `runtimePaths` から生成された値を上書きします。 |
+| `env` | `{}` | 追加環境変数。ここに置いた runtime command 環境変数は `runtimePaths` から生成された値を上書きします。ただし `SNA_APP_ID`、`SNA_AUTH_TOKEN`、`SNA_HOST`、`SNA_ALLOWED_ORIGINS` など launcher 所有の値は typed option が最終値です。 |
 | `readyTimeout` | `15000` | Standalone process が ready line を出すまで待つ時間(ms)。 |
 | `onLog` | none | Child process の stdout/stderr line、または in-process mode の SDK logger line を受け取ります。 |
 | `dataDir` | `dbPath` から計算 | Image と asset storage の base directory。 |
@@ -67,7 +75,8 @@ type RuntimePaths = {
 
 ホストアプリに設定画面がある場合や、ユーザーが選んだ CLI 位置を保存する
 場合は `runtimePaths` を使ってください。`env` は最後の退避手段として
-残り、`runtimePaths` から生成された値を上書きします。
+残り、`runtimePaths` から生成された値を上書きします。Server identity、
+auth、bind host、origin policy は typed launcher field で指定してください。
 
 ## Forked vs in-process
 
@@ -78,6 +87,11 @@ type RuntimePaths = {
 
 In-process mode は default agent を自動 spawn しません。Host が HTTP、WebSocket、または返された `sessionManager` から session を開始します。
 
+Standalone server を直接実行する方法は開発/デバッグ用です。Product
+integration では `startSnaServer()` または `startSnaServerInProcess()` を
+優先してください。Token、owner identity、bind host、shutdown lifecycle を
+host app が所有できます。
+
 ## 関数リファレンス
 
 ### `@sna-sdk/core/node` の `startSnaServer(options)`
@@ -86,11 +100,20 @@ In-process mode は default agent を自動 spawn しません。Host が HTTP�
 
 ```ts
 const handle = await startSnaServer({
+  appId: "my-app",
   dbPath: "/Users/me/Library/Application Support/MyApp/sna.db",
   port: 3099,
+  allowedOrigins: ["http://localhost:5173"],
   runtimePaths: {
     claudeCode: "/opt/homebrew/bin/claude",
   },
+});
+
+const client = new SnaClient({
+  baseUrl: handle.baseUrl,
+  authToken: handle.authToken,
+  http: true,
+  ws: true,
 });
 
 handle.stop();
@@ -117,6 +140,10 @@ Returns:
 type SnaServerHandle = {
   process: ChildProcess;
   port: number;
+  host: string;
+  appId: string;
+  baseUrl: string;
+  authToken: string;
   stop(): void;
 };
 ```
@@ -131,6 +158,10 @@ Returns:
 type InProcessSnaServerHandle = {
   process: null;
   port: number;
+  host: string;
+  appId: string;
+  baseUrl: string;
+  authToken: string;
   sessionManager: SessionManager;
   httpServer: http.Server;
   initLangfuse(config: { publicKey: string; secretKey: string; baseUrl?: string }): Promise<void>;

--- a/apps/docs/content/docs/sdks/core-launchers.ko.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.ko.mdx
@@ -109,12 +109,7 @@ const handle = await startSnaServer({
   },
 });
 
-const client = new SnaClient({
-  baseUrl: handle.baseUrl,
-  authToken: handle.authToken,
-  http: true,
-  ws: true,
-});
+const client = new SnaClient(handle.connection);
 
 handle.stop();
 ```
@@ -144,6 +139,7 @@ type SnaServerHandle = {
   appId: string;
   baseUrl: string;
   authToken: string;
+  connection: { baseUrl: string; authToken: string };
   stop(): void;
 };
 ```
@@ -162,6 +158,7 @@ type InProcessSnaServerHandle = {
   appId: string;
   baseUrl: string;
   authToken: string;
+  connection: { baseUrl: string; authToken: string };
   sessionManager: SessionManager;
   httpServer: http.Server;
   initLangfuse(config: { publicKey: string; secretKey: string; baseUrl?: string }): Promise<void>;

--- a/apps/docs/content/docs/sdks/core-launchers.ko.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.ko.mdx
@@ -22,6 +22,10 @@ Launcher handle은 서버를 중지하고 발견된 URL을 `@sna-sdk/client` 또
 ```ts
 type SnaServerOptions = {
   port?: number;
+  host?: string;
+  appId?: string;
+  authToken?: string;
+  allowedOrigins?: string[];
   dbPath: string;
   cwd?: string;
   maxSessions?: number;
@@ -50,6 +54,10 @@ type RuntimePaths = {
 | Field | Default | 설명 |
 | --- | --- | --- |
 | `port` | `3099` | Server에 전달할 API port. |
+| `host` | `127.0.0.1` | Bind host. Host app에 더 강한 transport boundary가 없다면 loopback을 유지하십시오. |
+| `appId` | `sna-sdk` | 이 server instance의 owner ID입니다. 이 서버가 만든 session metadata에 붙습니다. |
+| `authToken` | generated | Protected HTTP route와 WebSocket upgrade에 필요한 bearer token. |
+| `allowedOrigins` | `[]` | Browser `Origin` 요청 중 허용할 값. `Origin`을 보내지 않는 native client는 허용됩니다. |
 | `dbPath` | required | Absolute SQLite path. `cwd`가 없으면 launcher가 이 path에서 `cwd`를 계산합니다. |
 | `cwd` | `dirname(dbPath)` | Server process와 runtime session의 working directory. |
 | `maxSessions` | `5` | 동시에 유지할 수 있는 agent session 수. |
@@ -57,7 +65,7 @@ type RuntimePaths = {
 | `model` | SDK default | Runtime call의 기본 model. |
 | `permissionTimeoutMs` | `0` | `0`이면 permission prompt 응답을 host가 직접 관리합니다. 양수면 timeout 뒤 자동 deny됩니다. |
 | `nativeBinding` | auto-detected | 명시적인 `better-sqlite3` native binding path. Custom Electron build에서 사용합니다. |
-| `env` | `{}` | 추가 환경 변수. 여기에 둔 런타임 명령 환경 변수는 `runtimePaths`에서 생성된 값을 덮어씁니다. |
+| `env` | `{}` | 추가 환경 변수. 여기에 둔 runtime command 환경 변수는 `runtimePaths`에서 생성된 값을 덮어씁니다. 단 `SNA_APP_ID`, `SNA_AUTH_TOKEN`, `SNA_HOST`, `SNA_ALLOWED_ORIGINS` 같은 launcher 소유 값은 typed option이 최종값입니다. |
 | `readyTimeout` | `15000` | Standalone process가 ready line을 출력할 때까지 기다리는 시간(ms). |
 | `onLog` | none | Child process의 stdout/stderr line, 또는 in-process mode의 SDK logger line을 받습니다. |
 | `dataDir` | `dbPath`에서 계산 | Image와 asset storage의 base directory. |
@@ -67,7 +75,8 @@ type RuntimePaths = {
 
 호스트 앱에 설정 화면이 있거나 사용자가 선택한 CLI 위치를 저장한다면
 `runtimePaths`를 사용하십시오. `env`는 여전히 마지막 우회 수단으로 남아
-있으며, `runtimePaths`에서 생성된 값을 덮어씁니다.
+있으며, `runtimePaths`에서 생성된 값을 덮어씁니다. Server identity, auth,
+bind host, origin policy는 typed launcher field로 지정하십시오.
 
 ## Forked vs in-process
 
@@ -78,6 +87,11 @@ type RuntimePaths = {
 
 In-process mode는 default agent를 자동으로 spawn하지 않습니다. Host가 HTTP, WebSocket 또는 반환된 `sessionManager`로 session을 시작합니다.
 
+Standalone server를 직접 실행하는 방식은 개발/디버깅용 경로입니다. Product
+integration에서는 `startSnaServer()` 또는 `startSnaServerInProcess()`를
+우선 사용하십시오. 그래야 token, owner identity, bind host, shutdown lifecycle을
+host app이 직접 소유할 수 있습니다.
+
 ## 함수 레퍼런스
 
 ### `@sna-sdk/core/node`의 `startSnaServer(options)`
@@ -86,11 +100,20 @@ In-process mode는 default agent를 자동으로 spawn하지 않습니다. Host�
 
 ```ts
 const handle = await startSnaServer({
+  appId: "my-app",
   dbPath: "/Users/me/Library/Application Support/MyApp/sna.db",
   port: 3099,
+  allowedOrigins: ["http://localhost:5173"],
   runtimePaths: {
     claudeCode: "/opt/homebrew/bin/claude",
   },
+});
+
+const client = new SnaClient({
+  baseUrl: handle.baseUrl,
+  authToken: handle.authToken,
+  http: true,
+  ws: true,
 });
 
 handle.stop();
@@ -117,6 +140,10 @@ Returns:
 type SnaServerHandle = {
   process: ChildProcess;
   port: number;
+  host: string;
+  appId: string;
+  baseUrl: string;
+  authToken: string;
   stop(): void;
 };
 ```
@@ -131,6 +158,10 @@ Returns:
 type InProcessSnaServerHandle = {
   process: null;
   port: number;
+  host: string;
+  appId: string;
+  baseUrl: string;
+  authToken: string;
   sessionManager: SessionManager;
   httpServer: http.Server;
   initLangfuse(config: { publicKey: string; secretKey: string; baseUrl?: string }): Promise<void>;

--- a/apps/docs/content/docs/sdks/core-launchers.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.mdx
@@ -109,12 +109,7 @@ const handle = await startSnaServer({
   },
 });
 
-const client = new SnaClient({
-  baseUrl: handle.baseUrl,
-  authToken: handle.authToken,
-  http: true,
-  ws: true,
-});
+const client = new SnaClient(handle.connection);
 
 handle.stop();
 ```
@@ -144,6 +139,7 @@ type SnaServerHandle = {
   appId: string;
   baseUrl: string;
   authToken: string;
+  connection: { baseUrl: string; authToken: string };
   stop(): void;
 };
 ```
@@ -162,6 +158,7 @@ type InProcessSnaServerHandle = {
   appId: string;
   baseUrl: string;
   authToken: string;
+  connection: { baseUrl: string; authToken: string };
   sessionManager: SessionManager;
   httpServer: http.Server;
   initLangfuse(config: { publicKey: string; secretKey: string; baseUrl?: string }): Promise<void>;

--- a/apps/docs/content/docs/sdks/core-launchers.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.mdx
@@ -22,6 +22,10 @@ Launcher handles expose enough information to stop the server and pass the disco
 ```ts
 type SnaServerOptions = {
   port?: number;
+  host?: string;
+  appId?: string;
+  authToken?: string;
+  allowedOrigins?: string[];
   dbPath: string;
   cwd?: string;
   maxSessions?: number;
@@ -50,6 +54,10 @@ type RuntimePaths = {
 | Field | Default | Description |
 | --- | --- | --- |
 | `port` | `3099` | API port passed to the server. |
+| `host` | `127.0.0.1` | Bind host. Keep loopback unless the host app has a stronger transport boundary. |
+| `appId` | `sna-sdk` | Owner ID for this server instance. Sessions created through the server are tagged with this value. |
+| `authToken` | generated | Bearer token required by protected HTTP routes and WebSocket upgrades. |
+| `allowedOrigins` | `[]` | Browser `Origin` values allowed to call the server. Native clients that send no `Origin` are allowed. |
 | `dbPath` | required | Absolute SQLite path. The launcher also derives `cwd` from this path when `cwd` is omitted. |
 | `cwd` | `dirname(dbPath)` | Working directory for the server process and runtime sessions. |
 | `maxSessions` | `5` | Maximum concurrent agent sessions. |
@@ -57,7 +65,7 @@ type RuntimePaths = {
 | `model` | SDK default | Default model for runtime calls. |
 | `permissionTimeoutMs` | `0` | `0` leaves permission prompts under host control; positive values auto-deny after the timeout. |
 | `nativeBinding` | auto-detected | Explicit `better-sqlite3` native binding path. Use this for custom Electron builds. |
-| `env` | `{}` | Extra environment variables. Runtime command variables here override values generated from `runtimePaths`. |
+| `env` | `{}` | Extra environment variables. Runtime command variables here override values generated from `runtimePaths`; launcher-owned values such as `SNA_APP_ID`, `SNA_AUTH_TOKEN`, `SNA_HOST`, and `SNA_ALLOWED_ORIGINS` remain controlled by launcher options. |
 | `readyTimeout` | `15000` | Milliseconds to wait for the standalone process to print the ready line. |
 | `onLog` | none | Receives stdout/stderr lines from the child process or SDK logger lines in in-process mode. |
 | `dataDir` | derived from `dbPath` | Base directory for image and asset storage. |
@@ -67,7 +75,8 @@ type RuntimePaths = {
 
 Use `runtimePaths` when the host app has a setup screen or stores user-selected
 CLI locations. `env` is still available as the final escape hatch and overrides
-the values generated from `runtimePaths`.
+the values generated from `runtimePaths`. Use the typed launcher fields for
+server identity, auth, bind host, and origin policy.
 
 ## Forked vs in-process
 
@@ -78,6 +87,11 @@ the values generated from `runtimePaths`.
 
 In-process mode does not spawn a default agent. The host starts sessions through HTTP, WebSocket, or the returned `sessionManager`.
 
+Directly running the standalone server is a development/debugging path. Product
+integrations should prefer `startSnaServer()` or `startSnaServerInProcess()` so
+the token, owner identity, bind host, and shutdown lifecycle stay under the host
+app's control.
+
 ## Function reference
 
 ### `startSnaServer(options)` from `@sna-sdk/core/node`
@@ -86,11 +100,20 @@ Starts SNA from a plain Node host and returns a handle with connection informati
 
 ```ts
 const handle = await startSnaServer({
+  appId: "my-app",
   dbPath: "/Users/me/Library/Application Support/MyApp/sna.db",
   port: 3099,
+  allowedOrigins: ["http://localhost:5173"],
   runtimePaths: {
     claudeCode: "/opt/homebrew/bin/claude",
   },
+});
+
+const client = new SnaClient({
+  baseUrl: handle.baseUrl,
+  authToken: handle.authToken,
+  http: true,
+  ws: true,
 });
 
 handle.stop();
@@ -117,6 +140,10 @@ Returns:
 type SnaServerHandle = {
   process: ChildProcess;
   port: number;
+  host: string;
+  appId: string;
+  baseUrl: string;
+  authToken: string;
   stop(): void;
 };
 ```
@@ -131,6 +158,10 @@ Returns:
 type InProcessSnaServerHandle = {
   process: null;
   port: number;
+  host: string;
+  appId: string;
+  baseUrl: string;
+  authToken: string;
   sessionManager: SessionManager;
   httpServer: http.Server;
   initLangfuse(config: { publicKey: string; secretKey: string; baseUrl?: string }): Promise<void>;

--- a/apps/docs/content/docs/sdks/core-server.ja.mdx
+++ b/apps/docs/content/docs/sdks/core-server.ja.mdx
@@ -9,7 +9,8 @@ description: "`@sna-sdk/core/server` から export されるサーバー側エ�
 | サーフェス | 目的 |
 | --- | --- |
 | `createSnaApp(options?)` | SNA HTTP application を作成します。 |
-| `attachWebSocket(server, sessionManager)` | 既存 HTTP server に SNA WebSocket protocol を接続します。 |
+| `attachWebSocket(server, sessionManager, options?)` | 既存 HTTP server に SNA WebSocket protocol を接続します。 |
+| `generateSnaAuthToken()` | Protected HTTP / WebSocket route 用の bearer token を生成します。 |
 | `SessionManager` | Server-side agent session と lifecycle event を管理します。 |
 | `snaPortRoute` | ブラウザ自動検出のため現在の SNA port を公開します。 |
 | `runOnce`, `completion` | この entry point からも re-export される direct server-side helper です。 |
@@ -20,13 +21,14 @@ description: "`@sna-sdk/core/server` から export されるサーバー側エ�
 
 ~~~ts
 import { serve } from "@hono/node-server";
-import { createSnaApp, attachWebSocket, SessionManager } from "@sna-sdk/core/server";
+import { createSnaApp, attachWebSocket, generateSnaAuthToken, SessionManager } from "@sna-sdk/core/server";
 
 const sessionManager = new SessionManager({ maxSessions: 10 });
-const app = await createSnaApp({ sessionManager });
+const authToken = generateSnaAuthToken();
+const app = await createSnaApp({ sessionManager, authToken });
 
-const server = serve({ fetch: app.fetch, port: 3099 }) as unknown as import("node:http").Server;
-attachWebSocket(server, sessionManager);
+const server = serve({ fetch: app.fetch, port: 3099, hostname: "127.0.0.1" }) as unknown as import("node:http").Server;
+attachWebSocket(server, sessionManager, { authToken });
 ~~~
 
 サーバー entry point は agent lifecycle を所有する process の近くに置いてください。Browser client は server module を直接 import せず、`@sna-sdk/client` または `@sna-sdk/react` 経由で接続する方が安全です。
@@ -36,6 +38,8 @@ attachWebSocket(server, sessionManager);
 ```ts
 declare function createSnaApp(options?: {
   sessionManager?: SessionManager;
+  authToken?: string;
+  allowedOrigins?: string[];
 }): Promise<Hono>;
 ```
 
@@ -43,10 +47,10 @@ SNA route を公開する Hono HTTP application を作成します。OpenAPI app
 
 `sessionManager` を省略すると server が 1 つ作成します。HTTP route と WebSocket client が同じ session state を共有する必要がある場合、または host が lifecycle event に直接アクセスする必要がある場合は、manager を作成して渡してください。
 
-## `attachWebSocket(server, sessionManager)`
+## `attachWebSocket(server, sessionManager, options?)`
 
 ```ts
-const wss = attachWebSocket(httpServer, sessionManager);
+const wss = attachWebSocket(httpServer, sessionManager, { authToken, allowedOrigins });
 ```
 
 既存 Node HTTP server の `/ws` upgrade path に WebSocket server を接続します。`createSnaApp` に渡したものと同じ `SessionManager` を使ってください。そうしないと、HTTP command と WebSocket subscription が別々の session state を見ることになります。

--- a/apps/docs/content/docs/sdks/core-server.ko.mdx
+++ b/apps/docs/content/docs/sdks/core-server.ko.mdx
@@ -9,7 +9,8 @@ description: "`@sna-sdk/core/server`에서 export되는 서버 측 진입점입�
 | 표면 | 목적 |
 | --- | --- |
 | `createSnaApp(options?)` | SNA HTTP application을 생성합니다. |
-| `attachWebSocket(server, sessionManager)` | 기존 HTTP server에 SNA WebSocket protocol을 붙입니다. |
+| `attachWebSocket(server, sessionManager, options?)` | 기존 HTTP server에 SNA WebSocket protocol을 붙입니다. |
+| `generateSnaAuthToken()` | Protected HTTP 및 WebSocket route용 bearer token을 생성합니다. |
 | `SessionManager` | Server-side agent session과 lifecycle event를 관리합니다. |
 | `snaPortRoute` | 브라우저 자동 탐색을 위해 현재 SNA port를 노출합니다. |
 | `runOnce`, `completion` | 이 entry point에서도 re-export되는 direct server-side helper입니다. |
@@ -20,13 +21,14 @@ description: "`@sna-sdk/core/server`에서 export되는 서버 측 진입점입�
 
 ~~~ts
 import { serve } from "@hono/node-server";
-import { createSnaApp, attachWebSocket, SessionManager } from "@sna-sdk/core/server";
+import { createSnaApp, attachWebSocket, generateSnaAuthToken, SessionManager } from "@sna-sdk/core/server";
 
 const sessionManager = new SessionManager({ maxSessions: 10 });
-const app = await createSnaApp({ sessionManager });
+const authToken = generateSnaAuthToken();
+const app = await createSnaApp({ sessionManager, authToken });
 
-const server = serve({ fetch: app.fetch, port: 3099 }) as unknown as import("node:http").Server;
-attachWebSocket(server, sessionManager);
+const server = serve({ fetch: app.fetch, port: 3099, hostname: "127.0.0.1" }) as unknown as import("node:http").Server;
+attachWebSocket(server, sessionManager, { authToken });
 ~~~
 
 서버 entry point는 agent lifecycle을 소유하는 process 가까이에 두십시오. Browser client는 server module을 직접 import하지 말고 `@sna-sdk/client` 또는 `@sna-sdk/react`로 연결하는 편이 안전합니다.
@@ -36,6 +38,8 @@ attachWebSocket(server, sessionManager);
 ```ts
 declare function createSnaApp(options?: {
   sessionManager?: SessionManager;
+  authToken?: string;
+  allowedOrigins?: string[];
 }): Promise<Hono>;
 ```
 
@@ -43,10 +47,10 @@ SNA route를 노출하는 Hono HTTP application을 생성합니다. OpenAPI app 
 
 `sessionManager`를 생략하면 server가 하나를 생성합니다. HTTP route와 WebSocket client가 같은 session state를 공유해야 하거나 host가 lifecycle event에 직접 접근해야 한다면 manager를 직접 만들어 전달하십시오.
 
-## `attachWebSocket(server, sessionManager)`
+## `attachWebSocket(server, sessionManager, options?)`
 
 ```ts
-const wss = attachWebSocket(httpServer, sessionManager);
+const wss = attachWebSocket(httpServer, sessionManager, { authToken, allowedOrigins });
 ```
 
 기존 Node HTTP server의 `/ws` upgrade path에 WebSocket server를 붙입니다. `createSnaApp`에 전달한 것과 같은 `SessionManager`를 사용하십시오. 그렇지 않으면 HTTP command와 WebSocket subscription이 서로 다른 session state를 보게 됩니다.

--- a/apps/docs/content/docs/sdks/core-server.mdx
+++ b/apps/docs/content/docs/sdks/core-server.mdx
@@ -9,7 +9,8 @@ Use these APIs when you want to host SNA inside your own server process. The ser
 | Surface | Purpose |
 | --- | --- |
 | `createSnaApp(options?)` | Creates the SNA HTTP application. |
-| `attachWebSocket(server, sessionManager)` | Attaches the SNA WebSocket protocol to an existing HTTP server. |
+| `attachWebSocket(server, sessionManager, options?)` | Attaches the SNA WebSocket protocol to an existing HTTP server. |
+| `generateSnaAuthToken()` | Generates a bearer token for protected HTTP and WebSocket routes. |
 | `SessionManager` | Manages server-side agent sessions and lifecycle events. |
 | `snaPortRoute` | Exposes the current SNA port for browser auto-discovery. |
 | `runOnce`, `completion` | Direct server-side helpers also re-exported from this entry point. |
@@ -20,13 +21,14 @@ Deprecated compatibility route modules under `@sna-sdk/core/server/routes/*` rem
 
 ~~~ts
 import { serve } from "@hono/node-server";
-import { createSnaApp, attachWebSocket, SessionManager } from "@sna-sdk/core/server";
+import { createSnaApp, attachWebSocket, generateSnaAuthToken, SessionManager } from "@sna-sdk/core/server";
 
 const sessionManager = new SessionManager({ maxSessions: 10 });
-const app = await createSnaApp({ sessionManager });
+const authToken = generateSnaAuthToken();
+const app = await createSnaApp({ sessionManager, authToken });
 
-const server = serve({ fetch: app.fetch, port: 3099 }) as unknown as import("node:http").Server;
-attachWebSocket(server, sessionManager);
+const server = serve({ fetch: app.fetch, port: 3099, hostname: "127.0.0.1" }) as unknown as import("node:http").Server;
+attachWebSocket(server, sessionManager, { authToken });
 ~~~
 
 Keep the server entry point close to the process that owns the agent lifecycle. Browser clients should connect through `@sna-sdk/client` or `@sna-sdk/react` instead of importing server modules.
@@ -36,6 +38,8 @@ Keep the server entry point close to the process that owns the agent lifecycle. 
 ```ts
 declare function createSnaApp(options?: {
   sessionManager?: SessionManager;
+  authToken?: string;
+  allowedOrigins?: string[];
 }): Promise<Hono>;
 ```
 
@@ -43,10 +47,10 @@ Creates the Hono HTTP application that exposes SNA routes. It delegates to the O
 
 If `sessionManager` is omitted, the server creates one. Pass your own manager when HTTP routes and WebSocket clients must share the same session state, or when the host needs direct access to lifecycle events.
 
-## `attachWebSocket(server, sessionManager)`
+## `attachWebSocket(server, sessionManager, options?)`
 
 ```ts
-const wss = attachWebSocket(httpServer, sessionManager);
+const wss = attachWebSocket(httpServer, sessionManager, { authToken, allowedOrigins });
 ```
 
 Attaches a WebSocket server to the `/ws` upgrade path of an existing Node HTTP server. Use the same `SessionManager` passed to `createSnaApp`; otherwise HTTP commands and WebSocket subscriptions will observe different session state.

--- a/apps/docs/content/docs/sdks/react-components.ja.mdx
+++ b/apps/docs/content/docs/sdks/react-components.ja.mdx
@@ -34,7 +34,7 @@ import { useChatStore } from "@sna-sdk/react/stores/chat-store";
 `SnaChatUI` は application content を包み、built-in panel layout を管理します。
 
 ```tsx
-<SnaProvider snaUrl="http://localhost:3099">
+<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
   <SnaChatUI defaultOpen={false}>
     <App />
   </SnaChatUI>

--- a/apps/docs/content/docs/sdks/react-components.ja.mdx
+++ b/apps/docs/content/docs/sdks/react-components.ja.mdx
@@ -34,7 +34,7 @@ import { useChatStore } from "@sna-sdk/react/stores/chat-store";
 `SnaChatUI` は application content を包み、built-in panel layout を管理します。
 
 ```tsx
-<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
+<SnaProvider connection={sna.connection}>
   <SnaChatUI defaultOpen={false}>
     <App />
   </SnaChatUI>

--- a/apps/docs/content/docs/sdks/react-components.ko.mdx
+++ b/apps/docs/content/docs/sdks/react-components.ko.mdx
@@ -34,7 +34,7 @@ import { useChatStore } from "@sna-sdk/react/stores/chat-store";
 `SnaChatUI`는 application content를 감싸고 built-in panel layout을 관리합니다.
 
 ```tsx
-<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
+<SnaProvider connection={sna.connection}>
   <SnaChatUI defaultOpen={false}>
     <App />
   </SnaChatUI>

--- a/apps/docs/content/docs/sdks/react-components.ko.mdx
+++ b/apps/docs/content/docs/sdks/react-components.ko.mdx
@@ -34,7 +34,7 @@ import { useChatStore } from "@sna-sdk/react/stores/chat-store";
 `SnaChatUI`는 application content를 감싸고 built-in panel layout을 관리합니다.
 
 ```tsx
-<SnaProvider snaUrl="http://localhost:3099">
+<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
   <SnaChatUI defaultOpen={false}>
     <App />
   </SnaChatUI>

--- a/apps/docs/content/docs/sdks/react-components.mdx
+++ b/apps/docs/content/docs/sdks/react-components.mdx
@@ -33,7 +33,7 @@ import { useChatStore } from "@sna-sdk/react/stores/chat-store";
 `SnaChatUI` wraps the application content and manages the built-in panel layout.
 
 ```tsx
-<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
+<SnaProvider connection={sna.connection}>
   <SnaChatUI defaultOpen={false}>
     <App />
   </SnaChatUI>

--- a/apps/docs/content/docs/sdks/react-components.mdx
+++ b/apps/docs/content/docs/sdks/react-components.mdx
@@ -33,7 +33,7 @@ import { useChatStore } from "@sna-sdk/react/stores/chat-store";
 `SnaChatUI` wraps the application content and manages the built-in panel layout.
 
 ```tsx
-<SnaProvider snaUrl="http://localhost:3099">
+<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
   <SnaChatUI defaultOpen={false}>
     <App />
   </SnaChatUI>

--- a/apps/docs/content/docs/sdks/react-provider.ja.mdx
+++ b/apps/docs/content/docs/sdks/react-provider.ja.mdx
@@ -8,7 +8,7 @@ description: "SnaProvider、SnaSession、useSnaContext の props と返り値。
 ## `<SnaProvider>`
 
 ```tsx
-<SnaProvider snaUrl?: string authToken?: string sessionId?: string hydrate?: boolean>
+<SnaProvider connection?: SnaConnection snaUrl?: string authToken?: string sessionId?: string hydrate?: boolean>
   {children}
 </SnaProvider>
 ```
@@ -16,8 +16,9 @@ description: "SnaProvider、SnaSession、useSnaContext の props と返り値。
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `children` | `React.ReactNode` | required | SNA context を受け取る subtree です。 |
+| `connection` | `{ baseUrl: string; authToken?: string }` | none | SDK launcher が返す connection object です。Embedded SNA ではこれを優先します。 |
 | `snaUrl` | `string` | auto-discovery | SNA internal API server URL です。省略すると `/api/sna-port` を先に読み、失敗した場合は `http://localhost:3099` を使います。 |
-| `authToken` | `string` | none | SNA launcher が返す bearer token です。Protected server では必要です。 |
+| `authToken` | `string` | none | Custom deployment 用の token override です。SDK app では通常 `connection` を使います。 |
 | `sessionId` | `string` | `default` | descendants の default session ID です。 |
 | `hydrate` | `boolean` | `true` | mount 時に chat store が保存済み sessions と messages を取得するかを制御します。chat store を使わない app では `false` にできます。 |
 

--- a/apps/docs/content/docs/sdks/react-provider.ja.mdx
+++ b/apps/docs/content/docs/sdks/react-provider.ja.mdx
@@ -8,7 +8,7 @@ description: "SnaProvider、SnaSession、useSnaContext の props と返り値。
 ## `<SnaProvider>`
 
 ```tsx
-<SnaProvider snaUrl?: string sessionId?: string hydrate?: boolean>
+<SnaProvider snaUrl?: string authToken?: string sessionId?: string hydrate?: boolean>
   {children}
 </SnaProvider>
 ```
@@ -17,10 +17,11 @@ description: "SnaProvider、SnaSession、useSnaContext の props と返り値。
 | --- | --- | --- | --- |
 | `children` | `React.ReactNode` | required | SNA context を受け取る subtree です。 |
 | `snaUrl` | `string` | auto-discovery | SNA internal API server URL です。省略すると `/api/sna-port` を先に読み、失敗した場合は `http://localhost:3099` を使います。 |
+| `authToken` | `string` | none | SNA launcher が返す bearer token です。Protected server では必要です。 |
 | `sessionId` | `string` | `default` | descendants の default session ID です。 |
 | `hydrate` | `boolean` | `true` | mount 時に chat store が保存済み sessions と messages を取得するかを制御します。chat store を使わない app では `false` にできます。 |
 
-`SnaProvider` は UI を render しません。React context に `{ apiUrl, sessionId }` を提供し、必要に応じて `useChatStore` を hydrate します。
+`SnaProvider` は UI を render しません。React context に `{ apiUrl, authToken, sessionId }` を提供し、必要に応じて `useChatStore` を hydrate します。
 
 ## `<SnaSession>`
 
@@ -40,10 +41,11 @@ description: "SnaProvider、SnaSession、useSnaContext の props と返り値。
 ## `useSnaContext()`
 
 ```ts
-const context = useSnaContext(): { apiUrl: string; sessionId: string }
+const context = useSnaContext(): { apiUrl: string; authToken?: string; sessionId: string }
 ```
 
 | Field | Description |
 | --- | --- |
 | `apiUrl` | 現在の SNA server base URL です。 |
+| `authToken` | hooks と chat store が使う token です。 |
 | `sessionId` | 現在の subtree の active session ID です。 |

--- a/apps/docs/content/docs/sdks/react-provider.ko.mdx
+++ b/apps/docs/content/docs/sdks/react-provider.ko.mdx
@@ -10,7 +10,7 @@ description: "SnaProvider, SnaSession, useSnaContext의 props와 반환값."
 **Signature**
 
 ```tsx
-<SnaProvider snaUrl?: string sessionId?: string hydrate?: boolean>
+<SnaProvider snaUrl?: string authToken?: string sessionId?: string hydrate?: boolean>
   {children}
 </SnaProvider>
 ```
@@ -21,6 +21,7 @@ description: "SnaProvider, SnaSession, useSnaContext의 props와 반환값."
 | --- | --- | --- | --- |
 | `children` | `React.ReactNode` | required | SNA context를 받을 subtree입니다. |
 | `snaUrl` | `string` | auto-discovery | SNA internal API server URL입니다. 생략하면 `/api/sna-port`를 먼저 조회하고, 실패하면 `http://localhost:3099`를 사용합니다. |
+| `authToken` | `string` | none | SNA launcher가 반환한 bearer token입니다. Protected server에서는 필요합니다. |
 | `sessionId` | `string` | `default` | subtree의 기본 session ID입니다. |
 | `hydrate` | `boolean` | `true` | mount 시 chat store가 저장된 session/message를 가져올지 결정합니다. Chat store를 쓰지 않으면 `false`로 둘 수 있습니다. |
 
@@ -30,13 +31,13 @@ description: "SnaProvider, SnaSession, useSnaContext의 props와 반환값."
 import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 
 export function Root({ children }: { children: React.ReactNode }) {
-  return <SnaProvider snaUrl="http://localhost:3099">{children}</SnaProvider>;
+  return <SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>{children}</SnaProvider>;
 }
 ```
 
 **Output**
 
-`SnaProvider` 자체는 UI를 렌더링하지 않습니다. React context에 `{ apiUrl, sessionId }`를 넣고, 필요하면 `useChatStore`를 hydrate합니다.
+`SnaProvider` 자체는 UI를 렌더링하지 않습니다. React context에 `{ apiUrl, authToken, sessionId }`를 넣고, 필요하면 `useChatStore`를 hydrate합니다.
 
 ## `<SnaSession>`
 
@@ -74,7 +75,7 @@ export function Root({ children }: { children: React.ReactNode }) {
 **Signature**
 
 ```ts
-const context = useSnaContext(): { apiUrl: string; sessionId: string }
+const context = useSnaContext(): { apiUrl: string; authToken?: string; sessionId: string }
 ```
 
 **Returns**
@@ -82,6 +83,7 @@ const context = useSnaContext(): { apiUrl: string; sessionId: string }
 | Field | Description |
 | --- | --- |
 | `apiUrl` | 현재 SNA server base URL입니다. |
+| `authToken` | hook과 chat store가 사용할 token입니다. |
 | `sessionId` | 현재 subtree의 active session ID입니다. |
 
 **Example**

--- a/apps/docs/content/docs/sdks/react-provider.ko.mdx
+++ b/apps/docs/content/docs/sdks/react-provider.ko.mdx
@@ -10,7 +10,7 @@ description: "SnaProvider, SnaSession, useSnaContext의 props와 반환값."
 **Signature**
 
 ```tsx
-<SnaProvider snaUrl?: string authToken?: string sessionId?: string hydrate?: boolean>
+<SnaProvider connection?: SnaConnection snaUrl?: string authToken?: string sessionId?: string hydrate?: boolean>
   {children}
 </SnaProvider>
 ```
@@ -20,8 +20,9 @@ description: "SnaProvider, SnaSession, useSnaContext의 props와 반환값."
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `children` | `React.ReactNode` | required | SNA context를 받을 subtree입니다. |
+| `connection` | `{ baseUrl: string; authToken?: string }` | none | SDK launcher가 반환한 connection object입니다. Embedded SNA에서는 이 값을 우선 사용합니다. |
 | `snaUrl` | `string` | auto-discovery | SNA internal API server URL입니다. 생략하면 `/api/sna-port`를 먼저 조회하고, 실패하면 `http://localhost:3099`를 사용합니다. |
-| `authToken` | `string` | none | SNA launcher가 반환한 bearer token입니다. Protected server에서는 필요합니다. |
+| `authToken` | `string` | none | Custom deployment용 token override입니다. SDK 앱은 보통 `connection`을 사용합니다. |
 | `sessionId` | `string` | `default` | subtree의 기본 session ID입니다. |
 | `hydrate` | `boolean` | `true` | mount 시 chat store가 저장된 session/message를 가져올지 결정합니다. Chat store를 쓰지 않으면 `false`로 둘 수 있습니다. |
 
@@ -31,7 +32,7 @@ description: "SnaProvider, SnaSession, useSnaContext의 props와 반환값."
 import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 
 export function Root({ children }: { children: React.ReactNode }) {
-  return <SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>{children}</SnaProvider>;
+  return <SnaProvider connection={sna.connection}>{children}</SnaProvider>;
 }
 ```
 

--- a/apps/docs/content/docs/sdks/react-provider.mdx
+++ b/apps/docs/content/docs/sdks/react-provider.mdx
@@ -8,7 +8,7 @@ description: "Props and return values for SnaProvider, SnaSession, and useSnaCon
 ## `<SnaProvider>`
 
 ```tsx
-<SnaProvider snaUrl?: string sessionId?: string hydrate?: boolean>
+<SnaProvider snaUrl?: string authToken?: string sessionId?: string hydrate?: boolean>
   {children}
 </SnaProvider>
 ```
@@ -17,10 +17,11 @@ description: "Props and return values for SnaProvider, SnaSession, and useSnaCon
 | --- | --- | --- | --- |
 | `children` | `React.ReactNode` | required | Subtree that receives SNA context. |
 | `snaUrl` | `string` | auto-discovery | SNA internal API server URL. If omitted, it first reads `/api/sna-port`, then falls back to `http://localhost:3099`. |
+| `authToken` | `string` | none | Bearer token returned by the SNA launcher. Required for protected servers. |
 | `sessionId` | `string` | `default` | Default session ID for descendants. |
 | `hydrate` | `boolean` | `true` | Controls whether the chat store fetches persisted sessions and messages on mount. Set to `false` when the app does not use the chat store. |
 
-`SnaProvider` does not render UI. It provides `{ apiUrl, sessionId }` through React context and hydrates `useChatStore` when requested.
+`SnaProvider` does not render UI. It provides `{ apiUrl, authToken, sessionId }` through React context and hydrates `useChatStore` when requested.
 
 ## `<SnaSession>`
 
@@ -40,10 +41,11 @@ description: "Props and return values for SnaProvider, SnaSession, and useSnaCon
 ## `useSnaContext()`
 
 ```ts
-const context = useSnaContext(): { apiUrl: string; sessionId: string }
+const context = useSnaContext(): { apiUrl: string; authToken?: string; sessionId: string }
 ```
 
 | Field | Description |
 | --- | --- |
 | `apiUrl` | Current SNA server base URL. |
+| `authToken` | Token used by hooks and the chat store when present. |
 | `sessionId` | Active session ID for the current subtree. |

--- a/apps/docs/content/docs/sdks/react-provider.mdx
+++ b/apps/docs/content/docs/sdks/react-provider.mdx
@@ -8,7 +8,7 @@ description: "Props and return values for SnaProvider, SnaSession, and useSnaCon
 ## `<SnaProvider>`
 
 ```tsx
-<SnaProvider snaUrl?: string authToken?: string sessionId?: string hydrate?: boolean>
+<SnaProvider connection?: SnaConnection snaUrl?: string authToken?: string sessionId?: string hydrate?: boolean>
   {children}
 </SnaProvider>
 ```
@@ -16,8 +16,9 @@ description: "Props and return values for SnaProvider, SnaSession, and useSnaCon
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `children` | `React.ReactNode` | required | Subtree that receives SNA context. |
+| `connection` | `{ baseUrl: string; authToken?: string }` | none | Connection object returned by SDK launchers. Prefer this for embedded SNA. |
 | `snaUrl` | `string` | auto-discovery | SNA internal API server URL. If omitted, it first reads `/api/sna-port`, then falls back to `http://localhost:3099`. |
-| `authToken` | `string` | none | Bearer token returned by the SNA launcher. Required for protected servers. |
+| `authToken` | `string` | none | Token override for custom deployments. SDK apps usually use `connection`. |
 | `sessionId` | `string` | `default` | Default session ID for descendants. |
 | `hydrate` | `boolean` | `true` | Controls whether the chat store fetches persisted sessions and messages on mount. Set to `false` when the app does not use the chat store. |
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,8 +7,8 @@
     "dev": "next dev --port 8040",
     "docs:openapi": "tsx scripts/generate-openapi-docs.ts",
     "start": "next start",
-    "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
-    "postinstall": "fumadocs-mdx",
+    "types:check": "fumadocs-mdx source.config.ts .source && next typegen && tsc --noEmit",
+    "postinstall": "fumadocs-mdx source.config.ts .source",
     "lint": "eslint"
   },
   "dependencies": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,8 +7,8 @@
     "dev": "next dev --port 8040",
     "docs:openapi": "tsx scripts/generate-openapi-docs.ts",
     "start": "next start",
-    "types:check": "fumadocs-mdx source.config.ts .source && next typegen && tsc --noEmit",
-    "postinstall": "fumadocs-mdx source.config.ts .source",
+    "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
+    "postinstall": "fumadocs-mdx",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -11,10 +11,17 @@ npm install @sna-sdk/client
 ## Quick start
 
 ```ts
+import { startSnaServer } from "@sna-sdk/core/node";
 import { SnaClient } from "@sna-sdk/client";
 
+const handle = await startSnaServer({
+  appId: "my-app",
+  dbPath: "./data/sna.db",
+});
+
 const sna = new SnaClient({
-  baseUrl: "localhost:3099",
+  baseUrl: handle.baseUrl,
+  authToken: handle.authToken,
   ws: true,    // real-time push (subscriptions, snapshots, permission requests)
   http: true,  // ordering guarantees on state-changing ops
 });
@@ -45,6 +52,10 @@ await sna.agent.send(sessionId, "What's in this directory?");
 - WS endpoint: `ws://<baseUrl>/ws` (or `wss://` for HTTPS)
 - HTTP base:  `http://<baseUrl>` (or `https://`)
 
+Protected SNA servers require `authToken`. Launcher handles from
+`@sna-sdk/core/node` and `@sna-sdk/core/electron` return both `baseUrl`
+and `authToken`; pass them directly to the client.
+
 ### What HTTP guarantees (`http: true`)
 
 State-changing ops resolve only after the server has committed:
@@ -66,7 +77,7 @@ State-changing ops resolve only after the server has committed:
 ### Pure-WS mode
 
 ```ts
-new SnaClient({ baseUrl: "localhost:3099", ws: true, http: false });
+new SnaClient({ baseUrl: handle.baseUrl, authToken: handle.authToken, ws: true, http: false });
 ```
 
 Server ACKs immediately; async work may not be done when the Promise resolves. Use only for read-only or fire-and-forget flows.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -19,12 +19,7 @@ const handle = await startSnaServer({
   dbPath: "./data/sna.db",
 });
 
-const sna = new SnaClient({
-  baseUrl: handle.baseUrl,
-  authToken: handle.authToken,
-  ws: true,    // real-time push (subscriptions, snapshots, permission requests)
-  http: true,  // ordering guarantees on state-changing ops
-});
+const sna = new SnaClient(handle.connection);
 
 sna.sessions.onSnapshot((sessions) => updateSessionList(sessions));
 sna.connect();
@@ -52,9 +47,9 @@ await sna.agent.send(sessionId, "What's in this directory?");
 - WS endpoint: `ws://<baseUrl>/ws` (or `wss://` for HTTPS)
 - HTTP base:  `http://<baseUrl>` (or `https://`)
 
-Protected SNA servers require `authToken`. Launcher handles from
-`@sna-sdk/core/node` and `@sna-sdk/core/electron` return both `baseUrl`
-and `authToken`; pass them directly to the client.
+Protected SNA servers require a bearer token, but SDK launchers keep it paired
+with the server handle. Pass `handle.connection` to `SnaClient` instead of
+copying the token into app settings.
 
 ### What HTTP guarantees (`http: true`)
 
@@ -77,7 +72,7 @@ State-changing ops resolve only after the server has committed:
 ### Pure-WS mode
 
 ```ts
-new SnaClient({ baseUrl: handle.baseUrl, authToken: handle.authToken, ws: true, http: false });
+new SnaClient({ ...handle.connection, ws: true, http: false });
 ```
 
 Server ACKs immediately; async work may not be done when the Promise resolves. Use only for read-only or fire-and-forget flows.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,6 @@
 export { SnaClient } from "./sna-client.js";
 export type {
+  SnaClientConnection,
   SnaClientOptions,
   ConnectionStatus,
   SessionInfo,

--- a/packages/client/src/sna-client.spec.ts
+++ b/packages/client/src/sna-client.spec.ts
@@ -71,6 +71,17 @@ describe("connection lifecycle", () => {
     assert.deepEqual(statuses, ["connecting", "connected"]);
   });
 
+  it("adds authToken to the WebSocket URL", async () => {
+    sna = new SnaClient({ baseUrl: mock.host, authToken: "secret-token", ws: true, http: false, reconnect: false });
+
+    sna.connect();
+    await waitFor(() => sna.connected);
+
+    const url = new URL(mock.wsRequests[0], "ws://localhost");
+    assert.equal(url.pathname, "/ws");
+    assert.equal(url.searchParams.get("token"), "secret-token");
+  });
+
   it("disconnect fires status callback and closes socket", async () => {
     const statuses: string[] = [];
     sna = new SnaClient({ baseUrl: mock.host, ws: true, http: false, reconnect: false });
@@ -1056,6 +1067,15 @@ describe("HTTP transport (http: true)", () => {
     assert.equal(req.url, "/agent/sessions");
     assert.equal(req.body.label, "test");
     assert.equal(req.body.id, "s1");
+  });
+
+  it("sends authToken as a bearer token on HTTP requests", async () => {
+    mock.queueHttpResponse(200, { sessions: [] });
+    sna = new SnaClient({ baseUrl: mock.host, authToken: "secret-token", ws: false, http: true, reconnect: false });
+
+    await sna.sessions.list();
+
+    assert.equal(mock.httpRequests[0].headers.authorization, "Bearer secret-token");
   });
 
   it("sessions.create — no opts sends empty body", async () => {

--- a/packages/client/src/sna-client.spec.ts
+++ b/packages/client/src/sna-client.spec.ts
@@ -82,6 +82,18 @@ describe("connection lifecycle", () => {
     assert.equal(url.searchParams.get("token"), "secret-token");
   });
 
+  it("accepts launcher connection objects with default transports", async () => {
+    const connection = { baseUrl: mock.host, authToken: "secret-token" };
+    sna = new SnaClient({ ...connection, reconnect: false });
+
+    assert.equal(sna._httpUrl, `http://${mock.host}`);
+    sna.connect();
+    await waitFor(() => sna.connected);
+
+    const url = new URL(mock.wsRequests[0], "ws://localhost");
+    assert.equal(url.searchParams.get("token"), "secret-token");
+  });
+
   it("disconnect fires status callback and closes socket", async () => {
     const statuses: string[] = [];
     sna = new SnaClient({ baseUrl: mock.host, ws: true, http: false, reconnect: false });

--- a/packages/client/src/sna-client.ts
+++ b/packages/client/src/sna-client.ts
@@ -5,8 +5,8 @@
  *
  * ## Transport model
  *
- * Configure both transports explicitly via `ws` and `http` boolean flags.
- * Both URLs are derived from a single `baseUrl` — no need to specify them separately.
+ * Configure both transports with optional `ws` and `http` boolean flags.
+ * Both default to `true`, and both URLs are derived from a single `baseUrl`.
  *
  * | Transport | Used for | Enabled by |
  * |-----------|----------|------------|
@@ -52,12 +52,8 @@
  * ```ts
  * import { SnaClient } from "@sna-sdk/client";
  *
- * const sna = new SnaClient({
- *   baseUrl: "localhost:3099",
- *   authToken: process.env.SNA_AUTH_TOKEN,
- *   ws: true,
- *   http: true,
- * });
+ * const handle = await startSnaServer({ ... });
+ * const sna = new SnaClient(handle.connection);
  *
  * sna.sessions.onSnapshot((sessions) => setSessions(sessions));
  * sna.connect();
@@ -108,7 +104,7 @@ export type ConnectionStatus = "connecting" | "connected" | "disconnected";
 /**
  * Options for creating an {@link SnaClient} instance.
  */
-export interface SnaClientOptions {
+export interface SnaClientConnection {
   /**
    * Base URL of the SNA server.
    *
@@ -130,6 +126,12 @@ export interface SnaClientOptions {
    * WebSocket clients cannot set arbitrary headers.
    */
   authToken?: string;
+}
+
+/**
+ * Options for creating an {@link SnaClient} instance.
+ */
+export interface SnaClientOptions extends SnaClientConnection {
 
   /**
    * Enable WebSocket transport.
@@ -141,7 +143,7 @@ export interface SnaClientOptions {
    * When `false`, all WS-dependent operations will reject with an error.
    * Use `false` only when building an HTTP-only integration.
    */
-  ws: boolean;
+  ws?: boolean;
 
   /**
    * Enable REST (HTTP) transport.
@@ -154,7 +156,7 @@ export interface SnaClientOptions {
    * When `false`, all operations fall back to WebSocket (the server ACKs
    * immediately without waiting for async work to complete).
    */
-  http: boolean;
+  http?: boolean;
 
   /**
    * Whether to automatically reconnect when the WebSocket connection drops.
@@ -220,13 +222,15 @@ function resolveTransports(options: SnaClientOptions): ResolvedTransports {
   if (!/^https?:\/\//i.test(base)) {
     base = "http://" + base;
   }
-  const baseWsUrl = options.ws
+  const wsEnabled = options.ws ?? true;
+  const httpEnabled = options.http ?? true;
+  const baseWsUrl = wsEnabled
     ? base.replace(/^https:\/\//i, "wss://").replace(/^http:\/\//i, "ws://") + "/ws"
     : null;
   const wsUrl = baseWsUrl && authToken
     ? withQueryParam(baseWsUrl, "token", authToken)
     : baseWsUrl;
-  const httpBase = options.http ? base : null;
+  const httpBase = httpEnabled ? base : null;
 
   if (!wsUrl && !httpBase) {
     console.warn("[SnaClient] Both ws and http are false — no transport is available.");
@@ -246,15 +250,15 @@ function withQueryParam(url: string, key: string, value: string): string {
 /**
  * Dual-transport client for the SNA API server.
  *
- * Provide a single `baseUrl` and explicit `ws`/`http` flags.
- * The client derives the WS and HTTP endpoints automatically.
+ * Provide a launcher connection object, or a single `baseUrl` plus optional
+ * `ws`/`http` flags. The client derives the WS and HTTP endpoints automatically.
  *
  * @example
  * ```ts
  * const sna = new SnaClient({
  *   baseUrl: "localhost:3099",
- *   ws: true,   // real-time push, event streaming
- *   http: true, // ordering-guaranteed state changes
+ *   ws: true,   // optional, defaults true
+ *   http: true, // optional, defaults true
  * });
  * sna.connect();
  *

--- a/packages/client/src/sna-client.ts
+++ b/packages/client/src/sna-client.ts
@@ -54,6 +54,7 @@
  *
  * const sna = new SnaClient({
  *   baseUrl: "localhost:3099",
+ *   authToken: process.env.SNA_AUTH_TOKEN,
  *   ws: true,
  *   http: true,
  * });
@@ -120,6 +121,15 @@ export interface SnaClientOptions {
    * @example "https://my-server.com"
    */
   baseUrl: string;
+
+  /**
+   * Shared token issued by the local SNA server.
+   *
+   * HTTP requests send it as `Authorization: Bearer <token>`. WebSocket
+   * connections include it in the `/ws?token=...` URL because browser
+   * WebSocket clients cannot set arbitrary headers.
+   */
+  authToken?: string;
 
   /**
    * Enable WebSocket transport.
@@ -206,12 +216,16 @@ interface ResolvedTransports {
  */
 function resolveTransports(options: SnaClientOptions): ResolvedTransports {
   let base = options.baseUrl.trim().replace(/\/$/, "");
+  const authToken = options.authToken?.trim();
   if (!/^https?:\/\//i.test(base)) {
     base = "http://" + base;
   }
-  const wsUrl = options.ws
+  const baseWsUrl = options.ws
     ? base.replace(/^https:\/\//i, "wss://").replace(/^http:\/\//i, "ws://") + "/ws"
     : null;
+  const wsUrl = baseWsUrl && authToken
+    ? withQueryParam(baseWsUrl, "token", authToken)
+    : baseWsUrl;
   const httpBase = options.http ? base : null;
 
   if (!wsUrl && !httpBase) {
@@ -219,6 +233,12 @@ function resolveTransports(options: SnaClientOptions): ResolvedTransports {
   }
 
   return { wsUrl, httpBase };
+}
+
+function withQueryParam(url: string, key: string, value: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set(key, value);
+  return parsed.toString();
 }
 
 // ── Client ────────────────────────────────────────────────────────
@@ -254,6 +274,7 @@ export class SnaClient {
   private disposed = false;
 
   private readonly wsUrl: string | null;
+  private readonly authToken: string | undefined;
   private readonly _reconnect: boolean;
   private readonly reconnectDelay: number;
   private readonly maxReconnectAttempts: number;
@@ -295,6 +316,7 @@ export class SnaClient {
     const { wsUrl, httpBase } = resolveTransports(options);
     this.wsUrl = wsUrl;
     this._httpUrl = httpBase ?? undefined;
+    this.authToken = options.authToken?.trim() || undefined;
     this._reconnect = options.reconnect ?? true;
     this.reconnectDelay = options.reconnectDelay ?? 2000;
     this.maxReconnectAttempts = options.maxReconnectAttempts ?? 0;
@@ -497,12 +519,21 @@ export class SnaClient {
     const hasBody = body !== undefined && method !== "GET" && method !== "DELETE";
     const res = await fetch(base + path, {
       method,
-      headers: hasBody ? { "Content-Type": "application/json" } : undefined,
+      headers: this._authHeaders(hasBody ? { "Content-Type": "application/json" } : {}),
       body: hasBody ? JSON.stringify(body) : undefined,
     });
     const data = await res.json() as Record<string, unknown>;
     if (!res.ok) throw new Error((data.message as string) ?? `HTTP ${res.status}`);
     return data as T;
+  }
+
+  /** @internal */
+  _authHeaders(headers: Record<string, string> = {}): Record<string, string> | undefined {
+    const next = { ...headers };
+    if (this.authToken) {
+      next.Authorization = `Bearer ${this.authToken}`;
+    }
+    return Object.keys(next).length > 0 ? next : undefined;
   }
 
   /**
@@ -1507,7 +1538,7 @@ class AgentApi {
     const base = this.client._httpUrl.replace(/\/$/, "");
     const res = await fetch(`${base}/agent/run-once/stream`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "text/event-stream" },
+      headers: this.client._authHeaders({ "Content-Type": "application/json", Accept: "text/event-stream" }),
       body: JSON.stringify(opts),
     });
     if (!res.ok) {
@@ -1569,7 +1600,9 @@ class AgentApi {
     const base = this.client._httpUrl.replace(/\/$/, "");
     const params = new URLSearchParams({ session });
     if (since !== undefined) params.set("since", String(since));
-    const res = await fetch(`${base}/agent/events?${params}`);
+    const res = await fetch(`${base}/agent/events?${params}`, {
+      headers: this.client._authHeaders(),
+    });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     yield* SnaClient._parseSse(res);
   }

--- a/packages/client/src/test-helpers.ts
+++ b/packages/client/src/test-helpers.ts
@@ -13,6 +13,7 @@ if (!globalThis.WebSocket) {
 export interface HttpRequest {
   method: string;
   url: string;
+  headers: http.IncomingHttpHeaders;
   body: Record<string, unknown>;
 }
 
@@ -28,6 +29,8 @@ export interface MockServer {
   clients: Set<WsType>;
   /** Last connected client (convenience) */
   lastClient: () => WsType;
+  /** URLs used by accepted WebSocket upgrades */
+  wsRequests: string[];
   /** Send a JSON message to all connected clients */
   broadcast: (data: Record<string, unknown>) => void;
   /** Send a JSON message to the last connected client */
@@ -51,6 +54,7 @@ export interface MockServer {
 export function startMockWsServer(): Promise<MockServer> {
   return new Promise((resolve) => {
     const httpRequests: HttpRequest[] = [];
+    const wsRequests: string[] = [];
     const httpResponseQueue: Array<{ status: number; body: Record<string, unknown> }> = [];
 
     const server = http.createServer((req, res) => {
@@ -67,6 +71,7 @@ export function startMockWsServer(): Promise<MockServer> {
         httpRequests.push({
           method: req.method ?? "GET",
           url: req.url ?? "/",
+          headers: req.headers,
           body,
         });
 
@@ -83,7 +88,8 @@ export function startMockWsServer(): Promise<MockServer> {
     const clients = new Set<WsType>();
     const messageHandlers: Array<(ws: WsType, msg: Record<string, unknown>) => void> = [];
 
-    wss.on("connection", (ws) => {
+    wss.on("connection", (ws, req) => {
+      wsRequests.push(req.url ?? "");
       clients.add(ws);
       ws.on("close", () => clients.delete(ws));
       ws.on("message", (raw) => {
@@ -103,6 +109,7 @@ export function startMockWsServer(): Promise<MockServer> {
         wss,
         server,
         clients,
+        wsRequests,
         httpRequests,
         queueHttpResponse: (status, body) => { httpResponseQueue.push({ status, body }); },
         clearHttpRequests: () => { httpRequests.length = 0; },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -35,6 +35,7 @@ Peer dependencies: `better-sqlite3` (required), `langfuse` (optional, for tracin
 import { startSnaServer } from "@sna-sdk/core/node";
 
 const sna = await startSnaServer({
+  appId: "my-app",
   port: 3099,
   dbPath: "./data/sna.db",
   maxSessions: 20,
@@ -44,18 +45,26 @@ const sna = await startSnaServer({
 });
 ```
 
+Launchers bind to `127.0.0.1` by default, generate a per-server
+`authToken`, and tag sessions with `appId`. Pass `sna.baseUrl` and
+`sna.authToken` to `SnaClient` or `SnaProvider`. Browser renderer origins
+are rejected unless they are listed in `allowedOrigins`. Direct standalone
+server launches are for development/debugging and must provide
+`SNA_AUTH_TOKEN` explicitly.
+
 For Electron, use `@sna-sdk/core/electron` and add `asarUnpack: ["node_modules/@sna-sdk/core/**"]`.
 
 ### Mount the routes manually
 
 ```ts
-import { createSnaApp, attachWebSocket, SessionManager } from "@sna-sdk/core/server";
+import { createSnaApp, attachWebSocket, generateSnaAuthToken, SessionManager } from "@sna-sdk/core/server";
 import { serve } from "@hono/node-server";
 
 const sessionManager = new SessionManager({ maxSessions: 10 });
-const app = createSnaApp({ sessionManager });
-const server = serve({ fetch: app.fetch, port: 3099 });
-attachWebSocket(server, sessionManager);
+const authToken = generateSnaAuthToken();
+const app = await createSnaApp({ sessionManager, authToken });
+const server = serve({ fetch: app.fetch, port: 3099, hostname: "127.0.0.1" });
+attachWebSocket(server, sessionManager, { authToken });
 ```
 
 ### One-shot completion
@@ -161,7 +170,7 @@ const db = getDb();
 | Import path | Contents |
 |-------------|----------|
 | `@sna-sdk/core` | Default port/url, types (`AgentEvent`, `Session`, `SessionInfo`, `ChatSession`, `ChatMessage`, `CanonicalBlock`, `EmbedRecord`, …), `completion`, config helpers |
-| `@sna-sdk/core/server` | `createSnaApp`, `attachWebSocket`, `SessionManager`, `snaPortRoute`, `buildCanonicalFromDb`, `completion`, `runOnce`, related types |
+| `@sna-sdk/core/server` | `createSnaApp`, `attachWebSocket`, `generateSnaAuthToken`, `SessionManager`, `snaPortRoute`, `buildCanonicalFromDb`, `completion`, `runOnce`, related types |
 | `@sna-sdk/core/db/schema` | `getDb`, `resetDb`, schema types (`ChatSession`, `ChatMessage`, `ChatActor`, `ChatKind`) |
 | `@sna-sdk/core/providers` | `getProvider`, `registerProvider`, `getRuntimePool`, `ClaudeCodeProvider`, `CodexProvider`, `OpenCodeProvider`, `RuntimePool`, schemas (`SpawnOptionsSchema`, `RuntimeConfigSchema`, `RuntimeHandleSchema`) |
 | `@sna-sdk/core/electron` | `startSnaServer` (Electron-aware launcher) |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,11 +46,11 @@ const sna = await startSnaServer({
 ```
 
 Launchers bind to `127.0.0.1` by default, generate a per-server
-`authToken`, and tag sessions with `appId`. Pass `sna.baseUrl` and
-`sna.authToken` to `SnaClient` or `SnaProvider`. Browser renderer origins
-are rejected unless they are listed in `allowedOrigins`. Direct standalone
-server launches are for development/debugging and must provide
-`SNA_AUTH_TOKEN` explicitly.
+`authToken`, and tag sessions with `appId`. Use the returned
+`sna.connection` object with `SnaClient` or `SnaProvider` so consumers do not
+handle the token separately. Browser renderer origins are rejected unless they
+are listed in `allowedOrigins`. Direct standalone server launches are for
+development/debugging and must provide `SNA_AUTH_TOKEN` explicitly.
 
 For Electron, use `@sna-sdk/core/electron` and add `asarUnpack: ["node_modules/@sna-sdk/core/**"]`.
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,8 +15,20 @@ import path from "path";
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export interface SnaConfig {
+  /** Application owner ID for this SNA server instance. env: SNA_APP_ID */
+  appId?: string;
+
   /** SNA API server port. env: SNA_PORT */
   port: number;
+
+  /** SNA API bind host. env: SNA_HOST */
+  host: string;
+
+  /** Bearer token required for protected HTTP and WebSocket routes. env: SNA_AUTH_TOKEN */
+  authToken?: string;
+
+  /** Browser origins allowed to call the SNA API. env: SNA_ALLOWED_ORIGINS */
+  allowedOrigins: string[];
 
   /** Default LLM model. env: SNA_MODEL */
   model: string;
@@ -80,6 +92,8 @@ export interface SnaConfig {
 
 const defaults: SnaConfig = {
   port: 3099,
+  host: "127.0.0.1",
+  allowedOrigins: [],
   model: "claude-sonnet-4-6",
   defaultProvider: "claude-code",
   defaultPermissionMode: "default",
@@ -98,7 +112,13 @@ const defaults: SnaConfig = {
 
 function fromEnv(): Partial<SnaConfig> {
   const env: Partial<SnaConfig> = {};
+  if (process.env.SNA_APP_ID) env.appId = process.env.SNA_APP_ID;
   if (process.env.SNA_PORT) env.port = parseInt(process.env.SNA_PORT, 10);
+  if (process.env.SNA_HOST) env.host = process.env.SNA_HOST;
+  if (process.env.SNA_AUTH_TOKEN) env.authToken = process.env.SNA_AUTH_TOKEN;
+  if (process.env.SNA_ALLOWED_ORIGINS) {
+    env.allowedOrigins = process.env.SNA_ALLOWED_ORIGINS.split(",").map((origin) => origin.trim()).filter(Boolean);
+  }
   if (process.env.SNA_MODEL) env.model = process.env.SNA_MODEL;
   if (process.env.SNA_PERMISSION_MODE) env.defaultPermissionMode = process.env.SNA_PERMISSION_MODE as SnaConfig["defaultPermissionMode"];
   if (process.env.SNA_MAX_SESSIONS) env.maxSessions = parseInt(process.env.SNA_MAX_SESSIONS, 10);
@@ -127,4 +147,22 @@ export function setConfig(overrides: Partial<SnaConfig>): void {
 /** Reset to defaults + env. Useful for testing. */
 export function resetConfig(): void {
   current = { ...defaults, ...fromEnv() };
+}
+
+/** Return metadata tagged with the configured app owner, when one exists. */
+export function withConfiguredAppId(
+  meta: Record<string, unknown> | null | undefined,
+  options: { includeWhenMissing?: boolean } = {},
+): Record<string, unknown> | null | undefined {
+  const appId = current.appId?.trim();
+  if (!appId) return meta;
+  if (meta === undefined && !options.includeWhenMissing) return undefined;
+
+  const base = meta && typeof meta === "object" && !Array.isArray(meta) ? meta : {};
+  return { ...base, appId };
+}
+
+/** Metadata for newly created sessions owned by the configured app. */
+export function configuredAppMeta(): Record<string, unknown> | undefined {
+  return withConfiguredAppId(undefined, { includeWhenMissing: true }) as Record<string, unknown> | undefined;
 }

--- a/packages/core/src/electron/index.ts
+++ b/packages/core/src/electron/index.ts
@@ -205,7 +205,15 @@ export interface RuntimePaths {
   cursor?: string;
 }
 
-export interface SnaServerHandle {
+export interface SnaServerConnection {
+  /** Base HTTP URL for this server. */
+  baseUrl: string;
+
+  /** Bearer token required for protected routes. */
+  authToken: string;
+}
+
+export interface SnaServerHandle extends SnaServerConnection {
   /** The forked child process. */
   process: ChildProcess;
 
@@ -218,11 +226,8 @@ export interface SnaServerHandle {
   /** Application owner ID associated with this server process. */
   appId: string;
 
-  /** Base HTTP URL for this server. */
-  baseUrl: string;
-
-  /** Bearer token required for protected routes. */
-  authToken: string;
+  /** Portable client connection object for SnaClient/SnaProvider. */
+  connection: SnaServerConnection;
 
   /** Send SIGTERM to the server process for graceful shutdown. */
   stop(): void;
@@ -408,13 +413,16 @@ export async function startSnaServer(options: SnaServerOptions): Promise<SnaServ
     });
   });
 
+  const connection = { baseUrl: `http://${host}:${port}`, authToken };
+
   return {
     process: proc,
     port,
     host,
     appId,
-    baseUrl: `http://${host}:${port}`,
+    baseUrl: connection.baseUrl,
     authToken,
+    connection,
     stop() {
       proc.kill("SIGTERM");
     },
@@ -423,7 +431,7 @@ export async function startSnaServer(options: SnaServerOptions): Promise<SnaServ
 
 // ── In-process mode ──────────────────────────────────────────────────────────
 
-export interface InProcessSnaServerHandle {
+export interface InProcessSnaServerHandle extends SnaServerConnection {
   /** No child process — the server runs in the calling process. */
   process: null;
 
@@ -436,11 +444,8 @@ export interface InProcessSnaServerHandle {
   /** Application owner ID associated with this server instance. */
   appId: string;
 
-  /** Base HTTP URL for this server. */
-  baseUrl: string;
-
-  /** Bearer token required for protected routes. */
-  authToken: string;
+  /** Portable client connection object for SnaClient/SnaProvider. */
+  connection: SnaServerConnection;
 
   /** The session manager instance. */
   sessionManager: SessionManager;
@@ -602,13 +607,16 @@ export async function startSnaServerInProcess(
     }
   }
 
+  const connection = { baseUrl: `http://${host}:${port}`, authToken };
+
   return {
     process: null,
     port,
     host,
     appId,
-    baseUrl: `http://${host}:${port}`,
+    baseUrl: connection.baseUrl,
     authToken,
+    connection,
     sessionManager,
     httpServer,
     async initLangfuse(config) {

--- a/packages/core/src/electron/index.ts
+++ b/packages/core/src/electron/index.ts
@@ -52,11 +52,11 @@ import path from "path";
 
 // In-process mode imports
 import { Hono } from "hono";
-import { cors } from "hono/cors";
 import { serve } from "@hono/node-server";
 import { createSnaApp } from "../server/index.js";
 import { SessionManager } from "../server/session-manager.js";
 import { attachWebSocket } from "../server/ws.js";
+import { generateSnaAuthToken } from "../server/security.js";
 import { setConfig, getConfig } from "../config.js";
 import { getDb } from "../db/schema.js";
 import { logger as snaLogger, type LogLevel } from "../lib/logger.js";
@@ -66,6 +66,27 @@ import { logger as snaLogger, type LogLevel } from "../lib/logger.js";
 export interface SnaServerOptions {
   /** Port for the SNA API server. Default: 3099 */
   port?: number;
+
+  /** Hostname to bind. Default: 127.0.0.1 */
+  host?: string;
+
+  /**
+   * Application owner ID for this SNA server instance.
+   * Defaults to "sna-sdk" when launched through the SDK.
+   */
+  appId?: string;
+
+  /**
+   * Bearer token required for protected HTTP and WebSocket routes.
+   * When omitted, launchers generate one and return it on the handle.
+   */
+  authToken?: string;
+
+  /**
+   * Browser origins allowed to call SNA. Native clients that do not send
+   * Origin are allowed, but browser requests must match this list.
+   */
+  allowedOrigins?: string[];
 
   /** Absolute path to the SQLite database file. Required. */
   dbPath: string;
@@ -191,6 +212,18 @@ export interface SnaServerHandle {
   /** The port the server is listening on. */
   port: number;
 
+  /** The host the server is bound to. */
+  host: string;
+
+  /** Application owner ID associated with this server process. */
+  appId: string;
+
+  /** Base HTTP URL for this server. */
+  baseUrl: string;
+
+  /** Bearer token required for protected routes. */
+  authToken: string;
+
   /** Send SIGTERM to the server process for graceful shutdown. */
   stop(): void;
 }
@@ -275,6 +308,10 @@ function applyProcessEnv(env: Record<string, string>): void {
  */
 export async function startSnaServer(options: SnaServerOptions): Promise<SnaServerHandle> {
   const port = options.port ?? 3099;
+  const host = options.host ?? "127.0.0.1";
+  const appId = options.appId ?? "sna-sdk";
+  const authToken = options.authToken ?? generateSnaAuthToken();
+  const allowedOrigins = options.allowedOrigins ?? [];
   const cwd = options.cwd ?? path.dirname(options.dbPath);
   const readyTimeout = options.readyTimeout ?? 15_000;
   const { onLog } = options;
@@ -293,7 +330,16 @@ export async function startSnaServer(options: SnaServerOptions): Promise<SnaServ
   const runtimeEnv = runtimePathsToEnv(options.runtimePaths);
   const env: Record<string, string> = {
     ...(process.env as Record<string, string>),
+    ...runtimeEnv,
+    // Consumer env remains the escape hatch for runtime CLI variables and
+    // provider-specific settings. Launcher-owned security and process identity
+    // values are written below so the returned handle always matches the child.
+    ...(options.env ?? {}),
     SNA_PORT: String(port),
+    SNA_HOST: host,
+    SNA_APP_ID: appId,
+    SNA_AUTH_TOKEN: authToken,
+    SNA_ALLOWED_ORIGINS: allowedOrigins.join(","),
     SNA_DB_PATH: options.dbPath,
     ...(options.maxSessions != null ? { SNA_MAX_SESSIONS: String(options.maxSessions) } : {}),
     ...(options.permissionMode ? { SNA_PERMISSION_MODE: options.permissionMode } : {}),
@@ -303,9 +349,6 @@ export async function startSnaServer(options: SnaServerOptions): Promise<SnaServ
     ...(options.nativeBinding ? { SNA_SQLITE_NATIVE_BINDING: options.nativeBinding } : {}),
     ...(consumerModules ? { SNA_MODULES_PATH: consumerModules } : {}),
     ...(nodePath ? { NODE_PATH: nodePath } : {}),
-    ...runtimeEnv,
-    // Consumer overrides last so they can always win
-    ...(options.env ?? {}),
   };
 
   const proc = fork(standaloneScript, [], {
@@ -368,6 +411,10 @@ export async function startSnaServer(options: SnaServerOptions): Promise<SnaServ
   return {
     process: proc,
     port,
+    host,
+    appId,
+    baseUrl: `http://${host}:${port}`,
+    authToken,
     stop() {
       proc.kill("SIGTERM");
     },
@@ -382,6 +429,18 @@ export interface InProcessSnaServerHandle {
 
   /** The port the server is listening on. */
   port: number;
+
+  /** The host the server is bound to. */
+  host: string;
+
+  /** Application owner ID associated with this server instance. */
+  appId: string;
+
+  /** Base HTTP URL for this server. */
+  baseUrl: string;
+
+  /** Bearer token required for protected routes. */
+  authToken: string;
 
   /** The session manager instance. */
   sessionManager: SessionManager;
@@ -418,6 +477,10 @@ export async function startSnaServerInProcess(
   options: SnaServerOptions,
 ): Promise<InProcessSnaServerHandle> {
   const port = options.port ?? 3099;
+  const host = options.host ?? "127.0.0.1";
+  const appId = options.appId ?? "sna-sdk";
+  const authToken = options.authToken ?? generateSnaAuthToken();
+  const allowedOrigins = options.allowedOrigins ?? [];
   const cwd = options.cwd ?? path.dirname(options.dbPath);
 
   // Route ALL SNA SDK logger output through the consumer's onLog callback.
@@ -438,7 +501,11 @@ export async function startSnaServerInProcess(
 
   // Configure SNA SDK before any module reads config
   setConfig({
+    appId,
     port,
+    host,
+    authToken,
+    allowedOrigins,
     dbPath: options.dbPath,
     ...(options.dataDir ? { dataDir: options.dataDir } : {}),
     ...(options.maxSessions != null ? { maxSessions: options.maxSessions } : {}),
@@ -449,6 +516,10 @@ export async function startSnaServerInProcess(
 
   // Also set env vars so any module reading process.env directly works
   process.env.SNA_PORT = String(port);
+  process.env.SNA_HOST = host;
+  process.env.SNA_APP_ID = appId;
+  process.env.SNA_AUTH_TOKEN = authToken;
+  process.env.SNA_ALLOWED_ORIGINS = allowedOrigins.join(",");
   process.env.SNA_DB_PATH = options.dbPath;
   if (options.maxSessions != null) process.env.SNA_MAX_SESSIONS = String(options.maxSessions);
   if (options.permissionMode) process.env.SNA_PERMISSION_MODE = options.permissionMode;
@@ -490,8 +561,6 @@ export async function startSnaServerInProcess(
   const config = getConfig();
 
   const root = new Hono();
-  root.use("*", cors({ origin: "*", allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"] }));
-
   // Global error handler
   root.onError((err, c) => {
     const pathname = new URL(c.req.url).pathname;
@@ -510,17 +579,17 @@ export async function startSnaServerInProcess(
   // Create session manager (no default agent spawn)
   const sessionManager = new SessionManager({ maxSessions: config.maxSessions });
 
-  const snaApp = await createSnaApp({ sessionManager });
+  const snaApp = await createSnaApp({ sessionManager, authToken, allowedOrigins });
   root.route("/", snaApp);
 
   // Start HTTP server
-  const httpServer = serve({ fetch: root.fetch, port }, () => {
-    snaLogger.log("sna", `API server ready → http://localhost:${port}`);
-    snaLogger.log("sna", `WebSocket endpoint → ws://localhost:${port}/ws`);
+  const httpServer = serve({ fetch: root.fetch, port, hostname: host }, () => {
+    snaLogger.log("sna", `API server ready → http://${host}:${port}`);
+    snaLogger.log("sna", `WebSocket endpoint → ws://${host}:${port}/ws`);
   }) as unknown as http.Server;
 
   // Attach WebSocket on the same HTTP server
-  attachWebSocket(httpServer, sessionManager);
+  attachWebSocket(httpServer, sessionManager, { authToken, allowedOrigins });
 
   // Initialize Langfuse tracer if configured
   if (options.langfuse) {
@@ -536,6 +605,10 @@ export async function startSnaServerInProcess(
   return {
     process: null,
     port,
+    host,
+    appId,
+    baseUrl: `http://${host}:${port}`,
+    authToken,
     sessionManager,
     httpServer,
     async initLangfuse(config) {

--- a/packages/core/src/node/index.ts
+++ b/packages/core/src/node/index.ts
@@ -40,6 +40,7 @@ export {
 } from "../electron/index.js";
 export type {
   SnaServerOptions,
+  SnaServerConnection,
   SnaServerHandle,
   RuntimePaths,
   ResolveResult,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -15,8 +15,9 @@
  */
 
 import { SessionManager } from "./session-manager.js";
+import type { SnaSecurityOptions } from "./security.js";
 
-export interface SnaAppOptions {
+export interface SnaAppOptions extends SnaSecurityOptions {
   /** Session manager for multi-session support. Auto-created if omitted. */
   sessionManager?: SessionManager;
 }
@@ -41,6 +42,8 @@ export type {
   AgentStatus,
 } from "./session-manager.js";
 export { attachWebSocket } from "./ws.js";
+export { generateSnaAuthToken } from "./security.js";
+export type { SnaSecurityOptions } from "./security.js";
 export { buildCanonicalFromDb } from "../history/canonical.js";
 export { completion } from "../core/completion.js";
 export type { CompletionOptions, CompletionResult } from "../core/completion.js";

--- a/packages/core/src/server/routes/openapi.ts
+++ b/packages/core/src/server/routes/openapi.ts
@@ -25,11 +25,12 @@ import { saveEmbeds } from "../image-store.js";
 import { insertChatMessage } from "../../db/chat-messages.js";
 import { formatEmbedRef } from "../../history/embed-refs.js";
 import type { EmbedRecord } from "../../history/types.js";
-import { getConfig } from "../../config.js";
+import { configuredAppMeta, getConfig, withConfiguredAppId } from "../../config.js";
 import { completion, type CompletionOptions } from "../../core/completion.js";
 import type { ContentBlock } from "../../core/providers/types.js";
 import { resolveImagePath } from "../image-store.js";
 import { runOnce, type RunOnceOptions } from "../run-once.js";
+import { createHttpSecurityMiddleware, type SnaSecurityOptions } from "../security.js";
 
 // Resolve our own version from package.json so the OpenAPI document
 // reports whatever ships in @sna-sdk/core, not a hard-coded string that
@@ -1080,8 +1081,9 @@ function getSessionId(c: { req: { query: (k: string) => string | undefined } }):
   return c.req.query("session") ?? "default";
 }
 
-export async function createOpenApiApp(options?: { sessionManager?: SessionManager }) {
+export async function createOpenApiApp(options?: { sessionManager?: SessionManager } & SnaSecurityOptions) {
   const app = new OpenAPIHono();
+  app.use("*", createHttpSecurityMiddleware(options ?? {}));
 
   const openApiInfo = {
     openapi: "3.1.0" as const,
@@ -1135,7 +1137,7 @@ export async function createOpenApiApp(options?: { sessionManager?: SessionManag
         id: body.id,
         label: body.label,
         cwd: body.cwd,
-        meta: body.meta,
+        meta: withConfiguredAppId(body.meta, { includeWhenMissing: true }),
       });
       logger.log("route", `POST /sessions → created "${session.id}"`);
       return c.json({ status: "created", sessionId: session.id, label: session.label, meta: session.meta }, 200);
@@ -1172,7 +1174,11 @@ export async function createOpenApiApp(options?: { sessionManager?: SessionManag
     const { id } = c.req.valid("param");
     const body = c.req.valid("json");
     try {
-      sessionManager.updateSession(id, { label: body.label, meta: body.meta, cwd: body.cwd });
+      sessionManager.updateSession(id, {
+        label: body.label,
+        meta: body.meta !== undefined ? withConfiguredAppId(body.meta) as Record<string, unknown> : undefined,
+        cwd: body.cwd,
+      });
       logger.log("route", `PATCH /sessions/${id} → updated`);
       return c.json({ status: "updated", session: id }, 200);
     } catch (e: any) {
@@ -1188,7 +1194,7 @@ export async function createOpenApiApp(options?: { sessionManager?: SessionManag
     const sessionId = getSessionId(c);
     const body = c.req.valid("json");
 
-    const session = sessionManager.getOrCreateSession(sessionId, { cwd: body.cwd });
+    const session = sessionManager.getOrCreateSession(sessionId, { cwd: body.cwd, meta: configuredAppMeta() });
 
     if (session.process?.alive && !body.force) {
       logger.log("route", `POST /start?session=${sessionId} → already_running`);
@@ -1858,10 +1864,11 @@ export async function createOpenApiApp(options?: { sessionManager?: SessionManag
     const sessionType = body.type ?? body.chatType ?? "background";
     try {
       const db = getDb();
+      const meta = withConfiguredAppId(body.meta, { includeWhenMissing: true });
       db.prepare(
         `INSERT OR IGNORE INTO chat_sessions (id, label, type, meta) VALUES (?, ?, ?, ?)`
-      ).run(id, body.label ?? id, sessionType, body.meta ? JSON.stringify(body.meta) : null);
-      return c.json({ status: "created", id, meta: body.meta ?? null }, 200);
+      ).run(id, body.label ?? id, sessionType, meta ? JSON.stringify(meta) : null);
+      return c.json({ status: "created", id, meta: meta ?? null }, 200);
     } catch (e: any) {
       return c.json({ status: "error", message: e.message }, 500);
     }

--- a/packages/core/src/server/security.ts
+++ b/packages/core/src/server/security.ts
@@ -1,0 +1,123 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+export interface SnaSecurityOptions {
+  authToken?: string;
+  allowedOrigins?: string[];
+  unsafeDisableAuth?: boolean;
+}
+
+export interface ResolvedSnaSecurityOptions {
+  authToken?: string;
+  allowedOrigins: string[];
+  unsafeDisableAuth: boolean;
+}
+
+export function generateSnaAuthToken(): string {
+  return `sna_${randomBytes(32).toString("base64url")}`;
+}
+
+export function parseAllowedOrigins(value?: string): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+export function resolveSnaSecurityOptions(options: SnaSecurityOptions = {}): ResolvedSnaSecurityOptions {
+  const unsafeDisableAuth = options.unsafeDisableAuth === true;
+  const authToken = options.authToken?.trim() || process.env.SNA_AUTH_TOKEN?.trim();
+  const allowedOrigins = options.allowedOrigins ?? parseAllowedOrigins(process.env.SNA_ALLOWED_ORIGINS);
+
+  if (!unsafeDisableAuth && !authToken) {
+    throw new Error("SNA auth token is required. Pass authToken, set SNA_AUTH_TOKEN, or explicitly set unsafeDisableAuth for isolated tests only.");
+  }
+
+  return { authToken, allowedOrigins, unsafeDisableAuth };
+}
+
+export function isOriginAllowed(origin: string | undefined, allowedOrigins: string[]): boolean {
+  if (!origin) return true;
+  return allowedOrigins.includes("*") || allowedOrigins.includes(origin);
+}
+
+export function isAuthorizedToken(candidate: string | undefined, expected: string | undefined): boolean {
+  if (!candidate || !expected) return false;
+  const candidateBytes = Buffer.from(candidate);
+  const expectedBytes = Buffer.from(expected);
+  if (candidateBytes.length !== expectedBytes.length) return false;
+  return timingSafeEqual(candidateBytes, expectedBytes);
+}
+
+export function extractBearerToken(
+  authorization: string | undefined,
+  headerToken?: string | undefined,
+): string | undefined {
+  if (authorization?.startsWith("Bearer ")) {
+    return authorization.slice("Bearer ".length).trim();
+  }
+  return headerToken?.trim() || undefined;
+}
+
+export function extractWsToken(
+  headers: { authorization?: string; "x-sna-token"?: string },
+  url: URL,
+): string | undefined {
+  return extractBearerToken(headers.authorization, headers["x-sna-token"]) ?? url.searchParams.get("token") ?? undefined;
+}
+
+export function rejectUpgrade(socket: { write(data: string): void; destroy(): void }, status: 401 | 403, message: string): void {
+  socket.write(
+    `HTTP/1.1 ${status} ${status === 401 ? "Unauthorized" : "Forbidden"}\r\n` +
+    "Connection: close\r\n" +
+    "Content-Type: text/plain; charset=utf-8\r\n" +
+    `Content-Length: ${Buffer.byteLength(message)}\r\n` +
+    "\r\n" +
+    message,
+  );
+  socket.destroy();
+}
+
+function isPublicHttpRoute(method: string, pathname: string): boolean {
+  return method === "GET" && pathname === "/health";
+}
+
+function applyCorsHeaders(c: any, origin: string | undefined, allowedOrigins: string[]): void {
+  if (origin && isOriginAllowed(origin, allowedOrigins)) {
+    c.header("Access-Control-Allow-Origin", origin);
+    c.header("Vary", "Origin");
+  }
+  c.header("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS");
+  c.header("Access-Control-Allow-Headers", "Authorization, Content-Type, X-SNA-Token");
+}
+
+export function createHttpSecurityMiddleware(options: SnaSecurityOptions) {
+  const security = resolveSnaSecurityOptions(options);
+
+  return async (c: any, next: () => Promise<void>) => {
+    const method = c.req.method;
+    const pathname = new URL(c.req.url).pathname;
+    const origin = c.req.header("origin");
+
+    if (!security.unsafeDisableAuth && !isOriginAllowed(origin, security.allowedOrigins)) {
+      return c.json({ status: "error", message: "Origin not allowed" }, 403);
+    }
+
+    applyCorsHeaders(c, origin, security.allowedOrigins);
+
+    if (method === "OPTIONS") {
+      return c.body(null, 204);
+    }
+
+    if (security.unsafeDisableAuth || isPublicHttpRoute(method, pathname)) {
+      return next();
+    }
+
+    const token = extractBearerToken(c.req.header("authorization"), c.req.header("x-sna-token"));
+    if (!isAuthorizedToken(token, security.authToken)) {
+      return c.json({ status: "error", message: "Unauthorized" }, 401);
+    }
+
+    return next();
+  };
+}

--- a/packages/core/src/server/session-manager.ts
+++ b/packages/core/src/server/session-manager.ts
@@ -455,7 +455,7 @@ export class SessionManager {
   }
 
   /** Get or create a session (used for "default" backward compat). */
-  getOrCreateSession(id: string, opts?: { label?: string; cwd?: string }): Session {
+  getOrCreateSession(id: string, opts?: { label?: string; cwd?: string; meta?: Record<string, unknown> | null }): Session {
     const existing = this.sessions.get(id);
     if (existing) {
       // Update cwd if provided (handles server restart where session was recreated with wrong cwd)

--- a/packages/core/src/server/standalone.ts
+++ b/packages/core/src/server/standalone.ts
@@ -7,14 +7,13 @@
  */
 
 import { serve } from "@hono/node-server";
-import { cors } from "hono/cors";
 import fs from "fs";
 import path from "path";
 import { SessionManager } from "./session-manager.js";
 import { attachWebSocket } from "./ws.js";
 import { getProvider } from "../core/providers/index.js";
 import { logger } from "../lib/logger.js";
-import { getConfig } from "../config.js";
+import { configuredAppMeta, getConfig } from "../config.js";
 import { createSnaApp } from "./index.js";
 
 // Pre-flight: verify native modules are compatible before starting
@@ -34,11 +33,21 @@ try {
 }
 
 // All env parsing is done by config.ts — just read the resolved values
-const { port, defaultPermissionMode: permissionMode, model: defaultModel, maxSessions } = getConfig();
+const { appId, port, host, authToken, allowedOrigins, defaultPermissionMode: permissionMode, model: defaultModel, maxSessions } = getConfig();
+if (!authToken) {
+  console.error("SNA_AUTH_TOKEN is required for standalone server mode.");
+  process.exit(1);
+}
+
+let shutdownFromParentDisconnect: (() => void) | undefined;
+process.on("disconnect", () => {
+  if (shutdownFromParentDisconnect) shutdownFromParentDisconnect();
+  else process.exit(0);
+});
 
 // 1. Create session manager and main session
 const sessionManager = new SessionManager({ maxSessions });
-sessionManager.getOrCreateSession("default", { cwd: process.cwd() });
+sessionManager.getOrCreateSession("default", { cwd: process.cwd(), meta: configuredAppMeta() });
 
 // 2. Spawn agent into main session
 const provider = getProvider("claude-code");
@@ -48,14 +57,12 @@ sessionManager.setProcess("default", agentProcess);
 
 async function start() {
   // Create OpenAPI app with Swagger UI at /docs
-  const snaApp = await createSnaApp({ sessionManager });
+  const snaApp = await createSnaApp({ sessionManager, authToken, allowedOrigins });
 
   // Root wrapper with CORS, error handling, and request logging
   import("hono").then((honoModule) => {
     const Hono = honoModule.Hono;
     const root = new Hono();
-    root.use("*", cors({ origin: "*", allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"] }));
-
     root.onError((err, c) => {
       logger.err("err", `${c.req.method} ${new URL(c.req.url).pathname} → ${err.message}`);
       return c.json({ status: "error", message: err.message, stack: err.stack }, 500);
@@ -105,6 +112,7 @@ async function start() {
 
     process.on("SIGTERM", () => shutdown("SIGTERM"));
     process.on("SIGINT", () => shutdown("SIGINT"));
+    shutdownFromParentDisconnect = () => shutdown("parent process disconnected");
     process.on("uncaughtException", (err) => {
       if (shuttingDown) process.exit(0);
       console.error(err);
@@ -112,7 +120,7 @@ async function start() {
     });
 
     // Start listening — agent receives messages when ready
-    server = serve({ fetch: root.fetch, port }, () => {
+    server = serve({ fetch: root.fetch, port, hostname: host }, () => {
       // Write port file so /api/sna-port works consistently (Electron + standalone)
       const portDir = path.join(process.cwd(), ".sna");
       const portFile = path.join(portDir, "sna-api.port");
@@ -122,14 +130,15 @@ async function start() {
       } catch { /* non-fatal */ }
 
       console.log("");
-      logger.log("sna", `API server ready → http://localhost:${port}`);
-      logger.log("sna", `WebSocket endpoint → ws://localhost:${port}/ws`);
-      logger.log("sna", `OpenAPI docs → http://localhost:${port}/docs`);
+      logger.log("sna", `API server ready → http://${host}:${port}`);
+      if (appId) logger.log("sna", `App owner → ${appId}`);
+      logger.log("sna", `WebSocket endpoint → ws://${host}:${port}/ws`);
+      logger.log("sna", `OpenAPI docs → http://${host}:${port}/docs`);
       console.log("");
     });
 
     // Attach WebSocket on the same HTTP server
-    attachWebSocket(server as unknown as import("http").Server, sessionManager);
+    attachWebSocket(server as unknown as import("http").Server, sessionManager, { authToken, allowedOrigins });
 
     agentProcess.on("event", (e) => {
       if (e.type === "init") {

--- a/packages/core/src/server/ws.ts
+++ b/packages/core/src/server/ws.ts
@@ -63,10 +63,18 @@ import { saveEmbeds } from "./image-store.js";
 import { insertChatMessage } from "../db/chat-messages.js";
 import { formatEmbedRef } from "../history/embed-refs.js";
 import type { EmbedRecord } from "../history/types.js";
-import { getConfig } from "../config.js";
+import { configuredAppMeta, getConfig, withConfiguredAppId } from "../config.js";
 import type { SessionManager } from "./session-manager.js";
 import { spawnWithPool } from "../core/providers/index.js";
 import type { RuntimeHandle } from "../core/providers/runtime.js";
+import {
+  extractWsToken,
+  isAuthorizedToken,
+  isOriginAllowed,
+  rejectUpgrade,
+  resolveSnaSecurityOptions,
+  type SnaSecurityOptions,
+} from "./security.js";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -110,12 +118,24 @@ function replyError(ws: WebSocket, msg: WsRequest, message: string): void {
 export function attachWebSocket(
   server: HttpServer,
   sessionManager: SessionManager,
+  options: SnaSecurityOptions = {},
 ): WebSocketServer {
   const wss = new WebSocketServer({ noServer: true });
+  const security = resolveSnaSecurityOptions(options);
 
   server.on("upgrade", (req, socket, head) => {
     const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
     if (url.pathname === "/ws") {
+      const origin = req.headers.origin;
+      if (!security.unsafeDisableAuth && !isOriginAllowed(origin, security.allowedOrigins)) {
+        rejectUpgrade(socket, 403, "Origin not allowed");
+        return;
+      }
+      const token = extractWsToken(req.headers as { authorization?: string; "x-sna-token"?: string }, url);
+      if (!security.unsafeDisableAuth && !isAuthorizedToken(token, security.authToken)) {
+        rejectUpgrade(socket, 401, "Unauthorized");
+        return;
+      }
       wss.handleUpgrade(req, socket, head, (ws) => {
         wss.emit("connection", ws, req);
       });
@@ -291,7 +311,7 @@ function handleSessionsCreate(ws: WebSocket, msg: WsRequest, sm: SessionManager)
       id: msg.id as string | undefined,
       label: msg.label as string | undefined,
       cwd: msg.cwd as string | undefined,
-      meta: msg.meta as Record<string, unknown> | undefined,
+      meta: withConfiguredAppId(msg.meta as Record<string, unknown> | undefined, { includeWhenMissing: true }),
     });
     wsReply(ws, msg, { status: "created", sessionId: session.id, label: session.label, meta: session.meta });
   } catch (e: any) {
@@ -305,7 +325,7 @@ function handleSessionsUpdate(ws: WebSocket, msg: WsRequest, sm: SessionManager)
   try {
     sm.updateSession(id, {
       label: msg.label as string | undefined,
-      meta: msg.meta as Record<string, unknown> | undefined,
+      meta: msg.meta !== undefined ? withConfiguredAppId(msg.meta as Record<string, unknown> | undefined) as Record<string, unknown> : undefined,
       cwd: msg.cwd as string | undefined,
     });
     wsReply(ws, msg, { status: "updated", session: id });
@@ -329,6 +349,7 @@ async function handleAgentStart(ws: WebSocket, msg: WsRequest, sm: SessionManage
   const sessionId = (msg.session as string) ?? "default";
   const session = sm.getOrCreateSession(sessionId, {
     cwd: msg.cwd as string | undefined,
+    meta: configuredAppMeta(),
   });
 
   if (session.process?.alive && !msg.force) {
@@ -988,9 +1009,10 @@ function handleChatSessionsCreate(ws: WebSocket, msg: WsRequest): void {
   const id = (msg.id as string) ?? crypto.randomUUID().slice(0, 8);
   try {
     const db = getDb();
+    const meta = withConfiguredAppId(msg.meta as Record<string, unknown> | undefined, { includeWhenMissing: true });
     db.prepare(`INSERT OR IGNORE INTO chat_sessions (id, label, type, meta) VALUES (?, ?, ?, ?)`)
-      .run(id, (msg.label as string) ?? id, (msg.chatType as string) ?? "background", msg.meta ? JSON.stringify(msg.meta) : null);
-    wsReply(ws, msg, { status: "created", id, meta: (msg.meta as Record<string, unknown>) ?? null });
+      .run(id, (msg.label as string) ?? id, (msg.chatType as string) ?? "background", meta ? JSON.stringify(meta) : null);
+    wsReply(ws, msg, { status: "created", id, meta: meta ?? null });
   } catch (e: any) {
     replyError(ws, msg, e.message);
   }

--- a/packages/core/test/api-routes.test.ts
+++ b/packages/core/test/api-routes.test.ts
@@ -10,6 +10,8 @@ import fs from "fs";
 import path from "path";
 
 const TEST_DB_DIR = path.join(import.meta.dirname, "../.test-data-routes");
+const TEST_TOKEN = "test-sna-token";
+const ALLOWED_ORIGIN = "http://localhost:5173";
 
 function removeTestDir() {
   fs.rmSync(TEST_DB_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
@@ -94,7 +96,11 @@ describe("HTTP API Routes", () => {
     const { createSnaApp } = await import("../src/server/index.js");
     const { SessionManager } = await import("../src/server/session-manager.js");
     sm = new SessionManager();
-    app = await createSnaApp({ sessionManager: sm });
+    app = await createSnaApp({
+      sessionManager: sm,
+      authToken: TEST_TOKEN,
+      allowedOrigins: [ALLOWED_ORIGIN],
+    });
   });
 
   afterEach(async () => {
@@ -104,21 +110,60 @@ describe("HTTP API Routes", () => {
   });
 
   // Helper
-  async function req(method: string, path: string, body?: any) {
+  async function req(
+    method: string,
+    path: string,
+    body?: any,
+    options: { auth?: boolean; token?: string; origin?: string } = {},
+  ) {
     const opts: any = { method };
+    const headers: Record<string, string> = {};
     if (body) {
-      opts.headers = { "Content-Type": "application/json" };
+      headers["Content-Type"] = "application/json";
       opts.body = JSON.stringify(body);
+    }
+    if (options.auth !== false) {
+      headers.Authorization = `Bearer ${options.token ?? TEST_TOKEN}`;
+    }
+    if (options.origin) {
+      headers.Origin = options.origin;
+    }
+    if (Object.keys(headers).length > 0) {
+      opts.headers = headers;
     }
     return app.request(path, opts);
   }
 
   describe("Health", () => {
-    it("GET /health returns ok", async () => {
-      const res = await req("GET", "/health");
+    it("GET /health returns ok without authentication", async () => {
+      const res = await req("GET", "/health", undefined, { auth: false });
       const json = await res.json();
       assert.equal(json.ok, true);
       assert.equal(json.name, "sna");
+    });
+
+    it("rejects protected HTTP routes without a bearer token", async () => {
+      const res = await req("GET", "/agent/sessions", undefined, { auth: false });
+      assert.equal(res.status, 401);
+      assert.match((await res.json()).message, /Unauthorized/);
+    });
+
+    it("rejects protected HTTP routes with the wrong bearer token", async () => {
+      const res = await req("GET", "/agent/sessions", undefined, { token: "wrong" });
+      assert.equal(res.status, 401);
+      assert.match((await res.json()).message, /Unauthorized/);
+    });
+
+    it("rejects browser-origin requests from unapproved origins", async () => {
+      const res = await req("GET", "/agent/sessions", undefined, { origin: "https://evil.example" });
+      assert.equal(res.status, 403);
+      assert.match((await res.json()).message, /Origin not allowed/);
+    });
+
+    it("allows protected HTTP routes with a bearer token from an approved origin", async () => {
+      const res = await req("GET", "/agent/sessions", undefined, { origin: ALLOWED_ORIGIN });
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get("access-control-allow-origin"), ALLOWED_ORIGIN);
     });
   });
 

--- a/packages/core/test/api-routes.test.ts
+++ b/packages/core/test/api-routes.test.ts
@@ -177,6 +177,22 @@ describe("HTTP API Routes", () => {
       assert.deepEqual(json.meta, { app: "test" });
     });
 
+    it("POST /agent/sessions tags sessions with the configured appId", async () => {
+      const { resetConfig, setConfig } = await import("../src/config.js");
+      setConfig({ appId: "test-host" });
+      try {
+        const res = await req("POST", "/agent/sessions", {
+          label: "Owned",
+          meta: { appId: "spoofed", feature: "chat-panel" },
+        });
+        const json = await res.json();
+        assert.equal(json.status, "created");
+        assert.deepEqual(json.meta, { appId: "test-host", feature: "chat-panel" });
+      } finally {
+        resetConfig();
+      }
+    });
+
     it("GET /agent/sessions lists sessions", async () => {
       await req("POST", "/agent/sessions", { label: "S1" });
       const res = await req("GET", "/agent/sessions");
@@ -467,7 +483,11 @@ describe("HTTP API Routes", () => {
       try {
         const res = await app.request("/agent/run-once/stream", {
           method: "POST",
-          headers: { "Content-Type": "application/json", Accept: "text/event-stream" },
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+            Authorization: `Bearer ${TEST_TOKEN}`,
+          },
           body: JSON.stringify({ message: "hi", provider: "claude-code", timeout: 200 }),
           signal: ctrl.signal,
         });
@@ -513,6 +533,19 @@ describe("HTTP API Routes", () => {
       assert.equal(json.status, "created");
       assert.ok(json.id);
       assert.deepEqual(json.meta, { x: 1 });
+    });
+
+    it("POST /chat/sessions tags chat sessions with the configured appId", async () => {
+      const { resetConfig, setConfig } = await import("../src/config.js");
+      setConfig({ appId: "test-host" });
+      try {
+        const res = await req("POST", "/chat/sessions", { label: "OwnedChat" });
+        const json = await res.json();
+        assert.equal(json.status, "created");
+        assert.deepEqual(json.meta, { appId: "test-host" });
+      } finally {
+        resetConfig();
+      }
     });
 
     it("DELETE /chat/sessions/default is blocked", async () => {

--- a/packages/core/test/runtime-path-registration.test.ts
+++ b/packages/core/test/runtime-path-registration.test.ts
@@ -115,6 +115,10 @@ describe("runtime path registration", () => {
     try {
       assert.equal(handle.appId, "test-host");
       assert.equal(handle.authToken, "launcher-token");
+      assert.deepEqual(handle.connection, {
+        baseUrl: handle.baseUrl,
+        authToken: "launcher-token",
+      });
       assert.equal(process.env.SNA_APP_ID, "test-host");
       assert.equal(process.env.SNA_AUTH_TOKEN, "launcher-token");
       assert.equal(process.env.SNA_ALLOWED_ORIGINS, "http://localhost:5173");

--- a/packages/core/test/runtime-path-registration.test.ts
+++ b/packages/core/test/runtime-path-registration.test.ts
@@ -16,7 +16,11 @@ const ENV_KEYS = [
   "SNA_OPENCODE_COMMAND",
   "SNA_GROK_COMMAND",
   "SNA_CURSOR_COMMAND",
+  "SNA_APP_ID",
   "SNA_PORT",
+  "SNA_HOST",
+  "SNA_AUTH_TOKEN",
+  "SNA_ALLOWED_ORIGINS",
   "SNA_DB_PATH",
   "SNA_DATA_DIR",
   "SNA_PERMISSION_MODE",
@@ -85,6 +89,35 @@ describe("runtime path registration", () => {
       assert.equal(process.env.SNA_OPENCODE_COMMAND, "/runtime/opencode");
       assert.equal(process.env.SNA_GROK_COMMAND, "/runtime/grok");
       assert.equal(process.env.SNA_CURSOR_COMMAND, "/runtime/cursor-agent");
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it("keeps launcher-owned identity and auth values authoritative", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sna-launcher-identity-"));
+    tempDirs.push(dir);
+
+    const handle = await startSnaServerInProcess({
+      port: 0,
+      dbPath: path.join(dir, "sna.db"),
+      appId: "test-host",
+      authToken: "launcher-token",
+      allowedOrigins: ["http://localhost:5173"],
+      logLevel: "silent",
+      env: {
+        SNA_APP_ID: "wrong-app",
+        SNA_AUTH_TOKEN: "wrong-token",
+        SNA_ALLOWED_ORIGINS: "https://wrong.example",
+      },
+    });
+
+    try {
+      assert.equal(handle.appId, "test-host");
+      assert.equal(handle.authToken, "launcher-token");
+      assert.equal(process.env.SNA_APP_ID, "test-host");
+      assert.equal(process.env.SNA_AUTH_TOKEN, "launcher-token");
+      assert.equal(process.env.SNA_ALLOWED_ORIGINS, "http://localhost:5173");
     } finally {
       await handle.stop();
     }

--- a/packages/core/test/ws-handler.test.ts
+++ b/packages/core/test/ws-handler.test.ts
@@ -42,7 +42,7 @@ async function startServerOnly(): Promise<ServerOnlyContext> {
   const { serve } = await import("@hono/node-server");
 
   const sm = new SessionManager();
-  const app = createSnaApp({
+  const app = await createSnaApp({
     sessionManager: sm,
     authToken: TEST_TOKEN,
     allowedOrigins: [ALLOWED_ORIGIN],

--- a/packages/core/test/ws-handler.test.ts
+++ b/packages/core/test/ws-handler.test.ts
@@ -11,6 +11,8 @@ import { WebSocket } from "ws";
 import http from "http";
 
 const TEST_DB_DIR = path.join(import.meta.dirname, "../.test-data-ws");
+const TEST_TOKEN = "test-sna-token";
+const ALLOWED_ORIGIN = "http://localhost:5173";
 
 function setup() {
   if (fs.existsSync(TEST_DB_DIR)) fs.rmSync(TEST_DB_DIR, { recursive: true });
@@ -28,23 +30,87 @@ interface TestContext {
   rid: number;
 }
 
-async function startServer(): Promise<TestContext> {
+interface ServerOnlyContext {
+  server: http.Server;
+  port: number;
+  cleanup: () => void;
+}
+
+async function startServerOnly(): Promise<ServerOnlyContext> {
   const cleanup = setup();
   const { createSnaApp, SessionManager, attachWebSocket } = await import("../src/server/index.js");
   const { serve } = await import("@hono/node-server");
 
   const sm = new SessionManager();
-  const app = createSnaApp({ sessionManager: sm });
+  const app = createSnaApp({
+    sessionManager: sm,
+    authToken: TEST_TOKEN,
+    allowedOrigins: [ALLOWED_ORIGIN],
+  });
 
   return new Promise((resolve) => {
     const server = serve({ fetch: app.fetch, port: 0 }, (info) => {
       const port = (info as any).port ?? (server.address() as any)?.port;
-      attachWebSocket(server, sm);
-
-      const ws = new WebSocket(`ws://localhost:${port}/ws`);
-      ws.on("open", () => {
-        resolve({ ws, server, port, cleanup, rid: 0 });
+      attachWebSocket(server, sm, {
+        authToken: TEST_TOKEN,
+        allowedOrigins: [ALLOWED_ORIGIN],
       });
+      resolve({ server, port, cleanup });
+    });
+  });
+}
+
+async function startServer(): Promise<TestContext> {
+  const ctx = await startServerOnly();
+  const ws = await openWs(ctx.port, { token: TEST_TOKEN, origin: ALLOWED_ORIGIN });
+  return { ...ctx, ws, rid: 0 };
+}
+
+async function openWs(
+  port: number,
+  options: { token?: string; origin?: string } = {},
+): Promise<WebSocket> {
+  const url = new URL(`ws://localhost:${port}/ws`);
+  if (options.token) url.searchParams.set("token", options.token);
+  const ws = new WebSocket(url, {
+    headers: options.origin ? { Origin: options.origin } : undefined,
+  });
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("Timeout opening WebSocket")), 1000);
+    ws.once("open", () => {
+      clearTimeout(timer);
+      resolve(ws);
+    });
+    ws.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+async function assertWsRejected(
+  port: number,
+  options: { token?: string; origin?: string } = {},
+): Promise<void> {
+  const url = new URL(`ws://localhost:${port}/ws`);
+  if (options.token) url.searchParams.set("token", options.token);
+  const ws = new WebSocket(url, {
+    headers: options.origin ? { Origin: options.origin } : undefined,
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error("Timeout waiting for WebSocket rejection"));
+    }, 1000);
+    ws.once("open", () => {
+      clearTimeout(timer);
+      ws.close();
+      reject(new Error("WebSocket unexpectedly opened"));
+    });
+    ws.once("error", (err) => {
+      clearTimeout(timer);
+      assert.match(String(err), /Unexpected server response: (401|403)/);
+      resolve();
     });
   });
 }
@@ -89,6 +155,26 @@ describe("WebSocket Handler", () => {
     ctx.ws.close();
     ctx.server.close();
     ctx.cleanup();
+  });
+
+  it("rejects WebSocket upgrades without a token", async () => {
+    const serverCtx = await startServerOnly();
+    try {
+      await assertWsRejected(serverCtx.port, { origin: ALLOWED_ORIGIN });
+    } finally {
+      serverCtx.server.close();
+      serverCtx.cleanup();
+    }
+  });
+
+  it("rejects WebSocket upgrades from unapproved origins", async () => {
+    const serverCtx = await startServerOnly();
+    try {
+      await assertWsRejected(serverCtx.port, { token: TEST_TOKEN, origin: "https://evil.example" });
+    } finally {
+      serverCtx.server.close();
+      serverCtx.cleanup();
+    }
   });
 
   // ── Session CRUD ────────────────────────────────────

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -19,17 +19,18 @@ npm install @sna-sdk/react @sna-sdk/core
 ```tsx
 import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 
-<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
+<SnaProvider connection={sna.connection}>
   <YourApp />
 </SnaProvider>
 ```
 
-`SnaProvider` is a pure context provider — no UI, no peer deps beyond React. It auto-discovers the server URL via `/api/sna-port` if `snaUrl` is omitted; otherwise falls back to `http://localhost:3099`.
+`SnaProvider` is a pure context provider — no UI, no peer deps beyond React. In SDK-managed apps, pass `connection={sna.connection}` so the token stays paired with the server handle. It auto-discovers the server URL via `/api/sna-port` if no connection or `snaUrl` is provided; otherwise falls back to `http://localhost:3099`.
 
 | Prop | |
 |------|---|
+| `connection?` | Connection object returned by `startSnaServer` |
 | `snaUrl?` | Override the server URL |
-| `authToken?` | Bearer token returned by `startSnaServer` |
+| `authToken?` | Token override for custom deployments |
 | `sessionId?` | Default session id (default `"default"`) |
 | `hydrate?` | Hydrate chat-store on mount (default `true`) |
 
@@ -38,7 +39,7 @@ import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 ```tsx
 import { SnaChatUI } from "@sna-sdk/react/components/sna-chat-ui";
 
-<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
+<SnaProvider connection={sna.connection}>
   <SnaChatUI dangerouslySkipPermissions>
     <YourApp />
   </SnaChatUI>
@@ -57,7 +58,7 @@ import { SnaChatUI } from "@sna-sdk/react/components/sna-chat-ui";
 ```tsx
 import { SnaSession } from "@sna-sdk/react/components/sna-session";
 
-<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
+<SnaProvider connection={sna.connection}>
   <SnaSession id="default"><HelperAgent /></SnaSession>
   <SnaSession id={activeProjectSessionId}><ChatArea /></SnaSession>
 </SnaProvider>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -19,7 +19,7 @@ npm install @sna-sdk/react @sna-sdk/core
 ```tsx
 import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 
-<SnaProvider snaUrl="http://localhost:3099">
+<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
   <YourApp />
 </SnaProvider>
 ```
@@ -29,6 +29,7 @@ import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 | Prop | |
 |------|---|
 | `snaUrl?` | Override the server URL |
+| `authToken?` | Bearer token returned by `startSnaServer` |
 | `sessionId?` | Default session id (default `"default"`) |
 | `hydrate?` | Hydrate chat-store on mount (default `true`) |
 
@@ -37,7 +38,7 @@ import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 ```tsx
 import { SnaChatUI } from "@sna-sdk/react/components/sna-chat-ui";
 
-<SnaProvider snaUrl={apiUrl}>
+<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
   <SnaChatUI dangerouslySkipPermissions>
     <YourApp />
   </SnaChatUI>
@@ -56,7 +57,7 @@ import { SnaChatUI } from "@sna-sdk/react/components/sna-chat-ui";
 ```tsx
 import { SnaSession } from "@sna-sdk/react/components/sna-session";
 
-<SnaProvider snaUrl={apiUrl}>
+<SnaProvider snaUrl={sna.baseUrl} authToken={sna.authToken}>
   <SnaSession id="default"><HelperAgent /></SnaSession>
   <SnaSession id={activeProjectSessionId}><ChatArea /></SnaSession>
 </SnaProvider>

--- a/packages/react/dist/components/sna-chat-ui.js
+++ b/packages/react/dist/components/sna-chat-ui.js
@@ -4,7 +4,7 @@ import { memo, useEffect, useState } from "react";
 import { ChatPanel } from "./chat/chat-panel.js";
 import { useChatStore } from "../stores/chat-store.js";
 import { useResponsiveChat } from "../hooks/use-responsive-chat.js";
-import { useSnaContext } from "../context.js";
+import { authHeaders, useSnaContext } from "../context.js";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 const StableChatPanel = memo(function StableChatPanel2({
   onClose,
@@ -91,7 +91,7 @@ function SnaChatUI({
   defaultOpen = false,
   dangerouslySkipPermissions = false
 }) {
-  const { apiUrl, sessionId } = useSnaContext();
+  const { apiUrl, authToken, sessionId } = useSnaContext();
   const [agentReady, setAgentReady] = useState(false);
   const chatOpen = useChatStore((s) => s.isOpen);
   const setChatOpen = useChatStore((s) => s.setOpen);
@@ -102,10 +102,10 @@ function SnaChatUI({
     const permissionMode = dangerouslySkipPermissions ? "bypassPermissions" : void 0;
     fetch(`${apiUrl}/agent/start?session=${encodeURIComponent(sessionId)}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders(authToken, { "Content-Type": "application/json" }),
       body: JSON.stringify({ provider: "claude-code", permissionMode })
     }).then((res) => res.json()).then(() => setAgentReady(true)).catch(() => setAgentReady(true));
-  }, [apiUrl, dangerouslySkipPermissions, sessionId]);
+  }, [apiUrl, authToken, dangerouslySkipPermissions, sessionId]);
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!localStorage.getItem("sna-chat-panel")) {

--- a/packages/react/dist/components/sna-provider.d.ts
+++ b/packages/react/dist/components/sna-provider.d.ts
@@ -7,6 +7,8 @@ interface SnaProviderProps {
      * Defaults to auto-discovery via /api/sna-port, then http://localhost:3099.
      */
     snaUrl?: string;
+    /** Bearer token returned by startSnaServer/startSnaServerInProcess. */
+    authToken?: string;
     /**
      * Session ID for this provider scope.
      * @default "default"
@@ -45,6 +47,6 @@ interface SnaProviderProps {
  *   <SnaSession id={projectSessionId}><ChatArea /></SnaSession>
  * </SnaProvider>
  */
-declare function SnaProvider({ children, snaUrl, sessionId, hydrate: shouldHydrate, }: SnaProviderProps): react_jsx_runtime.JSX.Element;
+declare function SnaProvider({ children, snaUrl, authToken, sessionId, hydrate: shouldHydrate, }: SnaProviderProps): react_jsx_runtime.JSX.Element;
 
 export { SnaProvider };

--- a/packages/react/dist/components/sna-provider.d.ts
+++ b/packages/react/dist/components/sna-provider.d.ts
@@ -1,13 +1,23 @@
 import * as react_jsx_runtime from 'react/jsx-runtime';
 
+interface SnaConnection {
+    baseUrl: string;
+    authToken?: string;
+}
 interface SnaProviderProps {
     children: React.ReactNode;
+    /**
+     * Connection object returned by startSnaServer/startSnaServerInProcess.
+     * Prefer this in SDK-managed apps so the auth token stays paired with
+     * the server handle.
+     */
+    connection?: SnaConnection;
     /**
      * Override the SNA internal API server URL.
      * Defaults to auto-discovery via /api/sna-port, then http://localhost:3099.
      */
     snaUrl?: string;
-    /** Bearer token returned by startSnaServer/startSnaServerInProcess. */
+    /** Bearer token override for custom deployments. Prefer `connection`. */
     authToken?: string;
     /**
      * Session ID for this provider scope.
@@ -29,7 +39,7 @@ interface SnaProviderProps {
  *
  * @example
  * // Minimal — context only
- * <SnaProvider snaUrl="http://localhost:52341">
+ * <SnaProvider connection={sna.connection}>
  *   {children}
  * </SnaProvider>
  *
@@ -47,6 +57,6 @@ interface SnaProviderProps {
  *   <SnaSession id={projectSessionId}><ChatArea /></SnaSession>
  * </SnaProvider>
  */
-declare function SnaProvider({ children, snaUrl, authToken, sessionId, hydrate: shouldHydrate, }: SnaProviderProps): react_jsx_runtime.JSX.Element;
+declare function SnaProvider({ children, connection, snaUrl, authToken, sessionId, hydrate: shouldHydrate, }: SnaProviderProps): react_jsx_runtime.JSX.Element;
 
-export { SnaProvider };
+export { type SnaConnection, SnaProvider, type SnaProviderProps };

--- a/packages/react/dist/components/sna-provider.js
+++ b/packages/react/dist/components/sna-provider.js
@@ -5,42 +5,55 @@ import { useChatStore } from "../stores/chat-store.js";
 import { SnaContext, DEFAULT_SNA_URL } from "../context.js";
 function SnaProvider({
   children,
+  connection,
   snaUrl,
   authToken,
   sessionId = "default",
   hydrate: shouldHydrate = true
 }) {
-  const [resolvedUrl, setResolvedUrl] = useState(snaUrl ?? "");
+  const explicitUrl = connection?.baseUrl ?? snaUrl;
+  const explicitAuthToken = connection?.authToken ?? authToken;
+  const [resolvedUrl, setResolvedUrl] = useState(explicitUrl ?? "");
+  const [resolvedAuthToken, setResolvedAuthToken] = useState(explicitAuthToken);
   useEffect(() => {
     if (typeof window === "undefined") return;
     async function discover() {
-      if (snaUrl) {
-        setResolvedUrl(snaUrl);
-        return snaUrl;
+      if (explicitUrl) {
+        setResolvedUrl(explicitUrl);
+        setResolvedAuthToken(explicitAuthToken);
+        return { url: explicitUrl, token: explicitAuthToken };
       }
       try {
         const res = await fetch("/api/sna-port");
         const data = await res.json();
+        const discoveredToken = typeof data.authToken === "string" ? data.authToken : void 0;
+        if (typeof data.baseUrl === "string") {
+          setResolvedUrl(data.baseUrl);
+          setResolvedAuthToken(discoveredToken);
+          return { url: data.baseUrl, token: discoveredToken };
+        }
         if (data.port) {
           const url = `http://localhost:${data.port}`;
           setResolvedUrl(url);
-          return url;
+          setResolvedAuthToken(discoveredToken);
+          return { url, token: discoveredToken };
         }
       } catch {
       }
       const fallback = DEFAULT_SNA_URL;
       setResolvedUrl(fallback);
-      return fallback;
+      setResolvedAuthToken(void 0);
+      return { url: fallback, token: void 0 };
     }
-    discover().then((url) => {
+    discover().then(({ url, token }) => {
       useChatStore.getState()._setApiUrl(url);
-      useChatStore.getState()._setAuthToken(authToken);
+      useChatStore.getState()._setAuthToken(token);
       if (shouldHydrate) {
         useChatStore.getState().hydrate();
       }
     });
-  }, [snaUrl, authToken, shouldHydrate]);
-  return /* @__PURE__ */ jsx(SnaContext.Provider, { value: { apiUrl: resolvedUrl, authToken, sessionId }, children });
+  }, [explicitUrl, explicitAuthToken, shouldHydrate]);
+  return /* @__PURE__ */ jsx(SnaContext.Provider, { value: { apiUrl: resolvedUrl, authToken: resolvedAuthToken, sessionId }, children });
 }
 export {
   SnaProvider

--- a/packages/react/dist/components/sna-provider.js
+++ b/packages/react/dist/components/sna-provider.js
@@ -6,6 +6,7 @@ import { SnaContext, DEFAULT_SNA_URL } from "../context.js";
 function SnaProvider({
   children,
   snaUrl,
+  authToken,
   sessionId = "default",
   hydrate: shouldHydrate = true
 }) {
@@ -33,12 +34,13 @@ function SnaProvider({
     }
     discover().then((url) => {
       useChatStore.getState()._setApiUrl(url);
+      useChatStore.getState()._setAuthToken(authToken);
       if (shouldHydrate) {
         useChatStore.getState().hydrate();
       }
     });
-  }, [snaUrl, shouldHydrate]);
-  return /* @__PURE__ */ jsx(SnaContext.Provider, { value: { apiUrl: resolvedUrl, sessionId }, children });
+  }, [snaUrl, authToken, shouldHydrate]);
+  return /* @__PURE__ */ jsx(SnaContext.Provider, { value: { apiUrl: resolvedUrl, authToken, sessionId }, children });
 }
 export {
   SnaProvider

--- a/packages/react/dist/context.d.ts
+++ b/packages/react/dist/context.d.ts
@@ -10,6 +10,8 @@ interface SnaConfig {
      * Override via <SnaProvider snaUrl="..."> for custom deployments.
      */
     apiUrl: string;
+    /** Bearer token issued by the SNA server. */
+    authToken?: string;
     /**
      * Active session ID for this scope.
      * Set by <SnaSession id="...">. Defaults to "default".
@@ -18,5 +20,6 @@ interface SnaConfig {
 }
 declare const SnaContext: react.Context<SnaConfig>;
 declare function useSnaContext(): SnaConfig;
+declare function authHeaders(authToken: string | undefined, headers?: Record<string, string>): Record<string, string> | undefined;
 
-export { DEFAULT_SNA_URL, type SnaConfig, SnaContext, useSnaContext };
+export { DEFAULT_SNA_URL, type SnaConfig, SnaContext, authHeaders, useSnaContext };

--- a/packages/react/dist/context.js
+++ b/packages/react/dist/context.js
@@ -6,8 +6,16 @@ const SnaContext = createContext({ apiUrl: DEFAULT_SNA_URL, sessionId: "default"
 function useSnaContext() {
   return useContext(SnaContext);
 }
+function authHeaders(authToken, headers = {}) {
+  const next = { ...headers };
+  if (authToken) {
+    next.Authorization = `Bearer ${authToken}`;
+  }
+  return Object.keys(next).length > 0 ? next : void 0;
+}
 export {
   DEFAULT_SNA_URL,
   SnaContext,
+  authHeaders,
   useSnaContext
 };

--- a/packages/react/dist/hooks/use-agent.d.ts
+++ b/packages/react/dist/hooks/use-agent.d.ts
@@ -6,6 +6,8 @@ interface UseAgentOptions {
     sessionId?: string;
     /** Override base URL for agent API. Defaults to SnaContext apiUrl + "/agent" */
     baseUrl?: string;
+    /** Override bearer token. Defaults to SnaContext authToken. */
+    authToken?: string;
     /** Provider name. Defaults to "claude-code" */
     provider?: string;
     /** Permission mode for the agent */

--- a/packages/react/dist/hooks/use-agent.js
+++ b/packages/react/dist/hooks/use-agent.js
@@ -1,11 +1,12 @@
 "use client";
 import { useEffect, useRef, useState, useCallback } from "react";
-import { useSnaContext } from "../context.js";
+import { authHeaders, useSnaContext } from "../context.js";
 function useAgent(options = {}) {
   const ctx = useSnaContext();
   const {
     sessionId = ctx.sessionId,
     baseUrl = `${ctx.apiUrl}/agent`,
+    authToken = ctx.authToken,
     provider = "claude-code",
     permissionMode,
     reasoningLevel,
@@ -14,7 +15,7 @@ function useAgent(options = {}) {
   const sessionParam = `session=${encodeURIComponent(sessionId)}`;
   const [connected, setConnected] = useState(false);
   const [alive, setAlive] = useState(false);
-  const esRef = useRef(null);
+  const streamAbortRef = useRef(null);
   const onEventRef = useRef(options.onEvent);
   const onThinkingRef = useRef(options.onThinking);
   const onAssistantRef = useRef(options.onAssistant);
@@ -34,7 +35,9 @@ function useAgent(options = {}) {
     async function init() {
       let cursor = 0;
       try {
-        const res = await fetch(`${baseUrl}/status?${sessionParam}`);
+        const res = await fetch(`${baseUrl}/status?${sessionParam}`, {
+          headers: authHeaders(authToken)
+        });
         const data = await res.json();
         cursor = data.eventCount ?? 0;
         if (data.alive) setAlive(true);
@@ -42,46 +45,55 @@ function useAgent(options = {}) {
       }
       function connect() {
         if (disposed) return;
-        if (esRef.current) esRef.current.close();
-        const es = new EventSource(`${baseUrl}/events?${sessionParam}&since=${cursor}`);
-        esRef.current = es;
-        es.onopen = () => setConnected(true);
-        es.onmessage = (e) => {
-          if (!e.data || disposed) return;
-          if (e.lastEventId) cursor = parseInt(e.lastEventId, 10);
-          try {
-            const event = JSON.parse(e.data);
-            onEventRef.current?.(event);
-            if (event.type === "init") onInitRef.current?.(event);
-            if (event.type === "thinking") onThinkingRef.current?.(event);
-            if (event.type === "assistant") onAssistantRef.current?.(event);
-            if (event.type === "tool_result") onToolResultRef.current?.(event);
-            if (event.type === "complete") onCompleteRef.current?.(event);
-            if (event.type === "error") onErrorRef.current?.(event);
-          } catch {
-          }
-        };
-        es.onerror = () => {
+        streamAbortRef.current?.abort();
+        const ctrl = new AbortController();
+        streamAbortRef.current = ctrl;
+        fetch(`${baseUrl}/events?${sessionParam}&since=${cursor}`, {
+          headers: authHeaders(authToken, { Accept: "text/event-stream" }),
+          signal: ctrl.signal
+        }).then(async (res) => {
+          if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`);
+          setConnected(true);
+          await readSse(res, {
+            onId: (id) => {
+              cursor = parseInt(id, 10);
+            },
+            onData: (data) => {
+              if (!data || disposed) return;
+              try {
+                const event = JSON.parse(data);
+                onEventRef.current?.(event);
+                if (event.type === "init") onInitRef.current?.(event);
+                if (event.type === "thinking") onThinkingRef.current?.(event);
+                if (event.type === "assistant") onAssistantRef.current?.(event);
+                if (event.type === "tool_result") onToolResultRef.current?.(event);
+                if (event.type === "complete") onCompleteRef.current?.(event);
+                if (event.type === "error") onErrorRef.current?.(event);
+              } catch {
+              }
+            }
+          });
+        }).catch(() => {
+        }).finally(() => {
           setConnected(false);
-          es.close();
-          if (!disposed) setTimeout(connect, 3e3);
-        };
+          if (!disposed && !ctrl.signal.aborted) setTimeout(connect, 3e3);
+        });
       }
       connect();
     }
     init();
     return () => {
       disposed = true;
-      esRef.current?.close();
+      streamAbortRef.current?.abort();
     };
-  }, [baseUrl, sessionParam]);
+  }, [baseUrl, sessionParam, authToken]);
   const send = useCallback(async (message) => {
     console.log(`[useAgent:send] session=${sessionId}, message=${message.slice(0, 50)}`);
     setAlive(true);
     try {
       const res = await fetch(`${baseUrl}/send?${sessionParam}`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: authHeaders(authToken, { "Content-Type": "application/json" }),
         body: JSON.stringify({ message })
       });
       const data = await res.json();
@@ -91,11 +103,11 @@ function useAgent(options = {}) {
       console.error("[useAgent:send] FAILED:", err);
       return { status: "error", message: String(err) };
     }
-  }, [baseUrl, sessionParam, sessionId]);
+  }, [baseUrl, sessionParam, sessionId, authToken]);
   const start = useCallback(async (prompt) => {
     const res = await fetch(`${baseUrl}/start?${sessionParam}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders(authToken, { "Content-Type": "application/json" }),
       body: JSON.stringify({ provider, prompt, permissionMode, reasoningLevel, providerOptions })
     });
     const data = await res.json();
@@ -103,15 +115,18 @@ function useAgent(options = {}) {
       setAlive(true);
     }
     return data;
-  }, [baseUrl, sessionParam, provider, permissionMode, reasoningLevel, providerOptions]);
+  }, [baseUrl, sessionParam, authToken, provider, permissionMode, reasoningLevel, providerOptions]);
   const kill = useCallback(async () => {
     setAlive(false);
-    await fetch(`${baseUrl}/kill?${sessionParam}`, { method: "POST" });
-  }, [baseUrl, sessionParam]);
+    await fetch(`${baseUrl}/kill?${sessionParam}`, {
+      method: "POST",
+      headers: authHeaders(authToken)
+    });
+  }, [baseUrl, sessionParam, authToken]);
   const completion = useCallback(async (opts) => {
     const res = await fetch(`${baseUrl}/completion`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders(authToken, { "Content-Type": "application/json" }),
       body: JSON.stringify({
         provider,
         reasoningLevel,
@@ -119,8 +134,43 @@ function useAgent(options = {}) {
       })
     });
     return res.json();
-  }, [baseUrl, provider, reasoningLevel]);
+  }, [baseUrl, authToken, provider, reasoningLevel]);
   return { connected, alive, start, send, kill, completion };
+}
+async function readSse(response, handlers) {
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let eventId = "";
+  let data = "";
+  const flush = () => {
+    if (eventId) handlers.onId(eventId);
+    if (data) handlers.onData(data.replace(/\n$/, ""));
+    eventId = "";
+    data = "";
+  };
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line === "") {
+          flush();
+        } else if (line.startsWith("id:")) {
+          eventId = line.slice(3).trim();
+        } else if (line.startsWith("data:")) {
+          data += `${line.slice(5).trimStart()}
+`;
+        }
+      }
+    }
+    if (buffer) flush();
+  } finally {
+    reader.releaseLock();
+  }
 }
 export {
   useAgent

--- a/packages/react/dist/hooks/use-session-manager.js
+++ b/packages/react/dist/hooks/use-session-manager.js
@@ -1,15 +1,17 @@
 "use client";
 import { useState, useCallback, useEffect, useRef } from "react";
-import { useSnaContext } from "../context.js";
+import { authHeaders, useSnaContext } from "../context.js";
 function useSessionManager(pollInterval = 3e3) {
-  const { apiUrl } = useSnaContext();
+  const { apiUrl, authToken } = useSnaContext();
   const baseUrl = `${apiUrl}/agent`;
   const [sessions, setSessions] = useState([]);
   const [loading, setLoading] = useState(false);
   const prevJsonRef = useRef("");
   const refresh = useCallback(async () => {
     try {
-      const res = await fetch(`${baseUrl}/sessions`);
+      const res = await fetch(`${baseUrl}/sessions`, {
+        headers: authHeaders(authToken)
+      });
       const data = await res.json();
       const next = data.sessions ?? [];
       const json = JSON.stringify(next);
@@ -19,13 +21,13 @@ function useSessionManager(pollInterval = 3e3) {
       }
     } catch {
     }
-  }, [baseUrl]);
+  }, [baseUrl, authToken]);
   const createSession = useCallback(async (opts) => {
     setLoading(true);
     try {
       const res = await fetch(`${baseUrl}/sessions`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: authHeaders(authToken, { "Content-Type": "application/json" }),
         body: JSON.stringify(opts ?? {})
       });
       const data = await res.json();
@@ -41,23 +43,29 @@ function useSessionManager(pollInterval = 3e3) {
     } finally {
       setLoading(false);
     }
-  }, [baseUrl, refresh]);
+  }, [baseUrl, authToken, refresh]);
   const killSession = useCallback(async (id) => {
     try {
-      await fetch(`${baseUrl}/kill?session=${encodeURIComponent(id)}`, { method: "POST" });
+      await fetch(`${baseUrl}/kill?session=${encodeURIComponent(id)}`, {
+        method: "POST",
+        headers: authHeaders(authToken)
+      });
       await refresh();
     } catch (err) {
       console.error("[useSessionManager:kill]", err);
     }
-  }, [baseUrl, refresh]);
+  }, [baseUrl, authToken, refresh]);
   const deleteSession = useCallback(async (id) => {
     try {
-      await fetch(`${baseUrl}/sessions/${encodeURIComponent(id)}`, { method: "DELETE" });
+      await fetch(`${baseUrl}/sessions/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+        headers: authHeaders(authToken)
+      });
       await refresh();
     } catch (err) {
       console.error("[useSessionManager:delete]", err);
     }
-  }, [baseUrl, refresh]);
+  }, [baseUrl, authToken, refresh]);
   useEffect(() => {
     refresh();
     if (!pollInterval) return;

--- a/packages/react/dist/stores/chat-store.d.ts
+++ b/packages/react/dist/stores/chat-store.d.ts
@@ -18,7 +18,9 @@ interface ChatState {
     activeSessionId: string;
     sessions: Record<string, SessionChatState>;
     _apiUrl: string;
+    _authToken?: string;
     _setApiUrl: (url: string) => void;
+    _setAuthToken: (token: string | undefined) => void;
     /** Tracks which sessions have had their messages fetched */
     _hydratedSessions: Set<string>;
     setOpen: (open: boolean) => void;

--- a/packages/react/dist/stores/chat-store.js
+++ b/packages/react/dist/stores/chat-store.js
@@ -1,5 +1,6 @@
 "use client";
 import { create } from "zustand";
+import { authHeaders } from "../context.js";
 let messageCounter = 0;
 function emptySession() {
   return { messages: [], processedEventIds: /* @__PURE__ */ new Set() };
@@ -15,23 +16,29 @@ function actorKindToRole(actor, kind) {
   if (kind === "error") return "error";
   return "status";
 }
-function syncCreateSession(apiUrl, id, label, type) {
+function syncCreateSession(apiUrl, authToken, id, label, type) {
   if (!apiUrl) return;
   fetch(`${apiUrl}/chat/sessions`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: authHeaders(authToken, { "Content-Type": "application/json" }),
     body: JSON.stringify({ id, label: label ?? id, type: type ?? "background" })
   }).catch(() => {
   });
 }
-function syncDeleteSession(apiUrl, id) {
+function syncDeleteSession(apiUrl, authToken, id) {
   if (!apiUrl) return;
-  fetch(`${apiUrl}/chat/sessions/${encodeURIComponent(id)}`, { method: "DELETE" }).catch(() => {
+  fetch(`${apiUrl}/chat/sessions/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: authHeaders(authToken)
+  }).catch(() => {
   });
 }
-function syncClearMessages(apiUrl, sessionId) {
+function syncClearMessages(apiUrl, authToken, sessionId) {
   if (!apiUrl) return;
-  fetch(`${apiUrl}/chat/sessions/${encodeURIComponent(sessionId)}/messages`, { method: "DELETE" }).catch(() => {
+  fetch(`${apiUrl}/chat/sessions/${encodeURIComponent(sessionId)}/messages`, {
+    method: "DELETE",
+    headers: authHeaders(authToken)
+  }).catch(() => {
   });
 }
 const useChatStore = create()(
@@ -41,7 +48,9 @@ const useChatStore = create()(
     activeSessionId: "default",
     sessions: { default: emptySession() },
     _apiUrl: "",
+    _authToken: void 0,
     _setApiUrl: (url) => set({ _apiUrl: url }),
+    _setAuthToken: (token) => set({ _authToken: token }),
     _hydratedSessions: /* @__PURE__ */ new Set(),
     setOpen: (open) => set({ isOpen: open }),
     toggle: () => set((s) => ({ isOpen: !s.isOpen })),
@@ -59,7 +68,7 @@ const useChatStore = create()(
       const s = get().sessions;
       if (!s[id]) {
         set({ sessions: { ...s, [id]: emptySession() } });
-        syncCreateSession(get()._apiUrl, id);
+        syncCreateSession(get()._apiUrl, get()._authToken, id);
       }
     },
     removeSession: (id) => {
@@ -68,7 +77,7 @@ const useChatStore = create()(
       delete s[id];
       const activeSessionId = get().activeSessionId === id ? "default" : get().activeSessionId;
       set({ sessions: s, activeSessionId });
-      syncDeleteSession(get()._apiUrl, id);
+      syncDeleteSession(get()._apiUrl, get()._authToken, id);
     },
     addMessage: (msg, sessionId) => {
       const id = sessionId ?? get().activeSessionId;
@@ -94,7 +103,7 @@ const useChatStore = create()(
           [id]: emptySession()
         }
       }));
-      syncClearMessages(get()._apiUrl, id);
+      syncClearMessages(get()._apiUrl, get()._authToken, id);
     },
     markEventProcessed: (eventId, sessionId) => {
       const id = sessionId ?? get().activeSessionId;
@@ -121,7 +130,9 @@ const useChatStore = create()(
       const apiUrl = get()._apiUrl;
       if (!apiUrl) return;
       try {
-        const sessRes = await fetch(`${apiUrl}/chat/sessions`);
+        const sessRes = await fetch(`${apiUrl}/chat/sessions`, {
+          headers: authHeaders(get()._authToken)
+        });
         const sessData = await sessRes.json();
         const dbSessions = sessData.sessions;
         const sessions = {};
@@ -147,7 +158,8 @@ const useChatStore = create()(
       set({ _hydratedSessions: next });
       try {
         const msgRes = await fetch(
-          `${apiUrl}/chat/sessions/${encodeURIComponent(sessionId)}/messages`
+          `${apiUrl}/chat/sessions/${encodeURIComponent(sessionId)}/messages`,
+          { headers: authHeaders(get()._authToken) }
         );
         const msgData = await msgRes.json();
         const messages = msgData.messages.map((m) => ({

--- a/packages/react/src/components/sna-chat-ui.tsx
+++ b/packages/react/src/components/sna-chat-ui.tsx
@@ -4,7 +4,7 @@ import { memo, useEffect, useState } from "react";
 import { ChatPanel } from "./chat/chat-panel.js";
 import { useChatStore } from "../stores/chat-store.js";
 import { useResponsiveChat } from "../hooks/use-responsive-chat.js";
-import { useSnaContext } from "../context.js";
+import { authHeaders, useSnaContext } from "../context.js";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 const StableChatPanel = memo(function StableChatPanel({
@@ -104,7 +104,7 @@ export function SnaChatUI({
   defaultOpen = false,
   dangerouslySkipPermissions = false,
 }: SnaChatUIProps) {
-  const { apiUrl, sessionId } = useSnaContext();
+  const { apiUrl, authToken, sessionId } = useSnaContext();
   const [agentReady, setAgentReady] = useState(false);
   const chatOpen = useChatStore((s) => s.isOpen);
   const setChatOpen = useChatStore((s) => s.setOpen);
@@ -117,13 +117,13 @@ export function SnaChatUI({
     const permissionMode = dangerouslySkipPermissions ? "bypassPermissions" : undefined;
     fetch(`${apiUrl}/agent/start?session=${encodeURIComponent(sessionId)}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders(authToken, { "Content-Type": "application/json" }),
       body: JSON.stringify({ provider: "claude-code", permissionMode }),
     })
       .then((res) => res.json())
       .then(() => setAgentReady(true))
       .catch(() => setAgentReady(true));
-  }, [apiUrl, dangerouslySkipPermissions, sessionId]);
+  }, [apiUrl, authToken, dangerouslySkipPermissions, sessionId]);
 
   // Auto-open chat on first mount
   useEffect(() => {

--- a/packages/react/src/components/sna-provider.tsx
+++ b/packages/react/src/components/sna-provider.tsx
@@ -11,6 +11,8 @@ interface SnaProviderProps {
    * Defaults to auto-discovery via /api/sna-port, then http://localhost:3099.
    */
   snaUrl?: string;
+  /** Bearer token returned by startSnaServer/startSnaServerInProcess. */
+  authToken?: string;
   /**
    * Session ID for this provider scope.
    * @default "default"
@@ -53,6 +55,7 @@ interface SnaProviderProps {
 export function SnaProvider({
   children,
   snaUrl,
+  authToken,
   sessionId = "default",
   hydrate: shouldHydrate = true,
 }: SnaProviderProps) {
@@ -82,14 +85,15 @@ export function SnaProvider({
 
     discover().then((url) => {
       useChatStore.getState()._setApiUrl(url);
+      useChatStore.getState()._setAuthToken(authToken);
       if (shouldHydrate) {
         useChatStore.getState().hydrate();
       }
     });
-  }, [snaUrl, shouldHydrate]);
+  }, [snaUrl, authToken, shouldHydrate]);
 
   return (
-    <SnaContext.Provider value={{ apiUrl: resolvedUrl, sessionId }}>
+    <SnaContext.Provider value={{ apiUrl: resolvedUrl, authToken, sessionId }}>
       {children}
     </SnaContext.Provider>
   );

--- a/packages/react/src/components/sna-provider.tsx
+++ b/packages/react/src/components/sna-provider.tsx
@@ -4,14 +4,25 @@ import { useEffect, useState } from "react";
 import { useChatStore } from "../stores/chat-store.js";
 import { SnaContext, DEFAULT_SNA_URL } from "../context.js";
 
-interface SnaProviderProps {
+export interface SnaConnection {
+  baseUrl: string;
+  authToken?: string;
+}
+
+export interface SnaProviderProps {
   children: React.ReactNode;
+  /**
+   * Connection object returned by startSnaServer/startSnaServerInProcess.
+   * Prefer this in SDK-managed apps so the auth token stays paired with
+   * the server handle.
+   */
+  connection?: SnaConnection;
   /**
    * Override the SNA internal API server URL.
    * Defaults to auto-discovery via /api/sna-port, then http://localhost:3099.
    */
   snaUrl?: string;
-  /** Bearer token returned by startSnaServer/startSnaServerInProcess. */
+  /** Bearer token override for custom deployments. Prefer `connection`. */
   authToken?: string;
   /**
    * Session ID for this provider scope.
@@ -34,7 +45,7 @@ interface SnaProviderProps {
  *
  * @example
  * // Minimal — context only
- * <SnaProvider snaUrl="http://localhost:52341">
+ * <SnaProvider connection={sna.connection}>
  *   {children}
  * </SnaProvider>
  *
@@ -54,46 +65,59 @@ interface SnaProviderProps {
  */
 export function SnaProvider({
   children,
+  connection,
   snaUrl,
   authToken,
   sessionId = "default",
   hydrate: shouldHydrate = true,
 }: SnaProviderProps) {
-  const [resolvedUrl, setResolvedUrl] = useState(snaUrl ?? "");
+  const explicitUrl = connection?.baseUrl ?? snaUrl;
+  const explicitAuthToken = connection?.authToken ?? authToken;
+  const [resolvedUrl, setResolvedUrl] = useState(explicitUrl ?? "");
+  const [resolvedAuthToken, setResolvedAuthToken] = useState(explicitAuthToken);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     async function discover() {
-      if (snaUrl) {
-        setResolvedUrl(snaUrl);
-        return snaUrl;
+      if (explicitUrl) {
+        setResolvedUrl(explicitUrl);
+        setResolvedAuthToken(explicitAuthToken);
+        return { url: explicitUrl, token: explicitAuthToken };
       }
       try {
         const res = await fetch("/api/sna-port");
         const data = await res.json();
+        const discoveredToken = typeof data.authToken === "string" ? data.authToken : undefined;
+        if (typeof data.baseUrl === "string") {
+          setResolvedUrl(data.baseUrl);
+          setResolvedAuthToken(discoveredToken);
+          return { url: data.baseUrl, token: discoveredToken };
+        }
         if (data.port) {
           const url = `http://localhost:${data.port}`;
           setResolvedUrl(url);
-          return url;
+          setResolvedAuthToken(discoveredToken);
+          return { url, token: discoveredToken };
         }
       } catch { /* no endpoint */ }
       const fallback = DEFAULT_SNA_URL;
       setResolvedUrl(fallback);
-      return fallback;
+      setResolvedAuthToken(undefined);
+      return { url: fallback, token: undefined };
     }
 
-    discover().then((url) => {
+    discover().then(({ url, token }) => {
       useChatStore.getState()._setApiUrl(url);
-      useChatStore.getState()._setAuthToken(authToken);
+      useChatStore.getState()._setAuthToken(token);
       if (shouldHydrate) {
         useChatStore.getState().hydrate();
       }
     });
-  }, [snaUrl, authToken, shouldHydrate]);
+  }, [explicitUrl, explicitAuthToken, shouldHydrate]);
 
   return (
-    <SnaContext.Provider value={{ apiUrl: resolvedUrl, authToken, sessionId }}>
+    <SnaContext.Provider value={{ apiUrl: resolvedUrl, authToken: resolvedAuthToken, sessionId }}>
       {children}
     </SnaContext.Provider>
   );

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -14,6 +14,8 @@ export interface SnaConfig {
    * Override via <SnaProvider snaUrl="..."> for custom deployments.
    */
   apiUrl: string;
+  /** Bearer token issued by the SNA server. */
+  authToken?: string;
   /**
    * Active session ID for this scope.
    * Set by <SnaSession id="...">. Defaults to "default".
@@ -25,6 +27,17 @@ export const SnaContext = createContext<SnaConfig>({ apiUrl: DEFAULT_SNA_URL, se
 
 export function useSnaContext(): SnaConfig {
   return useContext(SnaContext);
+}
+
+export function authHeaders(
+  authToken: string | undefined,
+  headers: Record<string, string> = {},
+): Record<string, string> | undefined {
+  const next = { ...headers };
+  if (authToken) {
+    next.Authorization = `Bearer ${authToken}`;
+  }
+  return Object.keys(next).length > 0 ? next : undefined;
 }
 
 export { DEFAULT_SNA_URL };

--- a/packages/react/src/hooks/use-agent.ts
+++ b/packages/react/src/hooks/use-agent.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import type { AgentEvent } from "@sna-sdk/core";
-import { useSnaContext } from "../context.js";
+import { authHeaders, useSnaContext } from "../context.js";
 
 export type { AgentEvent };
 
@@ -11,6 +11,8 @@ interface UseAgentOptions {
   sessionId?: string;
   /** Override base URL for agent API. Defaults to SnaContext apiUrl + "/agent" */
   baseUrl?: string;
+  /** Override bearer token. Defaults to SnaContext authToken. */
+  authToken?: string;
   /** Provider name. Defaults to "claude-code" */
   provider?: string;
   /** Permission mode for the agent */
@@ -49,6 +51,7 @@ export function useAgent(options: UseAgentOptions = {}) {
   const {
     sessionId = ctx.sessionId,
     baseUrl = `${ctx.apiUrl}/agent`,
+    authToken = ctx.authToken,
     provider = "claude-code",
     permissionMode,
     reasoningLevel,
@@ -59,7 +62,7 @@ export function useAgent(options: UseAgentOptions = {}) {
 
   const [connected, setConnected] = useState(false);
   const [alive, setAlive] = useState(false);
-  const esRef = useRef<EventSource | null>(null);
+  const streamAbortRef = useRef<AbortController | null>(null);
 
   const onEventRef = useRef(options.onEvent);
   const onThinkingRef = useRef(options.onThinking);
@@ -84,7 +87,9 @@ export function useAgent(options: UseAgentOptions = {}) {
       // Get current event count so we only receive NEW events
       let cursor = 0;
       try {
-        const res = await fetch(`${baseUrl}/status?${sessionParam}`);
+        const res = await fetch(`${baseUrl}/status?${sessionParam}`, {
+          headers: authHeaders(authToken),
+        });
         const data = await res.json();
         cursor = data.eventCount ?? 0;
         if (data.alive) setAlive(true);
@@ -92,35 +97,41 @@ export function useAgent(options: UseAgentOptions = {}) {
 
       function connect() {
         if (disposed) return;
-        if (esRef.current) esRef.current.close();
+        streamAbortRef.current?.abort();
 
-        const es = new EventSource(`${baseUrl}/events?${sessionParam}&since=${cursor}`);
-        esRef.current = es;
+        const ctrl = new AbortController();
+        streamAbortRef.current = ctrl;
 
-        es.onopen = () => setConnected(true);
+        fetch(`${baseUrl}/events?${sessionParam}&since=${cursor}`, {
+          headers: authHeaders(authToken, { Accept: "text/event-stream" }),
+          signal: ctrl.signal,
+        })
+          .then(async (res) => {
+            if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`);
+            setConnected(true);
+            await readSse(res, {
+              onId: (id) => { cursor = parseInt(id, 10); },
+              onData: (data) => {
+                if (!data || disposed) return;
+                try {
+                  const event: AgentEvent = JSON.parse(data);
+                  onEventRef.current?.(event);
 
-        es.onmessage = (e) => {
-          if (!e.data || disposed) return;
-          // Track cursor from SSE id
-          if (e.lastEventId) cursor = parseInt(e.lastEventId, 10);
-          try {
-            const event: AgentEvent = JSON.parse(e.data);
-            onEventRef.current?.(event);
-
-            if (event.type === "init") onInitRef.current?.(event);
-            if (event.type === "thinking") onThinkingRef.current?.(event);
-            if (event.type === "assistant") onAssistantRef.current?.(event);
-            if (event.type === "tool_result") onToolResultRef.current?.(event);
-            if (event.type === "complete") onCompleteRef.current?.(event);
-            if (event.type === "error") onErrorRef.current?.(event);
-          } catch { /* malformed */ }
-        };
-
-        es.onerror = () => {
-          setConnected(false);
-          es.close();
-          if (!disposed) setTimeout(connect, 3000);
-        };
+                  if (event.type === "init") onInitRef.current?.(event);
+                  if (event.type === "thinking") onThinkingRef.current?.(event);
+                  if (event.type === "assistant") onAssistantRef.current?.(event);
+                  if (event.type === "tool_result") onToolResultRef.current?.(event);
+                  if (event.type === "complete") onCompleteRef.current?.(event);
+                  if (event.type === "error") onErrorRef.current?.(event);
+                } catch { /* malformed */ }
+              },
+            });
+          })
+          .catch(() => { /* reconnect below */ })
+          .finally(() => {
+            setConnected(false);
+            if (!disposed && !ctrl.signal.aborted) setTimeout(connect, 3000);
+          });
       }
 
       connect();
@@ -130,10 +141,10 @@ export function useAgent(options: UseAgentOptions = {}) {
 
     return () => {
       disposed = true;
-      esRef.current?.close();
+      streamAbortRef.current?.abort();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [baseUrl, sessionParam]);
+  }, [baseUrl, sessionParam, authToken]);
 
   // Send message to agent
   const send = useCallback(async (message: string) => {
@@ -142,7 +153,7 @@ export function useAgent(options: UseAgentOptions = {}) {
     try {
       const res = await fetch(`${baseUrl}/send?${sessionParam}`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: authHeaders(authToken, { "Content-Type": "application/json" }),
         body: JSON.stringify({ message }),
       });
       const data = await res.json();
@@ -152,13 +163,13 @@ export function useAgent(options: UseAgentOptions = {}) {
       console.error("[useAgent:send] FAILED:", err);
       return { status: "error", message: String(err) };
     }
-  }, [baseUrl, sessionParam, sessionId]);
+  }, [baseUrl, sessionParam, sessionId, authToken]);
 
   // Start agent session (if not already running)
   const start = useCallback(async (prompt?: string) => {
     const res = await fetch(`${baseUrl}/start?${sessionParam}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders(authToken, { "Content-Type": "application/json" }),
       body: JSON.stringify({ provider, prompt, permissionMode, reasoningLevel, providerOptions }),
     });
     const data = await res.json();
@@ -166,13 +177,16 @@ export function useAgent(options: UseAgentOptions = {}) {
       setAlive(true);
     }
     return data;
-  }, [baseUrl, sessionParam, provider, permissionMode, reasoningLevel, providerOptions]);
+  }, [baseUrl, sessionParam, authToken, provider, permissionMode, reasoningLevel, providerOptions]);
 
   // Kill agent
   const kill = useCallback(async () => {
     setAlive(false);
-    await fetch(`${baseUrl}/kill?${sessionParam}`, { method: "POST" });
-  }, [baseUrl, sessionParam]);
+    await fetch(`${baseUrl}/kill?${sessionParam}`, {
+      method: "POST",
+      headers: authHeaders(authToken),
+    });
+  }, [baseUrl, sessionParam, authToken]);
 
   // One-shot completion
   const completion = useCallback(async (opts: {
@@ -186,7 +200,7 @@ export function useAgent(options: UseAgentOptions = {}) {
   }) => {
     const res = await fetch(`${baseUrl}/completion`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders(authToken, { "Content-Type": "application/json" }),
       body: JSON.stringify({
         provider,
         reasoningLevel,
@@ -194,7 +208,47 @@ export function useAgent(options: UseAgentOptions = {}) {
       }),
     });
     return res.json();
-  }, [baseUrl, provider, reasoningLevel]);
+  }, [baseUrl, authToken, provider, reasoningLevel]);
 
   return { connected, alive, start, send, kill, completion };
+}
+
+async function readSse(
+  response: Response,
+  handlers: { onId: (id: string) => void; onData: (data: string) => void },
+): Promise<void> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let eventId = "";
+  let data = "";
+
+  const flush = () => {
+    if (eventId) handlers.onId(eventId);
+    if (data) handlers.onData(data.replace(/\n$/, ""));
+    eventId = "";
+    data = "";
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line === "") {
+          flush();
+        } else if (line.startsWith("id:")) {
+          eventId = line.slice(3).trim();
+        } else if (line.startsWith("data:")) {
+          data += `${line.slice(5).trimStart()}\n`;
+        }
+      }
+    }
+    if (buffer) flush();
+  } finally {
+    reader.releaseLock();
+  }
 }

--- a/packages/react/src/hooks/use-session-manager.ts
+++ b/packages/react/src/hooks/use-session-manager.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import type { SessionInfo } from "@sna-sdk/core";
-import { useSnaContext } from "../context.js";
+import { authHeaders, useSnaContext } from "../context.js";
 
 export type { SessionInfo };
 
@@ -18,7 +18,7 @@ export type { SessionInfo };
  * @param pollInterval - Auto-refresh interval in ms. 0 = no polling. Default 3000.
  */
 export function useSessionManager(pollInterval = 3000) {
-  const { apiUrl } = useSnaContext();
+  const { apiUrl, authToken } = useSnaContext();
   const baseUrl = `${apiUrl}/agent`;
 
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
@@ -27,7 +27,9 @@ export function useSessionManager(pollInterval = 3000) {
 
   const refresh = useCallback(async () => {
     try {
-      const res = await fetch(`${baseUrl}/sessions`);
+      const res = await fetch(`${baseUrl}/sessions`, {
+        headers: authHeaders(authToken),
+      });
       const data = await res.json();
       const next = data.sessions ?? [];
       const json = JSON.stringify(next);
@@ -38,14 +40,14 @@ export function useSessionManager(pollInterval = 3000) {
     } catch {
       // Server not ready
     }
-  }, [baseUrl]);
+  }, [baseUrl, authToken]);
 
   const createSession = useCallback(async (opts?: { label?: string; cwd?: string }): Promise<string | null> => {
     setLoading(true);
     try {
       const res = await fetch(`${baseUrl}/sessions`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: authHeaders(authToken, { "Content-Type": "application/json" }),
         body: JSON.stringify(opts ?? {}),
       });
       const data = await res.json();
@@ -61,25 +63,31 @@ export function useSessionManager(pollInterval = 3000) {
     } finally {
       setLoading(false);
     }
-  }, [baseUrl, refresh]);
+  }, [baseUrl, authToken, refresh]);
 
   const killSession = useCallback(async (id: string) => {
     try {
-      await fetch(`${baseUrl}/kill?session=${encodeURIComponent(id)}`, { method: "POST" });
+      await fetch(`${baseUrl}/kill?session=${encodeURIComponent(id)}`, {
+        method: "POST",
+        headers: authHeaders(authToken),
+      });
       await refresh();
     } catch (err) {
       console.error("[useSessionManager:kill]", err);
     }
-  }, [baseUrl, refresh]);
+  }, [baseUrl, authToken, refresh]);
 
   const deleteSession = useCallback(async (id: string) => {
     try {
-      await fetch(`${baseUrl}/sessions/${encodeURIComponent(id)}`, { method: "DELETE" });
+      await fetch(`${baseUrl}/sessions/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+        headers: authHeaders(authToken),
+      });
       await refresh();
     } catch (err) {
       console.error("[useSessionManager:delete]", err);
     }
-  }, [baseUrl, refresh]);
+  }, [baseUrl, authToken, refresh]);
 
   // Initial fetch + polling
   useEffect(() => {

--- a/packages/react/src/stores/chat-store.ts
+++ b/packages/react/src/stores/chat-store.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { create } from "zustand";
+import { authHeaders } from "../context.js";
 
 export interface ChatMessage {
   id: string;
@@ -27,7 +28,9 @@ interface ChatState {
 
   // API URL for DB sync (set by SnaProvider)
   _apiUrl: string;
+  _authToken?: string;
   _setApiUrl: (url: string) => void;
+  _setAuthToken: (token: string | undefined) => void;
   /** Tracks which sessions have had their messages fetched */
   _hydratedSessions: Set<string>;
 
@@ -74,24 +77,30 @@ function actorKindToRole(actor: string, kind: string): ChatMessage["role"] {
   return "status";
 }
 
-function syncCreateSession(apiUrl: string, id: string, label?: string, type?: string) {
+function syncCreateSession(apiUrl: string, authToken: string | undefined, id: string, label?: string, type?: string) {
   if (!apiUrl) return;
   fetch(`${apiUrl}/chat/sessions`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: authHeaders(authToken, { "Content-Type": "application/json" }),
     body: JSON.stringify({ id, label: label ?? id, type: type ?? "background" }),
   }).catch(() => { /* non-fatal */ });
 }
 
-function syncDeleteSession(apiUrl: string, id: string) {
+function syncDeleteSession(apiUrl: string, authToken: string | undefined, id: string) {
   if (!apiUrl) return;
-  fetch(`${apiUrl}/chat/sessions/${encodeURIComponent(id)}`, { method: "DELETE" })
+  fetch(`${apiUrl}/chat/sessions/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: authHeaders(authToken),
+  })
     .catch(() => { /* non-fatal */ });
 }
 
-function syncClearMessages(apiUrl: string, sessionId: string) {
+function syncClearMessages(apiUrl: string, authToken: string | undefined, sessionId: string) {
   if (!apiUrl) return;
-  fetch(`${apiUrl}/chat/sessions/${encodeURIComponent(sessionId)}/messages`, { method: "DELETE" })
+  fetch(`${apiUrl}/chat/sessions/${encodeURIComponent(sessionId)}/messages`, {
+    method: "DELETE",
+    headers: authHeaders(authToken),
+  })
     .catch(() => { /* non-fatal */ });
 }
 
@@ -102,7 +111,9 @@ export const useChatStore = create<ChatState>()(
     activeSessionId: "default",
     sessions: { default: emptySession() },
     _apiUrl: "",
+    _authToken: undefined,
     _setApiUrl: (url) => set({ _apiUrl: url }),
+    _setAuthToken: (token) => set({ _authToken: token }),
     _hydratedSessions: new Set<string>(),
 
     setOpen: (open) => set({ isOpen: open }),
@@ -124,7 +135,7 @@ export const useChatStore = create<ChatState>()(
       const s = get().sessions;
       if (!s[id]) {
         set({ sessions: { ...s, [id]: emptySession() } });
-        syncCreateSession(get()._apiUrl, id);
+        syncCreateSession(get()._apiUrl, get()._authToken, id);
       }
     },
 
@@ -134,7 +145,7 @@ export const useChatStore = create<ChatState>()(
       delete s[id];
       const activeSessionId = get().activeSessionId === id ? "default" : get().activeSessionId;
       set({ sessions: s, activeSessionId });
-      syncDeleteSession(get()._apiUrl, id);
+      syncDeleteSession(get()._apiUrl, get()._authToken, id);
     },
 
     addMessage: (msg, sessionId?) => {
@@ -164,7 +175,7 @@ export const useChatStore = create<ChatState>()(
           [id]: emptySession(),
         },
       }));
-      syncClearMessages(get()._apiUrl, id);
+      syncClearMessages(get()._apiUrl, get()._authToken, id);
     },
 
     markEventProcessed: (eventId, sessionId?) => {
@@ -195,7 +206,9 @@ export const useChatStore = create<ChatState>()(
 
       try {
         // Fetch session metadata only — no messages
-        const sessRes = await fetch(`${apiUrl}/chat/sessions`);
+        const sessRes = await fetch(`${apiUrl}/chat/sessions`, {
+          headers: authHeaders(get()._authToken),
+        });
         const sessData = await sessRes.json();
         const dbSessions = sessData.sessions as Array<{ id: string; label: string; type: string }>;
 
@@ -232,7 +245,8 @@ export const useChatStore = create<ChatState>()(
 
       try {
         const msgRes = await fetch(
-          `${apiUrl}/chat/sessions/${encodeURIComponent(sessionId)}/messages`
+          `${apiUrl}/chat/sessions/${encodeURIComponent(sessionId)}/messages`,
+          { headers: authHeaders(get()._authToken) },
         );
         const msgData = await msgRes.json();
         const messages = (msgData.messages as Array<{

--- a/packages/react/test/react-doc-surfaces.test.ts
+++ b/packages/react/test/react-doc-surfaces.test.ts
@@ -14,6 +14,7 @@ import { useChatStore, type ChatMessage } from "../src/stores/chat-store.js";
 type FetchRequest = {
   url: string;
   method: string;
+  headers: Record<string, string>;
   body?: unknown;
 };
 
@@ -112,6 +113,7 @@ function installFetch(responses: MockResponse[] | ((request: FetchRequest) => un
     const request = {
       url: String(input),
       method: init?.method ?? "GET",
+      headers: Object.fromEntries(new Headers(init?.headers).entries()),
       body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
     };
     requests.push(request);
@@ -119,8 +121,10 @@ function installFetch(responses: MockResponse[] | ((request: FetchRequest) => un
     const body = Array.isArray(responses)
       ? typeof responses[0] === "function"
         ? await (responses.shift() as (request: FetchRequest) => unknown | Promise<unknown>)(request)
-        : responses.shift() ?? {}
+      : responses.shift() ?? {}
       : await responses(request);
+
+    if (body instanceof Response) return body;
 
     return new Response(JSON.stringify(body ?? {}), {
       status: 200,
@@ -157,10 +161,31 @@ async function flush() {
   });
 }
 
-function contextProvider(children: React.ReactNode, sessionId = "default") {
+function createSseStream() {
+  const encoder = new TextEncoder();
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) { controller = c; },
+  });
+
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }),
+    send(event: Record<string, unknown>, id?: string) {
+      controller.enqueue(encoder.encode(`${id ? `id: ${id}\n` : ""}data: ${JSON.stringify(event)}\n\n`));
+    },
+    close() {
+      controller.close();
+    },
+  };
+}
+
+function contextProvider(children: React.ReactNode, sessionId = "default", authToken?: string) {
   return React.createElement(
     SnaContext.Provider,
-    { value: { apiUrl: "http://localhost:3099", sessionId } },
+    { value: { apiUrl: "http://localhost:3099", authToken, sessionId } },
     children,
   );
 }
@@ -324,10 +349,11 @@ describe("React documented surfaces", () => {
 
   it("useAgent opens the SSE stream, dispatches filtered callbacks, and posts documented commands", async () => {
     installWindow();
-    const sources = installEventSource();
+    const sse = createSseStream();
     const seen: string[] = [];
     const requests = installFetch((request) => {
       if (request.url.includes("/agent/status")) return { eventCount: 7, alive: true };
+      if (request.url.includes("/agent/events")) return sse.response;
       if (request.url.includes("/agent/start")) return { status: "started" };
       if (request.url.includes("/agent/send")) return { status: "sent" };
       if (request.url.includes("/agent/completion")) return { content: "done" };
@@ -352,23 +378,19 @@ describe("React documented surfaces", () => {
       return null;
     }
 
-    await render(contextProvider(React.createElement(Capture), "agent one"));
+    await render(contextProvider(React.createElement(Capture), "agent one", "test-token"));
 
     assert.equal(requests[0].url, "http://localhost:3099/agent/status?session=agent%20one");
-    assert.equal(sources[0].url, "http://localhost:3099/agent/events?session=agent%20one&since=7");
+    assert.equal(requests[0].headers.authorization, "Bearer test-token");
+    assert.equal(requests[1].url, "http://localhost:3099/agent/events?session=agent%20one&since=7");
+    assert.equal(requests[1].headers.authorization, "Bearer test-token");
     assert.equal(agent?.alive, true);
-
-    await act(async () => {
-      sources[0].onopen?.({} as Event);
-    });
     assert.equal(agent?.connected, true);
 
     for (const type of ["init", "thinking", "assistant", "tool_result", "complete", "error"] as const) {
       await act(async () => {
-        sources[0].onmessage?.({
-          data: JSON.stringify({ type, message: type }),
-          lastEventId: "8",
-        } as MessageEvent);
+        sse.send({ type, message: type }, "8");
+        await Promise.resolve();
       });
     }
 
@@ -392,34 +414,37 @@ describe("React documented surfaces", () => {
       await agent!.kill();
     });
 
-    assert.equal(requests[1].url, "http://localhost:3099/agent/start?session=agent%20one");
-    assert.deepEqual(requests[1].body, {
+    assert.equal(requests[2].url, "http://localhost:3099/agent/start?session=agent%20one");
+    assert.deepEqual(requests[2].body, {
       provider: "codex",
       prompt: "boot",
       permissionMode: "acceptEdits",
       reasoningLevel: 2,
       providerOptions: { serviceTier: "priority" },
     });
-    assert.equal(requests[2].url, "http://localhost:3099/agent/send?session=agent%20one");
-    assert.deepEqual(requests[2].body, { message: "hello" });
-    assert.equal(requests[3].url, "http://localhost:3099/agent/completion");
-    assert.deepEqual(requests[3].body, {
+    assert.equal(requests[2].headers.authorization, "Bearer test-token");
+    assert.equal(requests[3].url, "http://localhost:3099/agent/send?session=agent%20one");
+    assert.deepEqual(requests[3].body, { message: "hello" });
+    assert.equal(requests[4].url, "http://localhost:3099/agent/completion");
+    assert.deepEqual(requests[4].body, {
       provider: "codex",
       reasoningLevel: 3,
       prompt: "summarize",
       providerOptions: { serviceTier: "batch" },
     });
-    assert.equal(requests[4].url, "http://localhost:3099/agent/kill?session=agent%20one");
-    assert.equal(requests[4].method, "POST");
+    assert.equal(requests[5].url, "http://localhost:3099/agent/kill?session=agent%20one");
+    assert.equal(requests[5].method, "POST");
     assert.equal(agent?.alive, false);
   });
 
   it("useAgent closes the stream and schedules the documented reconnect delay on SSE error", async () => {
     installWindow();
-    const sources = installEventSource();
-    installFetch((request) => request.url.includes("/agent/status")
-      ? { eventCount: 0, alive: false }
-      : { status: "ok" });
+    const sse = createSseStream();
+    installFetch((request) => {
+      if (request.url.includes("/agent/status")) return { eventCount: 0, alive: false };
+      if (request.url.includes("/agent/events")) return sse.response;
+      return { status: "ok" };
+    });
     let agent: ReturnType<typeof useAgent> | undefined;
 
     function Capture() {
@@ -428,9 +453,6 @@ describe("React documented surfaces", () => {
     }
 
     await render(contextProvider(React.createElement(Capture)));
-    await act(async () => {
-      sources[0].onopen?.({} as Event);
-    });
     assert.equal(agent?.connected, true);
 
     const originalSetTimeout = globalThis.setTimeout;
@@ -441,13 +463,13 @@ describe("React documented surfaces", () => {
     }) as typeof setTimeout;
     try {
       await act(async () => {
-        sources[0].onerror?.({} as Event);
+        sse.close();
+        await Promise.resolve();
       });
     } finally {
       globalThis.setTimeout = originalSetTimeout;
     }
 
-    assert.equal(sources[0].closed, true);
     assert.equal(agent?.connected, false);
     assert.deepEqual(scheduled, [{ delay: 3000 }]);
   });

--- a/packages/react/test/react-doc-surfaces.test.ts
+++ b/packages/react/test/react-doc-surfaces.test.ts
@@ -65,6 +65,7 @@ function resetStore() {
     activeSessionId: "default",
     sessions: { default: emptySession() },
     _apiUrl: "",
+    _authToken: undefined,
     _hydratedSessions: new Set<string>(),
   });
 }
@@ -245,6 +246,32 @@ describe("React documented surfaces", () => {
     assert.equal(sessionContext?.apiUrl, "http://localhost:4242");
     assert.equal(sessionContext?.sessionId, "review-panel");
     assert.equal(useChatStore.getState()._apiUrl, "http://localhost:4242");
+  });
+
+  it("SnaProvider accepts a launcher connection object", async () => {
+    installWindow();
+    const requests = installFetch([]);
+    let providerContext: ReturnType<typeof useSnaContext> | undefined;
+
+    function Capture() {
+      providerContext = useSnaContext();
+      return null;
+    }
+
+    await render(React.createElement(
+      SnaProvider,
+      {
+        connection: { baseUrl: "http://localhost:4242", authToken: "secret-token" },
+        hydrate: false,
+      },
+      React.createElement(Capture),
+    ));
+
+    assert.equal(requests.length, 0);
+    assert.equal(providerContext?.apiUrl, "http://localhost:4242");
+    assert.equal(providerContext?.authToken, "secret-token");
+    assert.equal(useChatStore.getState()._apiUrl, "http://localhost:4242");
+    assert.equal(useChatStore.getState()._authToken, "secret-token");
   });
 
   it("SnaProvider hydrates the chat store by default and can skip hydration", async () => {


### PR DESCRIPTION
## Summary

- Require launcher-issued auth for protected local SNA HTTP and WebSocket routes, with browser origin allowlisting.
- Return `host`, `appId`, and a portable `connection` object from SDK launchers so SDK clients do not handle `authToken` separately.
- Tag created agent/chat sessions with the configured `appId` and prevent consumer env overrides from spoofing launcher-owned identity/security values.
- Refresh README, SDK docs, introduction pages, and cookbook examples for the secure embedded-server flow, runtime terminology, and `connection`-based client setup.

## Validation

- `pnpm --filter @sna-sdk/core test` (385 passing tests)
- `pnpm --filter @sna-sdk/client test` (111 passing tests)
- `pnpm --filter @sna-sdk/react test` (19 passing tests)
- `pnpm --filter @sna-sdk/testing test` (21 passing tests)
- `pnpm --filter @sna-sdk/core build`
- `pnpm --filter @sna-sdk/client build`
- `pnpm --filter @sna-sdk/react build`
- `pnpm --filter docs types:check`
- `git diff --check`

## Notes

This keeps the direct standalone server path available for development/debugging, but the documented SDK path now treats the spawned local SNA server as a process-owned child with an ephemeral token carried through `sna.connection`.