### PR TITLE
[codex] Document SNA auth in OpenAPI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ See [docs/architecture.md](docs/architecture.md) for the full picture. Quick map
 
 #### Server (`@sna-sdk/core`)
 
-`createSnaApp({ sessionManager })` returns an `OpenAPIHono` app exposing the full HTTP API plus its own OpenAPI 3.1 spec (`GET /openapi.json`, Swagger UI at `/docs`, plain-text viewer at `/spec`). `attachWebSocket(server, sessionManager)` mounts the WS handler on `/ws`. The standalone entry (`server/standalone.ts`) wires both up and is what the launcher API forks.
+`createSnaApp({ sessionManager, authToken })` returns an `OpenAPIHono` app exposing the full HTTP API plus its own OpenAPI 3.1 spec (`GET /openapi.json`, Swagger UI at `/docs`, plain-text viewer at `/spec`). All HTTP routes except `GET /health` require the bearer token, and the OpenAPI document declares `bearerAuth`, `401`, and `403` on protected operations. `attachWebSocket(server, sessionManager, { authToken })` mounts the WS handler on `/ws` with the same token. The standalone entry (`server/standalone.ts`) wires both up and is what the launcher API forks.
 
 The `SessionManager` owns every running agent. Each `Session` carries a `process` (Claude Code or Codex subprocess), a per-session event buffer, the current `SessionConfig` (legacy name: `StartConfig`, kept as an alias), and metadata. Every config mutation appends a `RuntimeSession` row to the chain in `runtime_sessions`; `Session.currentRuntimeId` points at the active one. Listeners cover lifecycle, config changes, state changes, agent events, permission requests, and skill events.
 
@@ -47,7 +47,7 @@ Binary attachments live in `embeds` JSON keyed by id; content text holds inline 
 
 #### Transports
 
-HTTP routes (`server/routes/{agent,chat}.ts`) cover state-changing ops with ordering guarantees. The WebSocket handler (`server/ws.ts`) wraps the same operations and adds push channels (`agent.event`, `sessions.snapshot`, `permission.request`, `session.lifecycle`).
+HTTP routes (`server/routes/{agent,chat}.ts`) cover state-changing ops with ordering guarantees. Protected HTTP and SSE calls use `Authorization: Bearer <authToken>`. The WebSocket handler (`server/ws.ts`) wraps the same operations, authenticates upgrades through bearer headers, `X-SNA-Token`, or `?token=...`, and adds push channels (`agent.event`, `sessions.snapshot`, `permission.request`, `session.lifecycle`).
 
 `server/api-types.ts` is the single source of truth for response shapes — both HTTP and WS use the typed helpers `httpJson` / `wsReply`, so drift between the two transports is a TypeScript error.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ client.disconnect();
 sna.stop();
 ```
 
-> Launchers bind to `127.0.0.1` by default, generate an auth token, and tag sessions with `appId`. SDK clients should pass the returned `sna.connection` object instead of handling the token separately. Direct standalone server usage is intended for development/debugging and must set `SNA_AUTH_TOKEN` explicitly.
+> Launchers bind to `127.0.0.1` by default, generate an auth token, and tag sessions with `appId`. SDK clients should pass the returned `sna.connection` object instead of handling the token separately. Protected HTTP and SSE routes use `Authorization: Bearer <authToken>`, and browser WebSocket upgrades use `/ws?token=<authToken>`. Direct standalone server usage is intended for development/debugging and must set `SNA_AUTH_TOKEN` explicitly.
 
 ### As a React app
 

--- a/apps/docs/content/docs/api/endpoints/meta.ja.json
+++ b/apps/docs/content/docs/api/endpoints/meta.ja.json
@@ -3,6 +3,7 @@
   "description": "OpenAPI からレンダリングした HTTP エンドポイントリファレンスです。",
   "icon": "Route",
   "pages": [
+    "index",
     "---システム---",
     "health/get",
     "api/sna-port/get",

--- a/apps/docs/content/docs/api/endpoints/meta.json
+++ b/apps/docs/content/docs/api/endpoints/meta.json
@@ -3,6 +3,7 @@
   "description": "OpenAPI-rendered HTTP endpoint reference.",
   "icon": "Route",
   "pages": [
+    "index",
     "---System---",
     "health/get",
     "api/sna-port/get",

--- a/apps/docs/content/docs/api/endpoints/meta.ko.json
+++ b/apps/docs/content/docs/api/endpoints/meta.ko.json
@@ -3,6 +3,7 @@
   "description": "OpenAPI에서 렌더링한 HTTP 엔드포인트 레퍼런스입니다.",
   "icon": "Route",
   "pages": [
+    "index",
     "---시스템---",
     "health/get",
     "api/sna-port/get",

--- a/apps/docs/content/docs/api/http.ja.mdx
+++ b/apps/docs/content/docs/api/http.ja.mdx
@@ -6,6 +6,18 @@ icon: Network
 
 HTTP API は表面別にまとまっています。以下の各パスはエンドポイント別の詳細仕様ページへリンクします。
 
+## 認証
+
+`GET /health` は公開されています。SNA ランタイムのその他すべてのルートは
+`/api/sna-port`、SSE ルート、chat image 取得も含めて
+`Authorization: Bearer <authToken>` を要求します。トークンがない場合や
+一致しない場合は `401`、許可されていない browser origin は `403` を返します。
+
+SDK が管理する host では、`handle.connection` を `SnaClient` または
+`SnaProvider` に渡します。別の app-owned discovery endpoint が信頼済み
+renderer に `{ baseUrl, authToken }` を返すことはできますが、SNA ランタイム
+自身の `/api/sna-port` ルートは引き続き保護されます。
+
 ## システム
 
 | メソッド | パス | 用途 |

--- a/apps/docs/content/docs/api/http.ko.mdx
+++ b/apps/docs/content/docs/api/http.ko.mdx
@@ -6,6 +6,18 @@ icon: Network
 
 HTTP API는 표면별로 묶여 있습니다. 아래 각 경로는 엔드포인트별 상세 명세 페이지로 연결됩니다.
 
+## 인증
+
+`GET /health`는 공개되어 있습니다. SNA 런타임의 그 밖의 모든 라우트는
+`/api/sna-port`, SSE 라우트, chat image 조회를 포함해
+`Authorization: Bearer <authToken>`을 요구합니다. 토큰이 없거나 맞지 않으면
+`401`, 허용되지 않은 browser origin이면 `403`을 반환합니다.
+
+SDK가 관리하는 host는 `handle.connection`을 `SnaClient`나 `SnaProvider`에
+전달하면 됩니다. 별도의 앱 소유 discovery endpoint가 신뢰된 renderer에
+`{ baseUrl, authToken }`을 반환할 수 있지만, SNA 런타임 자체의
+`/api/sna-port` 라우트는 계속 보호됩니다.
+
 ## 시스템
 
 | 메서드 | 경로 | 용도 |

--- a/apps/docs/content/docs/api/http.mdx
+++ b/apps/docs/content/docs/api/http.mdx
@@ -6,6 +6,18 @@ icon: Network
 
 The HTTP API is grouped by surface. Each path below links to a dedicated endpoint specification page.
 
+## Authentication
+
+`GET /health` is public. Every other route on the SNA runtime requires
+`Authorization: Bearer <authToken>`, including `/api/sna-port`, SSE
+routes, and chat image reads. Missing or invalid tokens return `401`;
+browser requests from disallowed origins return `403`.
+
+SDK-managed hosts should pass `handle.connection` to `SnaClient` or
+`SnaProvider`. A separate app-owned discovery endpoint may return
+`{ baseUrl, authToken }` to a trusted renderer, but the SNA runtime's
+own `/api/sna-port` route is still protected.
+
 ## System
 
 | Method | Path | Purpose |

--- a/apps/docs/content/docs/api/index.ja.mdx
+++ b/apps/docs/content/docs/api/index.ja.mdx
@@ -30,5 +30,16 @@ SNA の HTTP/WebSocket API と ACP を比較している場合は、
 | `GET /docs` | Swagger UI |
 | `GET /spec` | プレーンテキスト仕様 |
 
+## 認証
+
+`GET /health` 以外のランタイム HTTP ルートは
+`Authorization: Bearer <authToken>` を要求します。SSE ストリームと
+WebSocket upgrade も同じトークンで保護されます。SDK ランチャーはこの値を
+`handle.connection.authToken` として返すため、クライアントには
+`handle.connection` をそのまま渡すのが安全です。
+
+OpenAPI ドキュメントは global `bearerAuth` を宣言し、`/health` の
+security は空にし、保護されたルートに `401`/`403` response を表示します。
+
 正確な契約を確認する場合は、ライブサーバのスペックを直接見てください。
 ライブスペックが常に最終基準です。

--- a/apps/docs/content/docs/api/index.ko.mdx
+++ b/apps/docs/content/docs/api/index.ko.mdx
@@ -30,5 +30,16 @@ SNA의 HTTP/WebSocket API와 ACP를 비교하고 있다면
 | `GET /docs` | Swagger UI |
 | `GET /spec` | 평문 스펙 |
 
+## 인증
+
+`GET /health`를 제외한 모든 런타임 HTTP 라우트는
+`Authorization: Bearer <authToken>`을 요구합니다. SSE 스트림과 WebSocket
+upgrade도 같은 토큰으로 보호됩니다. SDK 런처는 이 값을
+`handle.connection.authToken`으로 반환하므로 클라이언트에는
+`handle.connection`을 그대로 전달하는 편이 안전합니다.
+
+OpenAPI 문서는 전역 `bearerAuth`를 선언하고, `/health`의 보안 요구사항은
+비우며, 보호된 라우트에 `401`/`403` 응답을 표시합니다.
+
 정확한 계약을 확인해야 할 때는 라이브 서버의 스펙을 직접 조회하세요.
 라이브 스펙이 항상 최종 기준입니다.

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -30,5 +30,16 @@ see here, the SDK types, and the live spec can't drift.
 | `GET /docs` | Swagger UI |
 | `GET /spec` | Plain text spec |
 
+## Authentication
+
+All runtime HTTP routes except `GET /health` require
+`Authorization: Bearer <authToken>`. The same token protects SSE
+streams and WebSocket upgrades. SDK launchers return it as
+`handle.connection.authToken`, and clients should pass
+`handle.connection` through intact.
+
+The OpenAPI document declares global `bearerAuth`, clears security on
+`/health`, and lists `401`/`403` responses on protected routes.
+
 When in doubt, hit the live server: it's always more authoritative than
 this page.

--- a/apps/docs/content/docs/api/openapi.ja.mdx
+++ b/apps/docs/content/docs/api/openapi.ja.mdx
@@ -21,6 +21,18 @@ Hono サーバはルートが使うのと同じ Zod スキーマから生成し�
 
 `3099` は `startSnaServer({ port })` が返したポートに置き換えてください。
 
+## 認証契約
+
+ランタイム仕様は `components.securitySchemes.bearerAuth` を含み、document
+level に `security: [{ bearerAuth: [] }]` を設定します。`GET /health` だけが
+公開 operation で、`security: []` として示されます。保護された operation
+には標準 error envelope を使う共通の `401` と `403` response が含まれます。
+
+`/openapi.json`、`/docs`、`/spec` に直接アクセスする場合も、他のランタイム
+ルートと同じ認証 middleware を通ります。静的ドキュメント生成では docs build
+script 内だけで `unsafeDisableAuth` を使うため、live secret なしで published
+reference を生成できます。
+
 ## ユースケース
 
 - **他言語クライアントを生成。** `/openapi.json` に任意の OpenAPI

--- a/apps/docs/content/docs/api/openapi.ko.mdx
+++ b/apps/docs/content/docs/api/openapi.ko.mdx
@@ -20,6 +20,18 @@ Hono 서버는 라우트가 쓰는 같은 Zod 스키마에서 생성한 OpenAPI 
 
 `3099`는 `startSnaServer({ port })`가 반환한 포트로 바꿔서 사용하세요.
 
+## 인증 계약
+
+런타임 스펙은 `components.securitySchemes.bearerAuth`를 포함하고 문서 레벨에
+`security: [{ bearerAuth: [] }]`를 설정합니다. `GET /health`만 공개 operation이며
+`security: []`로 표시됩니다. 보호된 operation에는 표준 error envelope을 쓰는
+공통 `401`과 `403` 응답이 포함됩니다.
+
+`/openapi.json`, `/docs`, `/spec`에 직접 접근할 때도 다른 런타임 라우트와
+같은 인증 middleware를 거칩니다. 정적 문서 생성은 docs build script 안에서만
+`unsafeDisableAuth`를 사용하므로 라이브 secret 없이 published reference를
+생성할 수 있습니다.
+
 ## 유스케이스
 
 - **다른 언어 클라이언트 생성.** `/openapi.json`에 원하는 OpenAPI

--- a/apps/docs/content/docs/api/openapi.mdx
+++ b/apps/docs/content/docs/api/openapi.mdx
@@ -21,6 +21,19 @@ When the server is running:
 
 Replace `3099` with whatever port `startSnaServer({ port })` returned.
 
+## Authentication contract
+
+The runtime spec includes `components.securitySchemes.bearerAuth` and
+sets `security: [{ bearerAuth: [] }]` at the document level. `GET /health`
+is the only public operation and is marked with `security: []`.
+Protected operations include shared `401` and `403` responses using the
+standard error envelope.
+
+Direct access to `/openapi.json`, `/docs`, and `/spec` goes through the
+same auth middleware as other runtime routes. Static docs generation uses
+`unsafeDisableAuth` only inside the docs build script so the published
+reference can be generated without a live secret.
+
 ## Use cases
 
 - **Generate clients in other languages.** Point any OpenAPI codegen

--- a/apps/docs/content/docs/api/websocket.ja.mdx
+++ b/apps/docs/content/docs/api/websocket.ja.mdx
@@ -17,6 +17,18 @@ ws://<host>:<port>/ws
 クライアントは一度接続して、その単一接続上にすべてのセッションを
 多重化します。
 
+## 認証
+
+WebSocket upgrade は保護された HTTP ルートと同じトークンを要求します。
+Browser client は任意の upgrade header を設定できないため、TypeScript
+client はトークンを `ws://<host>:<port>/ws?token=<authToken>` として送ります。
+Native client は upgrade request に `Authorization: Bearer <authToken>` または
+`X-SNA-Token` を使うこともできます。
+
+サーバに origin allowlist がある場合、browser WebSocket 接続は許可された
+`Origin` から来る必要があります。トークン失敗は upgrade を `401` で閉じ、
+origin 失敗は `403` で閉じます。
+
 ## ワイヤ形
 
 すべてのメッセージは `type` と payload を持つ JSON オブジェクトです。

--- a/apps/docs/content/docs/api/websocket.ko.mdx
+++ b/apps/docs/content/docs/api/websocket.ko.mdx
@@ -16,6 +16,18 @@ ws://<host>:<port>/ws
 
 클라이언트가 한 번 연결하고 그 단일 연결로 모든 세션을 다중화합니다.
 
+## 인증
+
+WebSocket upgrade는 보호된 HTTP 라우트와 같은 토큰을 요구합니다. Browser
+client는 임의의 upgrade header를 설정할 수 없으므로 TypeScript client는
+토큰을 `ws://<host>:<port>/ws?token=<authToken>` 형태로 보냅니다. Native
+client는 upgrade 요청에 `Authorization: Bearer <authToken>` 또는
+`X-SNA-Token`을 사용할 수도 있습니다.
+
+서버에 origin allowlist가 있으면 browser WebSocket 연결은 허용된 `Origin`에서
+와야 합니다. 토큰 실패는 upgrade를 `401`로 닫고, origin 실패는 `403`으로
+닫습니다.
+
 ## 와이어 모양
 
 모든 메시지는 `type`과 payload를 가진 JSON 객체입니다.

--- a/apps/docs/content/docs/api/websocket.mdx
+++ b/apps/docs/content/docs/api/websocket.mdx
@@ -17,6 +17,18 @@ ws://<host>:<port>/ws
 The client connects once and multiplexes all sessions over that single
 connection.
 
+## Authentication
+
+WebSocket upgrades require the same token as protected HTTP routes.
+Browser clients cannot set arbitrary upgrade headers, so the TypeScript
+client sends the token as `ws://<host>:<port>/ws?token=<authToken>`.
+Native clients can also use `Authorization: Bearer <authToken>` or
+`X-SNA-Token` on the upgrade request.
+
+If the server has an origin allowlist, browser WebSocket connections must
+come from an allowed `Origin`. Token failures close the upgrade with
+`401`; origin failures close it with `403`.
+
 ## Wire shape
 
 Every message is a JSON object with `type` + payload:

--- a/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ja.mdx
@@ -132,7 +132,9 @@ const sna = await startSnaServerInProcess({
 
 `sna.connection` を `SnaClient` または `SnaProvider` に渡します。Token は
 この server process のために生成され、connection object と一緒に扱われる
-値なので、長期間残るユーザー設定として保存しないでください。
+値なので、長期間残るユーザー設定として保存しない方が安全です。HTTP と SSE
+呼び出しはこの token を `Authorization: Bearer <authToken>` として送り、
+browser WebSocket 接続は upgrade に `/ws?token=<authToken>` を使います。
 
 Forked standalone SNA server では、path change を launch 前に反映するか、SNA を再起動する構成が扱いやすいです。In-process SNA では runtime adapter が同じ process 内で path を resolve するため、host が `process.env.SNA_*_COMMAND` を更新すると以後の spawn に反映できます。
 

--- a/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.ko.mdx
@@ -132,7 +132,9 @@ const sna = await startSnaServerInProcess({
 
 `sna.connection`을 `SnaClient`나 `SnaProvider`에 넘깁니다. Token은 이
 server process를 위해 생성되고 connection object와 함께 묶여 있으므로
-긴 수명의 사용자 설정으로 저장하지 마십시오.
+긴 수명의 사용자 설정으로 저장하지 않습니다. HTTP와 SSE 호출은 이 token을
+`Authorization: Bearer <authToken>`으로 보내고, browser WebSocket 연결은
+upgrade에 `/ws?token=<authToken>`을 사용합니다.
 
 Forked standalone SNA server에서는 path change를 launch 전에 반영하거나 SNA를 재시작하는 구성이 보통 다루기 쉽습니다. In-process SNA에서는 runtime adapter가 같은 process 안에서 path를 resolve하므로, host가 `process.env.SNA_*_COMMAND`를 갱신하면 이후 spawn에 반영될 수 있습니다.
 

--- a/apps/docs/content/docs/cookbook/runtime-setup.mdx
+++ b/apps/docs/content/docs/cookbook/runtime-setup.mdx
@@ -134,7 +134,9 @@ const sna = await startSnaServerInProcess({
 
 Pass `sna.connection` to `SnaClient` or `SnaProvider`. The token is generated
 for this server process and stays paired with that connection object; do not
-store it as a long-lived user setting.
+store it as a long-lived user setting. HTTP and SSE calls use it as
+`Authorization: Bearer <authToken>`, while browser WebSocket connections use
+`/ws?token=<authToken>` for the upgrade.
 
 For a forked standalone SNA server, path changes should usually be applied before launch or by restarting SNA. For in-process SNA, updating `process.env.SNA_*_COMMAND` in the host can affect later spawns because the runtime adapters resolve paths inside the same process.
 

--- a/apps/docs/content/docs/introduction/embedding.ja.mdx
+++ b/apps/docs/content/docs/introduction/embedding.ja.mdx
@@ -72,4 +72,6 @@ const client = new SnaClient(sna.connection);
 自動的に使います。そのため、React アプリでは IPC なしでレンダラが
 ポートを検出できます。Host が同じ信頼済み app endpoint から
 `{ baseUrl, authToken }` を返す場合、`SnaProvider` はその値を connection
-として自動的に使います。
+として自動的に使います。この helper は host app の境界内に置くのが安全です。
+ランタイム自身の `/api/sna-port` ルートは保護されており、同じ token が SSE
+と WebSocket traffic も認証します。

--- a/apps/docs/content/docs/introduction/embedding.ko.mdx
+++ b/apps/docs/content/docs/introduction/embedding.ko.mdx
@@ -70,4 +70,6 @@ const client = new SnaClient(sna.connection);
 `<SnaProvider>`는 `GET /api/sna-port` 헬퍼를 자동으로 사용합니다.
 따라서 React 앱에서는 IPC 없이도 renderer가 포트를 찾을 수 있습니다.
 Host가 같은 신뢰된 app endpoint에서 `{ baseUrl, authToken }`을 반환하면
-`SnaProvider`가 그 값을 connection으로 자동 사용합니다.
+`SnaProvider`가 그 값을 connection으로 자동 사용합니다. 이 helper는 host app
+경계 안에 두는 것이 안전합니다. 런타임 자체의 `/api/sna-port` 라우트는 보호되어
+있고, 같은 token이 SSE와 WebSocket traffic도 인증합니다.

--- a/apps/docs/content/docs/introduction/embedding.mdx
+++ b/apps/docs/content/docs/introduction/embedding.mdx
@@ -70,4 +70,6 @@ const client = new SnaClient(sna.connection);
 A helper endpoint `GET /api/sna-port` is wired by `<SnaProvider>` for
 React apps so the renderer can auto-discover the port without IPC. If your
 host exposes `{ baseUrl, authToken }` from that same trusted app endpoint,
-`SnaProvider` uses it as the connection automatically.
+`SnaProvider` uses it as the connection automatically. Treat that helper as
+part of the host app boundary: the runtime's own `/api/sna-port` route is
+protected, and the token also authenticates SSE and WebSocket traffic.

--- a/apps/docs/content/docs/sdks/client-transport.ja.mdx
+++ b/apps/docs/content/docs/sdks/client-transport.ja.mdx
@@ -42,6 +42,18 @@ const client = new SnaClient({
 | `localhost:3099` | `http://localhost:3099` | `ws://localhost:3099/ws` |
 | `https://sna.example.com` | `https://sna.example.com` | `wss://sna.example.com/ws` |
 
+## 認証動作
+
+`authToken` がある場合、HTTP と SSE request は
+`Authorization: Bearer <authToken>` を送ります。WebSocket 接続は browser
+runtime でも upgrade を認証できるように、同じトークンを
+`?token=<authToken>` として付けます。`baseUrl` と `authToken` がずれないよう、
+launcher の `handle.connection` object を渡すのが安全です。
+
+`401` はトークンがない、またはサーバーと一致しないことを意味します。`403`
+は request が server の `allowedOrigins` にない browser `Origin` から来た
+ことを意味します。
+
 ## `client.connect()`
 
 WebSocket 接続を開始します。すでに接続中または接続済みの場合は no-op です。接続直後に server が `sessions.snapshot` を push することがあるため、session state が必要な UI では `connect` の前に `sessions.onSnapshot` を登録してください。

--- a/apps/docs/content/docs/sdks/client-transport.ko.mdx
+++ b/apps/docs/content/docs/sdks/client-transport.ko.mdx
@@ -42,6 +42,17 @@ const client = new SnaClient({
 | `localhost:3099` | `http://localhost:3099` | `ws://localhost:3099/ws` |
 | `https://sna.example.com` | `https://sna.example.com` | `wss://sna.example.com/ws` |
 
+## 인증 동작
+
+`authToken`이 있으면 HTTP와 SSE 요청은
+`Authorization: Bearer <authToken>`을 보냅니다. WebSocket 연결은 browser
+runtime도 upgrade를 인증할 수 있도록 같은 토큰을 `?token=<authToken>`으로
+붙입니다. `baseUrl`과 `authToken`이 어긋나지 않도록 launcher의
+`handle.connection` object를 전달하는 방식이 가장 안전합니다.
+
+`401`은 토큰이 없거나 서버와 맞지 않는다는 뜻입니다. `403`은 요청이 서버의
+`allowedOrigins`에 없는 browser `Origin`에서 왔다는 뜻입니다.
+
 **Example**
 
 ```ts

--- a/apps/docs/content/docs/sdks/client-transport.mdx
+++ b/apps/docs/content/docs/sdks/client-transport.mdx
@@ -42,6 +42,18 @@ const client = new SnaClient({
 | `localhost:3099` | `http://localhost:3099` | `ws://localhost:3099/ws` |
 | `https://sna.example.com` | `https://sna.example.com` | `wss://sna.example.com/ws` |
 
+## Authentication behavior
+
+When `authToken` is present, HTTP and SSE requests send
+`Authorization: Bearer <authToken>`. WebSocket connections attach the
+same token as `?token=<authToken>` so browser runtimes can authenticate
+the upgrade. Keep `baseUrl` and `authToken` paired by passing the
+launcher's `handle.connection` object.
+
+`401` means the token is missing or does not match the server. `403`
+means the request came from a browser `Origin` that is not listed in the
+server's `allowedOrigins`.
+
 **Example**
 
 ```ts

--- a/apps/docs/content/docs/sdks/core-launchers.ja.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.ja.mdx
@@ -73,6 +73,12 @@ type RuntimePaths = {
 | `runtimePaths` | auto-detect | 明示的なランタイム CLI コマンドまたは絶対パス。`SNA_CLAUDE_COMMAND`、`SNA_CODEX_COMMAND`、`SNA_OPENCODE_COMMAND`、`SNA_GROK_COMMAND`、`SNA_CURSOR_COMMAND` に変換されます。 |
 | `langfuse` | none | Metadata で tracing を opt in した session で Langfuse tracing を有効にします。 |
 
+Launcher は `authToken` と `connection: { baseUrl, authToken }` を一緒に
+返します。Token を保存したり environment variable から組み立てたりせず、
+`connection` を `SnaClient` または `SnaProvider` に渡すのが安全です。
+生成された token は server handle が所有します。Token rotation が必要な場合は
+新しい token でサーバーを起動し直します。
+
 ホストアプリに設定画面がある場合や、ユーザーが選んだ CLI 位置を保存する
 場合は `runtimePaths` を使ってください。`env` は最後の退避手段として
 残り、`runtimePaths` から生成された値を上書きします。Server identity、

--- a/apps/docs/content/docs/sdks/core-launchers.ko.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.ko.mdx
@@ -54,7 +54,7 @@ type RuntimePaths = {
 | Field | Default | 설명 |
 | --- | --- | --- |
 | `port` | `3099` | Server에 전달할 API port. |
-| `host` | `127.0.0.1` | Bind host. Host app에 더 강한 transport boundary가 없다면 loopback을 유지하십시오. |
+| `host` | `127.0.0.1` | Bind host. Host app에 더 강한 transport boundary가 없다면 loopback을 유지하는 편이 안전합니다. |
 | `appId` | `sna-sdk` | 이 server instance의 owner ID입니다. 이 서버가 만든 session metadata에 붙습니다. |
 | `authToken` | generated | Protected HTTP route와 WebSocket upgrade에 필요한 bearer token. |
 | `allowedOrigins` | `[]` | Browser `Origin` 요청 중 허용할 값. `Origin`을 보내지 않는 native client는 허용됩니다. |
@@ -73,10 +73,16 @@ type RuntimePaths = {
 | `runtimePaths` | auto-detect | 명시적인 런타임 CLI 명령 또는 절대 경로입니다. 각각 `SNA_CLAUDE_COMMAND`, `SNA_CODEX_COMMAND`, `SNA_OPENCODE_COMMAND`, `SNA_GROK_COMMAND`, `SNA_CURSOR_COMMAND`로 변환됩니다. |
 | `langfuse` | none | Metadata로 tracing을 opt-in한 session에서 Langfuse tracing을 켭니다. |
 
+Launcher는 `authToken`과 `connection: { baseUrl, authToken }`을 함께
+반환합니다. Token을 저장하거나 environment variable에서 다시 만들지 말고
+`connection`을 `SnaClient`나 `SnaProvider`에 전달하는 편이 안전합니다.
+생성된 token은 server handle이 소유합니다. Token rotation이 필요하면 새 token으로
+서버를 다시 시작하면 됩니다.
+
 호스트 앱에 설정 화면이 있거나 사용자가 선택한 CLI 위치를 저장한다면
-`runtimePaths`를 사용하십시오. `env`는 여전히 마지막 우회 수단으로 남아
+`runtimePaths`를 사용하면 됩니다. `env`는 여전히 마지막 우회 수단으로 남아
 있으며, `runtimePaths`에서 생성된 값을 덮어씁니다. Server identity, auth,
-bind host, origin policy는 typed launcher field로 지정하십시오.
+bind host, origin policy는 typed launcher field로 지정합니다.
 
 ## Forked vs in-process
 

--- a/apps/docs/content/docs/sdks/core-launchers.mdx
+++ b/apps/docs/content/docs/sdks/core-launchers.mdx
@@ -73,6 +73,13 @@ type RuntimePaths = {
 | `runtimePaths` | auto-detect | Explicit runtime CLI commands or absolute paths. They map to `SNA_CLAUDE_COMMAND`, `SNA_CODEX_COMMAND`, `SNA_OPENCODE_COMMAND`, `SNA_GROK_COMMAND`, and `SNA_CURSOR_COMMAND`. |
 | `langfuse` | none | Enables tracing for sessions whose metadata opts in. |
 
+The launcher returns both `authToken` and
+`connection: { baseUrl, authToken }`. Pass `connection` to
+`SnaClient` or `SnaProvider` instead of persisting the token or
+reconstructing it from environment variables. The generated token is
+owned by the server handle; rotate it by starting the server with a new
+token.
+
 Use `runtimePaths` when the host app has a setup screen or stores user-selected
 CLI locations. `env` is still available as the final escape hatch and overrides
 the values generated from `runtimePaths`. Use the typed launcher fields for

--- a/apps/docs/content/docs/sdks/core-server.ja.mdx
+++ b/apps/docs/content/docs/sdks/core-server.ja.mdx
@@ -40,12 +40,19 @@ declare function createSnaApp(options?: {
   sessionManager?: SessionManager;
   authToken?: string;
   allowedOrigins?: string[];
+  unsafeDisableAuth?: boolean;
 }): Promise<Hono>;
 ```
 
 SNA route を公開する Hono HTTP application を作成します。OpenAPI app factory へ委譲するため、返された app には generated OpenAPI metadata と `/docs` の Swagger UI が含まれます。
 
 `sessionManager` を省略すると server が 1 つ作成します。HTTP route と WebSocket client が同じ session state を共有する必要がある場合、または host が lifecycle event に直接アクセスする必要がある場合は、manager を作成して渡してください。
+
+認証はデフォルトで有効です。`authToken` を渡すか `SNA_AUTH_TOKEN` を設定し、
+`GET /health` だけが公開状態に残ります。`unsafeDisableAuth` は隔離された
+test や docs generation にだけ使い、host app では使いません。
+`allowedOrigins` は token 検証の前に browser `Origin` 値を filter し、
+`Origin` を送らない native client は許可されます。
 
 ## `attachWebSocket(server, sessionManager, options?)`
 
@@ -54,6 +61,10 @@ const wss = attachWebSocket(httpServer, sessionManager, { authToken, allowedOrig
 ```
 
 既存 Node HTTP server の `/ws` upgrade path に WebSocket server を接続します。`createSnaApp` に渡したものと同じ `SessionManager` を使ってください。そうしないと、HTTP command と WebSocket subscription が別々の session state を見ることになります。
+
+`createSnaApp` で使ったものと同じ `authToken` と `allowedOrigins` を渡します。
+TypeScript client は browser upgrade を `?token=...` で認証します。Native
+client は `Authorization: Bearer ...` または `X-SNA-Token` も送れます。
 
 WebSocket server が push する message:
 

--- a/apps/docs/content/docs/sdks/core-server.ko.mdx
+++ b/apps/docs/content/docs/sdks/core-server.ko.mdx
@@ -40,12 +40,19 @@ declare function createSnaApp(options?: {
   sessionManager?: SessionManager;
   authToken?: string;
   allowedOrigins?: string[];
+  unsafeDisableAuth?: boolean;
 }): Promise<Hono>;
 ```
 
 SNA route를 노출하는 Hono HTTP application을 생성합니다. OpenAPI app factory로 위임하므로 반환된 app에는 generated OpenAPI metadata와 `/docs`의 Swagger UI가 포함됩니다.
 
 `sessionManager`를 생략하면 server가 하나를 생성합니다. HTTP route와 WebSocket client가 같은 session state를 공유해야 하거나 host가 lifecycle event에 직접 접근해야 한다면 manager를 직접 만들어 전달하십시오.
+
+인증은 기본으로 켜져 있습니다. `authToken`을 전달하거나 `SNA_AUTH_TOKEN`을
+설정해야 하며, `GET /health`만 공개 상태로 남습니다. `unsafeDisableAuth`는
+격리된 테스트나 문서 생성에만 사용하고 host app에서는 쓰지 않습니다.
+`allowedOrigins`는 token 검증 전에 browser `Origin` 값을 필터링하며,
+`Origin`을 보내지 않는 native client는 허용됩니다.
 
 ## `attachWebSocket(server, sessionManager, options?)`
 
@@ -54,6 +61,10 @@ const wss = attachWebSocket(httpServer, sessionManager, { authToken, allowedOrig
 ```
 
 기존 Node HTTP server의 `/ws` upgrade path에 WebSocket server를 붙입니다. `createSnaApp`에 전달한 것과 같은 `SessionManager`를 사용하십시오. 그렇지 않으면 HTTP command와 WebSocket subscription이 서로 다른 session state를 보게 됩니다.
+
+`createSnaApp`에 사용한 것과 같은 `authToken`과 `allowedOrigins`를 전달합니다.
+TypeScript client는 browser upgrade를 `?token=...`으로 인증합니다. Native
+client는 `Authorization: Bearer ...` 또는 `X-SNA-Token`도 보낼 수 있습니다.
 
 WebSocket server가 push하는 message:
 

--- a/apps/docs/content/docs/sdks/core-server.mdx
+++ b/apps/docs/content/docs/sdks/core-server.mdx
@@ -40,12 +40,19 @@ declare function createSnaApp(options?: {
   sessionManager?: SessionManager;
   authToken?: string;
   allowedOrigins?: string[];
+  unsafeDisableAuth?: boolean;
 }): Promise<Hono>;
 ```
 
 Creates the Hono HTTP application that exposes SNA routes. It delegates to the OpenAPI app factory, so the returned app includes generated OpenAPI metadata and Swagger UI at `/docs`.
 
 If `sessionManager` is omitted, the server creates one. Pass your own manager when HTTP routes and WebSocket clients must share the same session state, or when the host needs direct access to lifecycle events.
+
+Authentication is enabled by default. Pass `authToken` or set
+`SNA_AUTH_TOKEN`; only `GET /health` remains public. Use
+`unsafeDisableAuth` only for isolated tests or docs generation, never for
+a host app. `allowedOrigins` filters browser `Origin` values before token
+validation, while native clients that send no `Origin` are allowed.
 
 ## `attachWebSocket(server, sessionManager, options?)`
 
@@ -54,6 +61,11 @@ const wss = attachWebSocket(httpServer, sessionManager, { authToken, allowedOrig
 ```
 
 Attaches a WebSocket server to the `/ws` upgrade path of an existing Node HTTP server. Use the same `SessionManager` passed to `createSnaApp`; otherwise HTTP commands and WebSocket subscriptions will observe different session state.
+
+Pass the same `authToken` and `allowedOrigins` used by `createSnaApp`.
+The TypeScript client authenticates browser upgrades with `?token=...`;
+native clients can also send `Authorization: Bearer ...` or
+`X-SNA-Token`.
 
 The WebSocket server:
 

--- a/apps/docs/content/docs/sdks/react-provider.ja.mdx
+++ b/apps/docs/content/docs/sdks/react-provider.ja.mdx
@@ -16,13 +16,13 @@ description: "SnaProvider、SnaSession、useSnaContext の props と返り値。
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `children` | `React.ReactNode` | required | SNA context を受け取る subtree です。 |
-| `connection` | `{ baseUrl: string; authToken?: string }` | none | SDK launcher が返す connection object です。Embedded SNA ではこれを優先します。 |
-| `snaUrl` | `string` | auto-discovery | SNA internal API server URL です。省略すると `/api/sna-port` を先に読み、失敗した場合は `http://localhost:3099` を使います。 |
-| `authToken` | `string` | none | Custom deployment 用の token override です。SDK app では通常 `connection` を使います。 |
+| `connection` | `{ baseUrl: string; authToken?: string }` | none | SDK launcher が返す connection object です。保護された embedded SNA では token と URL を一緒に保つため、これを優先します。 |
+| `snaUrl` | `string` | auto-discovery | SNA internal API server URL です。省略すると host app の `/api/sna-port` を先に読み、失敗した場合は `http://localhost:3099` を使います。 |
+| `authToken` | `string` | none | Custom deployment 用の token override です。SDK が server を起動していない保護サーバーでは `snaUrl` と一緒に使います。 |
 | `sessionId` | `string` | `default` | descendants の default session ID です。 |
 | `hydrate` | `boolean` | `true` | mount 時に chat store が保存済み sessions と messages を取得するかを制御します。chat store を使わない app では `false` にできます。 |
 
-`SnaProvider` は UI を render しません。React context に `{ apiUrl, authToken, sessionId }` を提供し、必要に応じて `useChatStore` を hydrate します。
+`SnaProvider` は UI を render しません。React context に `{ apiUrl, authToken, sessionId }` を提供し、必要に応じて `useChatStore` を hydrate します。Discovery route は `{ baseUrl, authToken }` または `{ port, authToken }` を返せます。この route は信頼済み host app route としてだけ公開するのが安全です。
 
 ## `<SnaSession>`
 

--- a/apps/docs/content/docs/sdks/react-provider.ko.mdx
+++ b/apps/docs/content/docs/sdks/react-provider.ko.mdx
@@ -20,9 +20,9 @@ description: "SnaProvider, SnaSession, useSnaContext의 props와 반환값."
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `children` | `React.ReactNode` | required | SNA context를 받을 subtree입니다. |
-| `connection` | `{ baseUrl: string; authToken?: string }` | none | SDK launcher가 반환한 connection object입니다. Embedded SNA에서는 이 값을 우선 사용합니다. |
-| `snaUrl` | `string` | auto-discovery | SNA internal API server URL입니다. 생략하면 `/api/sna-port`를 먼저 조회하고, 실패하면 `http://localhost:3099`를 사용합니다. |
-| `authToken` | `string` | none | Custom deployment용 token override입니다. SDK 앱은 보통 `connection`을 사용합니다. |
+| `connection` | `{ baseUrl: string; authToken?: string }` | none | SDK launcher가 반환한 connection object입니다. 보호된 embedded SNA에서는 token과 URL이 함께 유지되도록 이 값을 우선 사용합니다. |
+| `snaUrl` | `string` | auto-discovery | SNA internal API server URL입니다. 생략하면 host app의 `/api/sna-port`를 먼저 조회하고, 실패하면 `http://localhost:3099`를 사용합니다. |
+| `authToken` | `string` | none | Custom deployment용 token override입니다. SDK가 server를 시작하지 않은 보호 서버에서는 `snaUrl`과 함께 사용합니다. |
 | `sessionId` | `string` | `default` | subtree의 기본 session ID입니다. |
 | `hydrate` | `boolean` | `true` | mount 시 chat store가 저장된 session/message를 가져올지 결정합니다. Chat store를 쓰지 않으면 `false`로 둘 수 있습니다. |
 
@@ -38,7 +38,7 @@ export function Root({ children }: { children: React.ReactNode }) {
 
 **Output**
 
-`SnaProvider` 자체는 UI를 렌더링하지 않습니다. React context에 `{ apiUrl, authToken, sessionId }`를 넣고, 필요하면 `useChatStore`를 hydrate합니다.
+`SnaProvider` 자체는 UI를 렌더링하지 않습니다. React context에 `{ apiUrl, authToken, sessionId }`를 넣고, 필요하면 `useChatStore`를 hydrate합니다. Discovery route는 `{ baseUrl, authToken }` 또는 `{ port, authToken }`을 반환할 수 있습니다. 이 route는 신뢰된 host app route로만 노출하는 편이 안전합니다.
 
 ## `<SnaSession>`
 

--- a/apps/docs/content/docs/sdks/react-provider.mdx
+++ b/apps/docs/content/docs/sdks/react-provider.mdx
@@ -16,13 +16,13 @@ description: "Props and return values for SnaProvider, SnaSession, and useSnaCon
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `children` | `React.ReactNode` | required | Subtree that receives SNA context. |
-| `connection` | `{ baseUrl: string; authToken?: string }` | none | Connection object returned by SDK launchers. Prefer this for embedded SNA. |
-| `snaUrl` | `string` | auto-discovery | SNA internal API server URL. If omitted, it first reads `/api/sna-port`, then falls back to `http://localhost:3099`. |
-| `authToken` | `string` | none | Token override for custom deployments. SDK apps usually use `connection`. |
+| `connection` | `{ baseUrl: string; authToken?: string }` | none | Connection object returned by SDK launchers. Prefer this for protected embedded SNA so the token stays paired with the URL. |
+| `snaUrl` | `string` | auto-discovery | SNA internal API server URL. If omitted, it first reads the host app's `/api/sna-port`, then falls back to `http://localhost:3099`. |
+| `authToken` | `string` | none | Token override for custom deployments. Use it with `snaUrl` when the protected server is not launched by the SDK. |
 | `sessionId` | `string` | `default` | Default session ID for descendants. |
 | `hydrate` | `boolean` | `true` | Controls whether the chat store fetches persisted sessions and messages on mount. Set to `false` when the app does not use the chat store. |
 
-`SnaProvider` does not render UI. It provides `{ apiUrl, authToken, sessionId }` through React context and hydrates `useChatStore` when requested.
+`SnaProvider` does not render UI. It provides `{ apiUrl, authToken, sessionId }` through React context and hydrates `useChatStore` when requested. The discovery route may return `{ baseUrl, authToken }` or `{ port, authToken }`; expose it only from a trusted host app route.
 
 ## `<SnaSession>`
 

--- a/apps/docs/openapi/sna.ja.json
+++ b/apps/docs/openapi/sna.ja.json
@@ -2,16 +2,29 @@
   "openapi": "3.1.0",
   "info": {
     "title": "SNA SDK API",
-    "version": "0.16.0",
+    "version": "0.17.0",
     "description": "Skills-Native Application SDK — AI agent provider (Claude Code、Codex、OpenCode) を backend process として spawn し、通信するための HTTP API です。"
   },
   "components": {
     "schemas": {},
-    "parameters": {}
+    "parameters": {},
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "SNA auth token"
+      }
+    }
   },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
   "paths": {
     "/health": {
       "get": {
+        "security": [],
         "summary": "Health check",
         "description": "SNA サーバが稼働しているか確認します。",
         "responses": {
@@ -58,6 +71,11 @@
       "get": {
         "summary": "SNA API ポート取得",
         "description": "動的に割り当てられた SNA API ポートを返します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "ポート番号です。",
@@ -72,6 +90,62 @@
                   },
                   "required": [
                     "port"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -110,6 +184,11 @@
       "post": {
         "summary": "セッション作成",
         "description": "プロセスを開始せずにエージェントセッションレコードを作成します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -170,6 +249,62 @@
                     "sessionId",
                     "label",
                     "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -240,6 +375,11 @@
       "get": {
         "summary": "セッション一覧取得",
         "description": "エージェントセッション一覧を取得します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -493,6 +633,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_sessions_get",
@@ -505,6 +701,11 @@
       "delete": {
         "summary": "セッション削除",
         "description": "エージェントセッション、履歴、runtime chain、保留中の権限要求を削除します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -539,6 +740,62 @@
           },
           "400": {
             "description": "Cannot remove default session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
             "content": {
               "application/json": {
                 "schema": {
@@ -630,6 +887,11 @@
       "patch": {
         "summary": "セッション更新",
         "description": "セッションの label、meta、cwd を更新します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -685,6 +947,62 @@
                   "required": [
                     "status",
                     "session"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -757,6 +1075,11 @@
       "post": {
         "summary": "エージェント開始",
         "description": "セッション内でエージェントプロセスを開始します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -893,6 +1216,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "開始に失敗しました。",
             "content": {
@@ -932,6 +1311,11 @@
       "post": {
         "summary": "メッセージ送信",
         "description": "アクティブなエージェントへメッセージを送信します。画像も送信できます。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1031,6 +1415,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "サーバ内部エラーです。",
             "content": {
@@ -1070,6 +1510,11 @@
       "post": {
         "summary": "エージェント再起動",
         "description": "エージェントを終了して再 spawn します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1187,6 +1632,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "再起動に失敗しました。",
             "content": {
@@ -1226,6 +1727,11 @@
       "post": {
         "summary": "セッション再開",
         "description": "DB 履歴を注入してセッションを再開します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1375,6 +1881,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "再開に失敗しました。",
             "content": {
@@ -1414,6 +1976,11 @@
       "post": {
         "summary": "エージェント中断",
         "description": "現在のエージェントターンを中断します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1446,6 +2013,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_interrupt_post",
@@ -1458,6 +2081,11 @@
       "post": {
         "summary": "モデル変更",
         "description": "実行中セッションのモデルを変更します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1512,6 +2140,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_set_model_post",
@@ -1524,6 +2208,11 @@
       "post": {
         "summary": "権限モード変更",
         "description": "実行中セッションの権限モードを変更します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1578,6 +2267,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_set_permission_mode_post",
@@ -1590,6 +2335,11 @@
       "patch": {
         "summary": "セッション設定 patch",
         "description": "統一セッション設定 patch を適用します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1686,6 +2436,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "404": {
             "description": "セッションが見つかりません。",
             "content": {
@@ -1722,6 +2528,11 @@
       "post": {
         "summary": "エージェント終了",
         "description": "セッションレコードは残し、エージェントプロセスを終了します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1754,6 +2565,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_kill_post",
@@ -1766,6 +2633,11 @@
       "get": {
         "summary": "エージェント状態",
         "description": "セッション状態スナップショットを返します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1888,6 +2760,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_status_get",
@@ -1900,6 +2828,11 @@
       "post": {
         "summary": "単発実行",
         "description": "一時的なエージェント実行を 1 回行い、最終結果を返します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2017,6 +2950,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "実行失敗、または timeout です。",
             "content": {
@@ -2056,6 +3045,11 @@
       "post": {
         "summary": "単発実行ストリーム",
         "description": "一時実行を 1 回行い、AgentEvent を SSE でストリーミングします。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2157,6 +3151,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_run_once_stream_post",
@@ -2169,6 +3219,11 @@
       "post": {
         "summary": "Completion",
         "description": "セッション管理なしで軽量な単発 LLM completion を実行します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2318,6 +3373,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Completion に失敗しました。",
             "content": {
@@ -2357,6 +3468,11 @@
       "post": {
         "summary": "モデル一覧取得",
         "description": "provider runtime で利用可能なモデルを調べます。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2484,6 +3600,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "listModels 呼び出しに失敗しました。",
             "content": {
@@ -2523,6 +3695,11 @@
       "get": {
         "summary": "エージェントイベント SSE ストリーム",
         "description": "セッションの AgentEvent を Server-Sent Events でストリーミングします。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2556,6 +3733,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_events_get",
@@ -2568,6 +3801,11 @@
       "post": {
         "summary": "権限要求",
         "description": "権限要求を送信し、判断を待ちます。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2617,6 +3855,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_permission_request_post",
@@ -2629,6 +3923,11 @@
       "post": {
         "summary": "権限応答",
         "description": "保留中の権限要求を承認または拒否します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2675,6 +3974,62 @@
                   },
                   "required": [
                     "status"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -2747,6 +4102,11 @@
       "get": {
         "summary": "Pending 権限要求",
         "description": "保留中の権限要求一覧を取得します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2797,6 +4157,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_permission_pending_get",
@@ -2809,6 +4225,11 @@
       "get": {
         "summary": "Chat セッション一覧取得",
         "description": "DB に保存された chat セッション一覧を取得します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Chat セッション一覧です。",
@@ -2861,6 +4282,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "データベースエラーです。",
             "content": {
@@ -2898,6 +4375,11 @@
       "post": {
         "summary": "Chat セッション作成",
         "description": "DB に chat セッションを作成します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2962,6 +4444,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "データベースエラーです。",
             "content": {
@@ -3001,6 +4539,11 @@
       "delete": {
         "summary": "Chat セッション削除",
         "description": "chat セッションを削除します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3035,6 +4578,62 @@
           },
           "400": {
             "description": "Cannot delete default session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
             "content": {
               "application/json": {
                 "schema": {
@@ -3100,6 +4699,11 @@
       "get": {
         "summary": "Chat メッセージ一覧取得",
         "description": "chat セッションのメッセージ一覧を取得します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3148,6 +4752,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "データベースエラーです。",
             "content": {
@@ -3185,6 +4845,11 @@
       "post": {
         "summary": "Chat メッセージ作成",
         "description": "正規化された chat メッセージを追加します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3299,6 +4964,62 @@
               }
             }
           },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "データベースエラーです。",
             "content": {
@@ -3336,6 +5057,11 @@
       "delete": {
         "summary": "Chat メッセージ削除",
         "description": "chat セッション内のすべてのメッセージを削除します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3363,6 +5089,62 @@
                   },
                   "required": [
                     "status"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -3407,6 +5189,11 @@
       "get": {
         "summary": "画像提供",
         "description": "保存済み chat 画像 embed を提供します。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3432,6 +5219,62 @@
               "image/png": {
                 "schema": {
                   "nullable": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証が必要です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "許可されていない origin です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
                 }
               }
             }

--- a/apps/docs/openapi/sna.json
+++ b/apps/docs/openapi/sna.json
@@ -2,16 +2,29 @@
   "openapi": "3.1.0",
   "info": {
     "title": "SNA SDK API",
-    "version": "0.16.0",
+    "version": "0.17.0",
     "description": "Skills-Native Application SDK — HTTP API for spawning and communicating with AI agent providers (Claude Code, Codex, OpenCode)."
   },
   "components": {
     "schemas": {},
-    "parameters": {}
+    "parameters": {},
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "SNA auth token"
+      }
+    }
   },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
   "paths": {
     "/health": {
       "get": {
+        "security": [],
         "summary": "Health check",
         "description": "Verify the SNA server is running.",
         "responses": {
@@ -58,6 +71,11 @@
       "get": {
         "summary": "Get SNA API port",
         "description": "Return the dynamically allocated SNA API port.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Port number.",
@@ -72,6 +90,62 @@
                   },
                   "required": [
                     "port"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -110,6 +184,11 @@
       "post": {
         "summary": "Create a session",
         "description": "Create an agent session record without starting a process.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -170,6 +249,62 @@
                     "sessionId",
                     "label",
                     "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -240,6 +375,11 @@
       "get": {
         "summary": "List sessions",
         "description": "List agent sessions.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -493,6 +633,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_sessions_get",
@@ -505,6 +701,11 @@
       "delete": {
         "summary": "Remove a session",
         "description": "Remove an agent session, its history, runtime chain, and pending permission request.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -539,6 +740,62 @@
           },
           "400": {
             "description": "Cannot remove default session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
             "content": {
               "application/json": {
                 "schema": {
@@ -630,6 +887,11 @@
       "patch": {
         "summary": "Update session",
         "description": "Update session metadata: label, meta, and cwd.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -685,6 +947,62 @@
                   "required": [
                     "status",
                     "session"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -757,6 +1075,11 @@
       "post": {
         "summary": "Start agent",
         "description": "Start an agent process inside a session.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -893,6 +1216,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Start failed.",
             "content": {
@@ -932,6 +1311,11 @@
       "post": {
         "summary": "Send message",
         "description": "Send a message to the active agent. Images are supported.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1031,6 +1415,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error.",
             "content": {
@@ -1070,6 +1510,11 @@
       "post": {
         "summary": "Restart agent",
         "description": "Kill and re-spawn an agent.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1187,6 +1632,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Restart failed.",
             "content": {
@@ -1226,6 +1727,11 @@
       "post": {
         "summary": "Resume session",
         "description": "Resume a session with database history injected.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1375,6 +1881,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Resume failed.",
             "content": {
@@ -1414,6 +1976,11 @@
       "post": {
         "summary": "Interrupt agent",
         "description": "Interrupt the current agent turn.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1446,6 +2013,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_interrupt_post",
@@ -1458,6 +2081,11 @@
       "post": {
         "summary": "Set model",
         "description": "Change the model for a live session.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1512,6 +2140,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_set_model_post",
@@ -1524,6 +2208,11 @@
       "post": {
         "summary": "Set permission mode",
         "description": "Change permission mode for a live session.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1578,6 +2267,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_set_permission_mode_post",
@@ -1590,6 +2335,11 @@
       "patch": {
         "summary": "Patch session config",
         "description": "Apply a unified session config patch.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1686,6 +2436,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "404": {
             "description": "Session not found.",
             "content": {
@@ -1722,6 +2528,11 @@
       "post": {
         "summary": "Kill agent",
         "description": "Kill the agent process while preserving the session record.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1754,6 +2565,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_kill_post",
@@ -1766,6 +2633,11 @@
       "get": {
         "summary": "Agent status",
         "description": "Return a session status snapshot.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1888,6 +2760,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_status_get",
@@ -1900,6 +2828,11 @@
       "post": {
         "summary": "Run once",
         "description": "Run one temporary agent execution and return the final result.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2017,6 +2950,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Execution failed or timed out.",
             "content": {
@@ -2056,6 +3045,11 @@
       "post": {
         "summary": "Run once stream",
         "description": "Run one temporary execution and stream AgentEvent objects over SSE.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2157,6 +3151,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_run_once_stream_post",
@@ -2169,6 +3219,11 @@
       "post": {
         "summary": "Completion",
         "description": "Run a lightweight one-shot LLM completion without session management.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2318,6 +3373,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Completion failed.",
             "content": {
@@ -2357,6 +3468,11 @@
       "post": {
         "summary": "List models",
         "description": "Inspect available models for a provider runtime.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2484,6 +3600,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "listModels call failed.",
             "content": {
@@ -2523,6 +3695,11 @@
       "get": {
         "summary": "Agent event SSE stream",
         "description": "Stream session AgentEvent objects over Server-Sent Events.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2556,6 +3733,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_events_get",
@@ -2568,6 +3801,11 @@
       "post": {
         "summary": "Permission request",
         "description": "Submit a permission request and wait for a decision.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2617,6 +3855,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_permission_request_post",
@@ -2629,6 +3923,11 @@
       "post": {
         "summary": "Permission respond",
         "description": "Approve or deny a pending permission request.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2675,6 +3974,62 @@
                   },
                   "required": [
                     "status"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -2747,6 +4102,11 @@
       "get": {
         "summary": "Pending permissions",
         "description": "List pending permission requests.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2797,6 +4157,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_permission_pending_get",
@@ -2809,6 +4225,11 @@
       "get": {
         "summary": "List chat sessions",
         "description": "List chat sessions stored in the database.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Chat sessions.",
@@ -2861,6 +4282,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Database error.",
             "content": {
@@ -2898,6 +4375,11 @@
       "post": {
         "summary": "Create chat session",
         "description": "Create a chat session in the database.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2962,6 +4444,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Database error.",
             "content": {
@@ -3001,6 +4539,11 @@
       "delete": {
         "summary": "Delete chat session",
         "description": "Delete a chat session.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3035,6 +4578,62 @@
           },
           "400": {
             "description": "Cannot delete default session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3100,6 +4699,11 @@
       "get": {
         "summary": "List chat messages",
         "description": "List messages for a chat session.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3148,6 +4752,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Database error.",
             "content": {
@@ -3185,6 +4845,11 @@
       "post": {
         "summary": "Create chat message",
         "description": "Append a normalized chat message.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3299,6 +4964,62 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Database error.",
             "content": {
@@ -3336,6 +5057,11 @@
       "delete": {
         "summary": "Clear chat messages",
         "description": "Clear all messages in a chat session.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3363,6 +5089,62 @@
                   },
                   "required": [
                     "status"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -3407,6 +5189,11 @@
       "get": {
         "summary": "Serve image",
         "description": "Serve a stored chat image embed.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3432,6 +5219,62 @@
               "image/png": {
                 "schema": {
                   "nullable": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Origin not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
                 }
               }
             }

--- a/apps/docs/openapi/sna.ko.json
+++ b/apps/docs/openapi/sna.ko.json
@@ -2,16 +2,29 @@
   "openapi": "3.1.0",
   "info": {
     "title": "SNA SDK API",
-    "version": "0.16.0",
+    "version": "0.17.0",
     "description": "Skills-Native Application SDK — AI agent provider(Claude Code, Codex, OpenCode)를 backend process로 spawn하고 통신하기 위한 HTTP API입니다."
   },
   "components": {
     "schemas": {},
-    "parameters": {}
+    "parameters": {},
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "SNA auth token"
+      }
+    }
   },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
   "paths": {
     "/health": {
       "get": {
+        "security": [],
         "summary": "Health check",
         "description": "SNA 서버가 실행 중인지 확인합니다.",
         "responses": {
@@ -58,6 +71,11 @@
       "get": {
         "summary": "SNA API 포트 조회",
         "description": "동적으로 할당된 SNA API 포트를 반환합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "포트 번호입니다.",
@@ -72,6 +90,62 @@
                   },
                   "required": [
                     "port"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -110,6 +184,11 @@
       "post": {
         "summary": "세션 생성",
         "description": "프로세스를 시작하지 않고 에이전트 세션 레코드를 생성합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -170,6 +249,62 @@
                     "sessionId",
                     "label",
                     "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -240,6 +375,11 @@
       "get": {
         "summary": "세션 목록 조회",
         "description": "에이전트 세션 목록을 조회합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -493,6 +633,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_sessions_get",
@@ -505,6 +701,11 @@
       "delete": {
         "summary": "세션 삭제",
         "description": "에이전트 세션, 히스토리, runtime chain, 대기 중인 권한 요청을 삭제합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -539,6 +740,62 @@
           },
           "400": {
             "description": "Cannot remove default session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -630,6 +887,11 @@
       "patch": {
         "summary": "세션 갱신",
         "description": "세션의 label, meta, cwd를 갱신합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -685,6 +947,62 @@
                   "required": [
                     "status",
                     "session"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -757,6 +1075,11 @@
       "post": {
         "summary": "에이전트 시작",
         "description": "세션 안에서 에이전트 프로세스를 시작합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -893,6 +1216,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "시작에 실패했습니다.",
             "content": {
@@ -932,6 +1311,11 @@
       "post": {
         "summary": "메시지 전송",
         "description": "활성 에이전트에 메시지를 보냅니다. 이미지도 함께 전송할 수 있습니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1031,6 +1415,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "서버 내부 오류입니다.",
             "content": {
@@ -1070,6 +1510,11 @@
       "post": {
         "summary": "에이전트 재시작",
         "description": "에이전트를 종료한 뒤 다시 spawn합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1187,6 +1632,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "재시작에 실패했습니다.",
             "content": {
@@ -1226,6 +1727,11 @@
       "post": {
         "summary": "세션 재개",
         "description": "DB 히스토리를 주입해 세션을 재개합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1375,6 +1881,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "재개에 실패했습니다.",
             "content": {
@@ -1414,6 +1976,11 @@
       "post": {
         "summary": "에이전트 중단",
         "description": "현재 에이전트 턴을 중단합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1446,6 +2013,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_interrupt_post",
@@ -1458,6 +2081,11 @@
       "post": {
         "summary": "모델 변경",
         "description": "실행 중인 세션의 모델을 변경합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1512,6 +2140,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_set_model_post",
@@ -1524,6 +2208,11 @@
       "post": {
         "summary": "권한 모드 변경",
         "description": "실행 중인 세션의 권한 모드를 변경합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1578,6 +2267,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_set_permission_mode_post",
@@ -1590,6 +2335,11 @@
       "patch": {
         "summary": "세션 설정 patch",
         "description": "통합 세션 설정 patch를 적용합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1686,6 +2436,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "404": {
             "description": "세션을 찾을 수 없습니다.",
             "content": {
@@ -1722,6 +2528,11 @@
       "post": {
         "summary": "에이전트 종료",
         "description": "세션 레코드는 유지하고 에이전트 프로세스를 종료합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1754,6 +2565,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_kill_post",
@@ -1766,6 +2633,11 @@
       "get": {
         "summary": "에이전트 상태",
         "description": "세션 상태 스냅샷을 반환합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1888,6 +2760,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_status_get",
@@ -1900,6 +2828,11 @@
       "post": {
         "summary": "단발 실행",
         "description": "임시 에이전트 실행을 한 번 수행하고 최종 결과를 반환합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2017,6 +2950,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "실행 실패 또는 timeout입니다.",
             "content": {
@@ -2056,6 +3045,11 @@
       "post": {
         "summary": "단발 실행 스트림",
         "description": "임시 실행을 한 번 수행하고 AgentEvent를 SSE로 스트리밍합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2157,6 +3151,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_run_once_stream_post",
@@ -2169,6 +3219,11 @@
       "post": {
         "summary": "Completion",
         "description": "세션 관리 없이 가벼운 단발 LLM completion을 실행합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2318,6 +3373,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Completion에 실패했습니다.",
             "content": {
@@ -2357,6 +3468,11 @@
       "post": {
         "summary": "모델 목록 조회",
         "description": "provider runtime에서 사용할 수 있는 모델을 조회합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2484,6 +3600,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "listModels 호출에 실패했습니다.",
             "content": {
@@ -2523,6 +3695,11 @@
       "get": {
         "summary": "에이전트 이벤트 SSE 스트림",
         "description": "세션 AgentEvent를 Server-Sent Events로 스트리밍합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2556,6 +3733,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_events_get",
@@ -2568,6 +3801,11 @@
       "post": {
         "summary": "권한 요청",
         "description": "권한 요청을 제출하고 결정을 기다립니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2617,6 +3855,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "post_agent_permission_request_post",
@@ -2629,6 +3923,11 @@
       "post": {
         "summary": "권한 응답",
         "description": "대기 중인 권한 요청을 승인하거나 거부합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2675,6 +3974,62 @@
                   },
                   "required": [
                     "status"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -2747,6 +4102,11 @@
       "get": {
         "summary": "Pending 권한 요청",
         "description": "대기 중인 권한 요청 목록을 조회합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2797,6 +4157,62 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "get_agent_permission_pending_get",
@@ -2809,6 +4225,11 @@
       "get": {
         "summary": "Chat 세션 목록 조회",
         "description": "DB에 저장된 chat 세션 목록을 조회합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Chat 세션 목록입니다.",
@@ -2861,6 +4282,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "데이터베이스 오류입니다.",
             "content": {
@@ -2898,6 +4375,11 @@
       "post": {
         "summary": "Chat 세션 생성",
         "description": "DB에 chat 세션을 생성합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2962,6 +4444,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "데이터베이스 오류입니다.",
             "content": {
@@ -3001,6 +4539,11 @@
       "delete": {
         "summary": "Chat 세션 삭제",
         "description": "chat 세션을 삭제합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3035,6 +4578,62 @@
           },
           "400": {
             "description": "Cannot delete default session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3100,6 +4699,11 @@
       "get": {
         "summary": "Chat 메시지 목록 조회",
         "description": "chat 세션의 메시지 목록을 조회합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3148,6 +4752,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "데이터베이스 오류입니다.",
             "content": {
@@ -3185,6 +4845,11 @@
       "post": {
         "summary": "Chat 메시지 생성",
         "description": "정규화된 chat 메시지를 추가합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3299,6 +4964,62 @@
               }
             }
           },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "데이터베이스 오류입니다.",
             "content": {
@@ -3336,6 +5057,11 @@
       "delete": {
         "summary": "Chat 메시지 삭제",
         "description": "chat 세션의 모든 메시지를 삭제합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3363,6 +5089,62 @@
                   },
                   "required": [
                     "status"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -3407,6 +5189,11 @@
       "get": {
         "summary": "이미지 제공",
         "description": "저장된 chat 이미지 embed를 제공합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -3432,6 +5219,62 @@
               "image/png": {
                 "schema": {
                   "nullable": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증이 필요합니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "허용되지 않은 origin입니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "stack": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
                 }
               }
             }

--- a/apps/docs/scripts/generate-openapi-docs.ts
+++ b/apps/docs/scripts/generate-openapi-docs.ts
@@ -83,7 +83,7 @@ const schemaDir = path.join(docsRoot, 'openapi');
 const endpointsDir = path.join(docsRoot, 'content/docs/api/endpoints');
 
 async function writeOpenApiSchema() {
-  const app = await createOpenApiApp();
+  const app = await createOpenApiApp({ unsafeDisableAuth: true });
   const packageJson = JSON.parse(
     await fs.readFile(path.join(repoRoot, 'packages/core/package.json'), 'utf8'),
   ) as { version?: string };
@@ -155,6 +155,8 @@ function localizeResponses(responses: Record<string, { description?: string }> |
 
   const translations: Record<string, Partial<Record<Locale, string>>> = {
     'Server is healthy.': { ko: '서버가 정상입니다.', ja: 'サーバは正常です。' },
+    'Authentication required.': { ko: '인증이 필요합니다.', ja: '認証が必要です。' },
+    'Origin not allowed.': { ko: '허용되지 않은 origin입니다.', ja: '許可されていない origin です。' },
     'Port number.': { ko: '포트 번호입니다.', ja: 'ポート番号です。' },
     'SNA API not running.': { ko: 'SNA API가 실행 중이 아닙니다.', ja: 'SNA API が実行されていません。' },
     'Session created.': { ko: '세션이 생성되었습니다.', ja: 'セッションが作成されました。' },

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -49,7 +49,9 @@ await sna.agent.send(sessionId, "What's in this directory?");
 
 Protected SNA servers require a bearer token, but SDK launchers keep it paired
 with the server handle. Pass `handle.connection` to `SnaClient` instead of
-copying the token into app settings.
+copying the token into app settings. HTTP and SSE requests send
+`Authorization: Bearer <authToken>`; WebSocket uses `/ws?token=<authToken>` for
+browser-compatible upgrades.
 
 ### What HTTP guarantees (`http: true`)
 

--- a/packages/client/src/sna-client.spec.ts
+++ b/packages/client/src/sna-client.spec.ts
@@ -1090,6 +1090,24 @@ describe("HTTP transport (http: true)", () => {
     assert.equal(mock.httpRequests[0].headers.authorization, "Bearer secret-token");
   });
 
+  it("sends authToken as a bearer token on HTTP SSE requests", async () => {
+    mock.queueHttpResponse(200, {});
+    mock.queueHttpResponse(200, {});
+    sna = new SnaClient({ baseUrl: mock.host, authToken: "secret-token", ws: false, http: true, reconnect: false });
+
+    for await (const _event of sna.agent.runOnceStream({ message: "hello" })) {
+      // Mock response has no SSE data lines.
+    }
+    for await (const _event of sna.agent.streamEvents("default")) {
+      // Mock response has no SSE data lines.
+    }
+
+    assert.equal(mock.httpRequests[0].url, "/agent/run-once/stream");
+    assert.equal(mock.httpRequests[0].headers.authorization, "Bearer secret-token");
+    assert.equal(mock.httpRequests[1].url, "/agent/events?session=default");
+    assert.equal(mock.httpRequests[1].headers.authorization, "Bearer secret-token");
+  });
+
   it("sessions.create — no opts sends empty body", async () => {
     mock.queueHttpResponse(200, { status: "created", sessionId: "auto", label: "auto", meta: null });
     sna = httpClient();

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,8 +8,8 @@ Your app → SNA server → spawn(agentic CLI runtime) → events back over WS
 
 ## What's inside
 
-- **HTTP server (`createSnaApp`)** — Hono app (built on `@hono/zod-openapi`) with `/agent/*`, `/chat/*`, `/health` routes. Single source of truth for response shapes via `server/api-types.ts`. Live OpenAPI 3.1 spec published at `/openapi.json`, with Swagger UI at `/docs` and a plain-text viewer at `/spec`.
-- **WebSocket handler (`attachWebSocket`)** — Mounts at `/ws`. Wraps the full HTTP API plus push channels (`agent.event`, `sessions.snapshot`, `permission.request`, `session.lifecycle`, `session.state-changed`, `session.config-changed`).
+- **HTTP server (`createSnaApp`)**: Hono app (built on `@hono/zod-openapi`) with `/agent/*`, `/chat/*`, `/health` routes. Single source of truth for response shapes via `server/api-types.ts`. Live OpenAPI 3.1 spec published at `/openapi.json`, with Swagger UI at `/docs` and a plain-text viewer at `/spec`. All runtime HTTP routes except `GET /health` require bearer auth.
+- **WebSocket handler (`attachWebSocket`)**: Mounts at `/ws`. Wraps the full HTTP API plus push channels (`agent.event`, `sessions.snapshot`, `permission.request`, `session.lifecycle`, `session.state-changed`, `session.config-changed`). Uses the same auth token as HTTP.
 - **`SessionManager`** — Multi-session lifecycle, per-session event buffer, lifecycle/state/config pub/sub, permission-request bridging, `runtime_sessions` chain for per-mutation history.
 - **Providers** — `ClaudeCodeProvider`, `CodexProvider`, `OpenCodeProvider`, `GrokProvider`, and `CursorProvider`, all exposing a uniform `AgentProcess` interface (`send`, `setModel`, `setPermissionMode`, `interrupt`, `kill`, `applyPatch`, `respondToPermission`). Codex and OpenCode are pooled through `RuntimePool`; the others are stateless per-session.
 - **Canonical conversation model** — `chat_messages` rows split a message into orthogonal `actor` × `kind` axes. `history/canonical.ts` rebuilds blocks; `history/{claude-code,codex,opencode}.ts` adapters convert canonical → native wire format.
@@ -48,8 +48,10 @@ const sna = await startSnaServer({
 Launchers bind to `127.0.0.1` by default, generate a per-server
 `authToken`, and tag sessions with `appId`. Use the returned
 `sna.connection` object with `SnaClient` or `SnaProvider` so consumers do not
-handle the token separately. Browser renderer origins are rejected unless they
-are listed in `allowedOrigins`. Direct standalone server launches are for
+handle the token separately. HTTP and SSE calls send the token as
+`Authorization: Bearer <authToken>`, and browser WebSocket upgrades use
+`/ws?token=<authToken>`. Browser renderer origins are rejected unless they are
+listed in `allowedOrigins`. Direct standalone server launches are for
 development/debugging and must provide `SNA_AUTH_TOKEN` explicitly.
 
 For Electron, use `@sna-sdk/core/electron` and add `asarUnpack: ["node_modules/@sna-sdk/core/**"]`.

--- a/packages/core/src/server/routes/openapi.ts
+++ b/packages/core/src/server/routes/openapi.ts
@@ -5,7 +5,7 @@
  * Zod schemas validate requests and generate OpenAPI spec automatically.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, createRoute, z, type RouteConfig } from "@hono/zod-openapi";
 import { swaggerUI } from "@hono/swagger-ui";
 import { streamSSE } from "hono/streaming";
 import fs from "fs";
@@ -100,11 +100,64 @@ const ErrorResponse = z.object({
   stack: z.string().optional(),
 });
 
+const UnauthorizedResponse = {
+  description: "Authentication required.",
+  content: { "application/json": { schema: ErrorResponse } },
+} as const;
+
+const ForbiddenResponse = {
+  description: "Origin not allowed.",
+  content: { "application/json": { schema: ErrorResponse } },
+} as const;
+
+const bearerAuthSecurityScheme = {
+  type: "http",
+  scheme: "bearer",
+  bearerFormat: "SNA auth token",
+} as const;
+
+function withOpenApiSecurity(config: any) {
+  return {
+    ...config,
+    components: {
+      ...config.components,
+      securitySchemes: {
+        ...config.components?.securitySchemes,
+        bearerAuth: bearerAuthSecurityScheme,
+      },
+    },
+    security: config.security ?? [{ bearerAuth: [] }],
+  };
+}
+
+function applyOpenApiSecurity(document: any) {
+  document.components ??= {};
+  document.components.securitySchemes = {
+    ...document.components.securitySchemes,
+    bearerAuth: bearerAuthSecurityScheme,
+  };
+  document.security ??= [{ bearerAuth: [] }];
+  return document;
+}
+
+function protectedRoute<const P extends string, R extends Omit<RouteConfig, "path"> & { path: P }>(routeConfig: R) {
+  return createRoute({
+    ...routeConfig,
+    security: [{ bearerAuth: [] }],
+    responses: {
+      401: UnauthorizedResponse,
+      403: ForbiddenResponse,
+      ...routeConfig.responses,
+    },
+  });
+}
+
 // ── Health ────────────────────────────────────────────────────────────
 
 const healthRoute = createRoute({
   method: "get",
   path: "/health",
+  security: [],
   summary: "Health check",
   description: "Verify the SNA server is running.",
   responses: {
@@ -117,7 +170,7 @@ const healthRoute = createRoute({
 
 // ── SNA Port ──────────────────────────────────────────────────────────
 
-const snaPortRoute = createRoute({
+const snaPortRoute = protectedRoute({
   method: "get",
   path: "/api/sna-port",
   summary: "Get SNA API port",
@@ -136,7 +189,7 @@ const snaPortRoute = createRoute({
 
 // ── Session CRUD ──────────────────────────────────────────────────────
 
-const createSessionRoute = createRoute({
+const createSessionRoute = protectedRoute({
   method: "post",
   path: "/agent/sessions",
   summary: "Create a session",
@@ -172,7 +225,7 @@ const createSessionRoute = createRoute({
   },
 });
 
-const listSessionsRoute = createRoute({
+const listSessionsRoute = protectedRoute({
   method: "get",
   path: "/agent/sessions",
   summary: "List sessions",
@@ -190,7 +243,7 @@ const listSessionsRoute = createRoute({
   },
 });
 
-const removeSessionRoute = createRoute({
+const removeSessionRoute = protectedRoute({
   method: "delete",
   path: "/agent/sessions/{id}",
   summary: "Remove a session",
@@ -218,7 +271,7 @@ const removeSessionRoute = createRoute({
   },
 });
 
-const updateSessionRoute = createRoute({
+const updateSessionRoute = protectedRoute({
   method: "patch",
   path: "/agent/sessions/{id}",
   summary: "Update session",
@@ -251,7 +304,7 @@ const updateSessionRoute = createRoute({
 
 // ── Agent Lifecycle ───────────────────────────────────────────────────
 
-const startRoute = createRoute({
+const startRoute = protectedRoute({
   method: "post",
   path: "/agent/start",
   summary: "Start agent",
@@ -298,7 +351,7 @@ const startRoute = createRoute({
   },
 });
 
-const sendRoute = createRoute({
+const sendRoute = protectedRoute({
   method: "post",
   path: "/agent/send",
   summary: "Send message",
@@ -332,7 +385,7 @@ const sendRoute = createRoute({
   },
 });
 
-const restartRoute = createRoute({
+const restartRoute = protectedRoute({
   method: "post",
   path: "/agent/restart",
   summary: "Restart agent",
@@ -375,7 +428,7 @@ const restartRoute = createRoute({
   },
 });
 
-const resumeRoute = createRoute({
+const resumeRoute = protectedRoute({
   method: "post",
   path: "/agent/resume",
   summary: "Resume session",
@@ -423,7 +476,7 @@ const resumeRoute = createRoute({
   },
 });
 
-const interruptRoute = createRoute({
+const interruptRoute = protectedRoute({
   method: "post",
   path: "/agent/interrupt",
   summary: "Interrupt agent",
@@ -441,7 +494,7 @@ const interruptRoute = createRoute({
   },
 });
 
-const setModelRoute = createRoute({
+const setModelRoute = protectedRoute({
   method: "post",
   path: "/agent/set-model",
   summary: "Set model",
@@ -463,7 +516,7 @@ const setModelRoute = createRoute({
   },
 });
 
-const setPermissionModeRoute = createRoute({
+const setPermissionModeRoute = protectedRoute({
   method: "post",
   path: "/agent/set-permission-mode",
   summary: "Set permission mode",
@@ -485,7 +538,7 @@ const setPermissionModeRoute = createRoute({
   },
 });
 
-const sessionPatchRoute = createRoute({
+const sessionPatchRoute = protectedRoute({
   method: "patch",
   path: "/agent/session",
   summary: "Patch session config",
@@ -532,7 +585,7 @@ const sessionPatchRoute = createRoute({
   },
 });
 
-const killRoute = createRoute({
+const killRoute = protectedRoute({
   method: "post",
   path: "/agent/kill",
   summary: "Kill agent",
@@ -550,7 +603,7 @@ const killRoute = createRoute({
   },
 });
 
-const statusRoute = createRoute({
+const statusRoute = protectedRoute({
   method: "get",
   path: "/agent/status",
   summary: "Agent status",
@@ -582,7 +635,7 @@ const statusRoute = createRoute({
 
 // ── One-shot ──────────────────────────────────────────────────────────
 
-const runOnceRoute = createRoute({
+const runOnceRoute = protectedRoute({
   method: "post",
   path: "/agent/run-once",
   summary: "Run once",
@@ -624,7 +677,7 @@ const runOnceRoute = createRoute({
   },
 });
 
-const runOnceStreamRoute = createRoute({
+const runOnceStreamRoute = protectedRoute({
   method: "post",
   path: "/agent/run-once/stream",
   summary: "Run once (SSE stream)",
@@ -667,7 +720,7 @@ const runOnceStreamRoute = createRoute({
   },
 });
 
-const completionRoute = createRoute({
+const completionRoute = protectedRoute({
   method: "post",
   path: "/agent/completion",
   summary: "Completion",
@@ -720,7 +773,7 @@ const completionRoute = createRoute({
 
 // ── Permission ────────────────────────────────────────────────────────
 
-const permissionRequestRoute = createRoute({
+const permissionRequestRoute = protectedRoute({
   method: "post",
   path: "/agent/permission-request",
   summary: "Permission request",
@@ -742,7 +795,7 @@ const permissionRequestRoute = createRoute({
   },
 });
 
-const permissionRespondRoute = createRoute({
+const permissionRespondRoute = protectedRoute({
   method: "post",
   path: "/agent/permission-respond",
   summary: "Permission respond",
@@ -771,7 +824,7 @@ const permissionRespondRoute = createRoute({
   },
 });
 
-const listModelsRoute = createRoute({
+const listModelsRoute = protectedRoute({
   method: "post",
   path: "/agent/list-models",
   summary: "List models",
@@ -831,7 +884,7 @@ const listModelsRoute = createRoute({
   },
 });
 
-const agentEventsRoute = createRoute({
+const agentEventsRoute = protectedRoute({
   method: "get",
   path: "/agent/events",
   summary: "Agent event SSE stream",
@@ -862,7 +915,7 @@ const agentEventsRoute = createRoute({
   },
 });
 
-const permissionPendingRoute = createRoute({
+const permissionPendingRoute = protectedRoute({
   method: "get",
   path: "/agent/permission-pending",
   summary: "Pending permissions",
@@ -886,7 +939,7 @@ const permissionPendingRoute = createRoute({
 
 // ── Chat Sessions ─────────────────────────────────────────────────────
 
-const chatListSessionsRoute = createRoute({
+const chatListSessionsRoute = protectedRoute({
   method: "get",
   path: "/chat/sessions",
   summary: "List chat sessions",
@@ -912,7 +965,7 @@ const chatListSessionsRoute = createRoute({
   },
 });
 
-const chatCreateSessionRoute = createRoute({
+const chatCreateSessionRoute = protectedRoute({
   method: "post",
   path: "/chat/sessions",
   summary: "Create chat session",
@@ -944,7 +997,7 @@ const chatCreateSessionRoute = createRoute({
   },
 });
 
-const chatDeleteSessionRoute = createRoute({
+const chatDeleteSessionRoute = protectedRoute({
   method: "delete",
   path: "/chat/sessions/{id}",
   summary: "Delete chat session",
@@ -970,7 +1023,7 @@ const chatDeleteSessionRoute = createRoute({
 
 // ── Chat Messages ─────────────────────────────────────────────────────
 
-const chatListMessagesRoute = createRoute({
+const chatListMessagesRoute = protectedRoute({
   method: "get",
   path: "/chat/sessions/{id}/messages",
   summary: "List chat messages",
@@ -994,7 +1047,7 @@ const chatListMessagesRoute = createRoute({
   },
 });
 
-const chatCreateMessageRoute = createRoute({
+const chatCreateMessageRoute = protectedRoute({
   method: "post",
   path: "/chat/sessions/{id}/messages",
   summary: "Create chat message",
@@ -1030,7 +1083,7 @@ const chatCreateMessageRoute = createRoute({
   },
 });
 
-const chatClearMessagesRoute = createRoute({
+const chatClearMessagesRoute = protectedRoute({
   method: "delete",
   path: "/chat/sessions/{id}/messages",
   summary: "Clear chat messages",
@@ -1052,7 +1105,7 @@ const chatClearMessagesRoute = createRoute({
 
 // ── Image Serving ─────────────────────────────────────────────────────
 
-const serveImageRoute = createRoute({
+const serveImageRoute = protectedRoute({
   method: "get",
   path: "/chat/images/{sessionId}/{filename}",
   summary: "Serve image",
@@ -1083,6 +1136,12 @@ function getSessionId(c: { req: { query: (k: string) => string | undefined } }):
 
 export async function createOpenApiApp(options?: { sessionManager?: SessionManager } & SnaSecurityOptions) {
   const app = new OpenAPIHono();
+  const getOpenAPIDocument = app.getOpenAPIDocument.bind(app);
+  app.getOpenAPIDocument = ((objectConfig: any, generatorConfig?: any) =>
+    applyOpenApiSecurity(getOpenAPIDocument(withOpenApiSecurity(objectConfig), generatorConfig))) as typeof app.getOpenAPIDocument;
+  const getOpenAPI31Document = app.getOpenAPI31Document.bind(app);
+  app.getOpenAPI31Document = ((objectConfig: any, generatorConfig?: any) =>
+    applyOpenApiSecurity(getOpenAPI31Document(withOpenApiSecurity(objectConfig), generatorConfig))) as typeof app.getOpenAPI31Document;
   app.use("*", createHttpSecurityMiddleware(options ?? {}));
 
   const openApiInfo = {
@@ -1092,6 +1151,12 @@ export async function createOpenApiApp(options?: { sessionManager?: SessionManag
       version: SNA_VERSION,
       description: "Skills-Native Application SDK — HTTP API for spawning and communicating with AI agent providers (Claude Code, Codex, OpenCode).",
     },
+    components: {
+      securitySchemes: {
+        bearerAuth: bearerAuthSecurityScheme,
+      },
+    },
+    security: [{ bearerAuth: [] }],
   };
 
   // Swagger UI — accessible at /docs

--- a/packages/core/test/api-routes.test.ts
+++ b/packages/core/test/api-routes.test.ts
@@ -167,6 +167,42 @@ describe("HTTP API Routes", () => {
     });
   });
 
+  describe("OpenAPI auth contract", () => {
+    function getDocument(targetApp = app) {
+      return targetApp.getOpenAPIDocument({
+        openapi: "3.1.0",
+        info: { title: "SNA SDK API", version: "0.0.0" },
+      }) as any;
+    }
+
+    it("documents bearer auth while keeping health public", async () => {
+      const { createSnaApp } = await import("../src/server/index.js");
+      const documentedApp = await createSnaApp({ authToken: TEST_TOKEN, allowedOrigins: [ALLOWED_ORIGIN] });
+      const document = getDocument(documentedApp);
+
+      assert.deepEqual(document.components?.securitySchemes?.bearerAuth, {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "SNA auth token",
+      });
+      assert.deepEqual(document.security, [{ bearerAuth: [] }]);
+      assert.deepEqual(document.paths["/health"].get.security, []);
+      assert.deepEqual(document.paths["/agent/sessions"].get.security, [{ bearerAuth: [] }]);
+      assert.equal(document.paths["/agent/sessions"].get.responses["401"].description, "Authentication required.");
+      assert.equal(document.paths["/agent/sessions"].get.responses["403"].description, "Origin not allowed.");
+      assert.ok(document.paths["/agent/sessions"].get.responses["401"].content["application/json"].schema);
+    });
+
+    it("can generate the documented auth contract with runtime auth disabled for tooling", async () => {
+      const { createSnaApp } = await import("../src/server/index.js");
+      const docsApp = await createSnaApp({ unsafeDisableAuth: true });
+      const document = getDocument(docsApp);
+
+      assert.deepEqual(document.security, [{ bearerAuth: [] }]);
+      assert.deepEqual(document.paths["/agent/sessions"].get.security, [{ bearerAuth: [] }]);
+    });
+  });
+
   describe("Session CRUD", () => {
     it("POST /agent/sessions creates session", async () => {
       const res = await req("POST", "/agent/sessions", { label: "Test", cwd: "/tmp", meta: { app: "test" } });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -24,13 +24,13 @@ import { SnaProvider } from "@sna-sdk/react/components/sna-provider";
 </SnaProvider>
 ```
 
-`SnaProvider` is a pure context provider — no UI, no peer deps beyond React. In SDK-managed apps, pass `connection={sna.connection}` so the token stays paired with the server handle. It auto-discovers the server URL via `/api/sna-port` if no connection or `snaUrl` is provided; otherwise falls back to `http://localhost:3099`.
+`SnaProvider` is a pure context provider with no UI and no peer deps beyond React. In SDK-managed apps, pass `connection={sna.connection}` so the token stays paired with the server handle. It auto-discovers the server URL via the host app's `/api/sna-port` if no connection or `snaUrl` is provided; that route may return `{ baseUrl, authToken }` or `{ port, authToken }`. Otherwise it falls back to `http://localhost:3099`.
 
 | Prop | |
 |------|---|
 | `connection?` | Connection object returned by `startSnaServer` |
 | `snaUrl?` | Override the server URL |
-| `authToken?` | Token override for custom deployments |
+| `authToken?` | Token override for protected custom deployments |
 | `sessionId?` | Default session id (default `"default"`) |
 | `hydrate?` | Hydrate chat-store on mount (default `true`) |
 


### PR DESCRIPTION
## Summary

- Add the SNA bearer auth contract to generated OpenAPI documents.
- Mark protected HTTP routes with `bearerAuth` plus shared 401/403 error responses using the existing Zod `ErrorResponse` shape.
- Keep `/health` public in the OpenAPI contract.
- Regenerate localized OpenAPI JSON/docs and add SDK regression coverage for bearer tokens on HTTP SSE calls.
- Update API, SDK, launcher, React, embedding, cookbook, and package README docs with the new auth behavior.

## Why

SNA runtime auth was already enforced by the server and supported by the SDK client, but the OpenAPI spec and prose docs did not consistently document the required bearer token, auth failure responses, WebSocket token handling, or trusted discovery flow. That left docs and generated clients out of sync with runtime behavior.

## Validation

- `pnpm --filter docs docs:openapi`
- `pnpm --filter docs types:check`
- `pnpm --filter docs build`
- `node --import tsx --test src/sna-client.spec.ts`
- `pnpm --filter @sna-sdk/core build`
- `pnpm --filter @sna-sdk/core test`

Note: while validating the first commit, `better-sqlite3` initially had a stale native binary for the active Node ABI. Rebuilt it with `pnpm --filter @sna-sdk/core rebuild better-sqlite3`, then reran the core suite successfully.