### PR TITLE
fix: ignore Codex agentMessage start events

### DIFF
--- a/packages/core/src/core/providers/codex.ts
+++ b/packages/core/src/core/providers/codex.ts
@@ -1380,6 +1380,10 @@ class CodexProcess implements AgentProcess {
           timestamp: Date.now(),
         };
 
+      case "agent_message":
+      case "agentMessage":
+        return null;
+
       case "userMessage":
       case "user_message":
         return null; // echo of user input — skip

--- a/packages/core/test/acp-base.test.ts
+++ b/packages/core/test/acp-base.test.ts
@@ -65,6 +65,11 @@ rl.on("line", (line) => {
   }
 
   if (msg.method === "session/prompt") {
+    if (mode.includes("assistant-only")) {
+      notify({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hel" } });
+      notify({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "lo" } });
+    }
+
     if (mode.includes("updates")) {
       notify({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "plan" } });
       notify({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hel" } });
@@ -228,6 +233,27 @@ describe("ACP shared adapter base", () => {
     assert.ok(events.some((event) => event.type === "tool_use" && event.data?.toolName === "Read" && (event.data as any).fromUpdate === true));
     assert.ok(events.some((event) => event.type === "tool_result" && event.data?.status === "completed" && event.data?.rawOutput === "ok"));
     assert.ok(events.some((event) => event.type === "complete" && event.data?.stopReason === "end_turn"));
+  });
+
+  it("assistant-only ACP updates emit no tool lifecycle events", async () => {
+    const { proc } = await startProcess({ cwd: process.cwd() }, "assistant-only");
+    const events: AgentEvent[] = [];
+    proc.on("event", (event) => events.push(event));
+
+    proc.send("plain assistant reply");
+    await waitFor(() => events.some((event) => event.type === "complete"));
+
+    assert.deepEqual(
+      events.filter((event) => event.type === "assistant_delta").map((event) => event.delta),
+      ["Hel", "lo"],
+    );
+    assert.ok(events.some((event) => event.type === "assistant" && event.message === "Hello"));
+    assert.ok(events.some((event) => event.type === "complete"));
+    assert.deepEqual(
+      events.filter((event) => event.type === "tool_use" || event.type === "tool_use_delta" || event.type === "tool_result"),
+      [],
+      "assistant-only ACP turns must not surface fake tool events",
+    );
   });
 
   it("surfaces unknown ACP tool-like updates as generic tool events", async () => {

--- a/packages/core/test/claude-tool-input-delta.test.ts
+++ b/packages/core/test/claude-tool-input-delta.test.ts
@@ -52,6 +52,63 @@ function makeMockProc(): { proc: ChildProcess; pushLine: (line: string) => void;
 const SPAWN_OPTIONS: SpawnOptions = { cwd: "/tmp/test-cc-fixture" };
 
 describe("ClaudeCodeProcess — tool_use_delta forwarding", () => {
+  it("assistant-only stream-json transcript emits no tool lifecycle events", async () => {
+    const { proc, pushLine, close } = makeMockProc();
+    const cc = new ClaudeCodeProcess(proc, SPAWN_OPTIONS);
+
+    const events: AgentEvent[] = [];
+    cc.on("event", (e) => events.push(e));
+
+    pushLine(JSON.stringify({
+      type: "system",
+      subtype: "init",
+      session_id: "cc-assistant-only",
+      model: "claude-sonnet-4-6",
+    }));
+    pushLine(JSON.stringify({
+      type: "stream_event",
+      event: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+    }));
+    pushLine(JSON.stringify({
+      type: "stream_event",
+      event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" } },
+    }));
+    pushLine(JSON.stringify({
+      type: "stream_event",
+      event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: " world" } },
+    }));
+    pushLine(JSON.stringify({
+      type: "stream_event",
+      event: { type: "content_block_stop", index: 0 },
+    }));
+    pushLine(JSON.stringify({
+      type: "result",
+      subtype: "success",
+      result: "Hello world",
+      duration_ms: 42,
+      total_cost_usd: 0,
+      usage: { input_tokens: 3, output_tokens: 2 },
+    }));
+
+    await new Promise<void>((resolve) => {
+      cc.on("exit", () => resolve());
+      close();
+    });
+    await new Promise((r) => setTimeout(r, 250));
+
+    assert.deepEqual(
+      events.filter((e) => e.type === "assistant_delta").map((e) => e.delta),
+      ["Hello", " world"],
+    );
+    assert.ok(events.some((e) => e.type === "assistant" && e.message === "Hello world"));
+    assert.ok(events.some((e) => e.type === "complete"));
+    assert.deepEqual(
+      events.filter((e) => e.type === "tool_use" || e.type === "tool_use_delta" || e.type === "tool_result"),
+      [],
+      "assistant-only Claude Code turns must not surface fake tool events",
+    );
+  });
+
   it("emits tool_use_delta for each input_json_delta in the captured fixture", async () => {
     const { proc, pushLine, close } = makeMockProc();
     const cc = new ClaudeCodeProcess(proc, SPAWN_OPTIONS);

--- a/packages/core/test/codex-item-normalization.test.ts
+++ b/packages/core/test/codex-item-normalization.test.ts
@@ -47,6 +47,81 @@ describe("CodexProcess — item normalization", () => {
     delete process.env.CODEX_MOCK_TURN_NOTIFICATIONS;
   });
 
+  it("does not treat agentMessage starts as tool_use while preserving assistant deltas and completion", async () => {
+    process.env.CODEX_MOCK_TURN_NOTIFICATIONS = JSON.stringify([
+      {
+        jsonrpc: "2.0",
+        method: "item/started",
+        params: {
+          item: {
+            type: "agentMessage",
+            id: "msg_1",
+            status: "in_progress",
+          },
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "item/agentMessage/delta",
+        params: {
+          itemId: "msg_1",
+          delta: "Hello ",
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "item/agentMessage/delta",
+        params: {
+          itemId: "msg_1",
+          delta: "world",
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          item: {
+            type: "agentMessage",
+            id: "msg_1",
+            status: "completed",
+            text: "Hello world",
+          },
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "thread/status/changed",
+        params: { status: "idle" },
+      },
+    ]);
+
+    const provider = new CodexProvider();
+    const proc = provider.spawn({ cwd: process.cwd(), prompt: "say hello" });
+    const events: AgentEvent[] = [];
+    proc.on("event", (e) => events.push(e));
+
+    await waitFor(() => events.some((e) => e.type === "complete"));
+    proc.kill();
+
+    assert.equal(
+      events.some((e) => e.type === "tool_use" && (e.data as any)?.toolName === "agentMessage"),
+      false,
+      "agentMessage item/started must not surface as a fake tool_use",
+    );
+    assert.equal(
+      events.some((e) => e.type === "tool_result" && (e.data as any)?.toolName === "agentMessage"),
+      false,
+      "assistant messages should not require a matching tool_result",
+    );
+
+    const deltas = events.filter((e) => e.type === "assistant_delta").map((e) => e.delta).join("");
+    assert.equal(deltas, "Hello world");
+
+    const assistant = events.find((e) => e.type === "assistant");
+    assert.equal(assistant?.message, "Hello world");
+    assert.ok(events.some((e) => e.type === "complete"), "turn should still complete");
+  });
+
   it("forwards image_generation lifecycle as tool_use (start) + tool_result (savedPath + revisedPrompt + duration)", async () => {
     process.env.CODEX_MOCK_TURN_NOTIFICATIONS = JSON.stringify([
       {

--- a/packages/core/test/opencode-history-injection.test.ts
+++ b/packages/core/test/opencode-history-injection.test.ts
@@ -56,6 +56,11 @@ describe("OpenCodeProvider end-to-end via mock server", () => {
     assert.ok(types.includes("assistant_delta"), "assistant_delta should fire");
     assert.ok(types.includes("assistant"), "final assistant should fire");
     assert.ok(types.includes("complete"), "complete should fire");
+    assert.deepEqual(
+      events.filter((e) => e.type === "tool_use" || e.type === "tool_use_delta" || e.type === "tool_result"),
+      [],
+      "assistant-only OpenCode turns must not surface fake tool events",
+    );
 
     // Init carries the OpenCode session id.
     const init = events.find((e) => e.type === "init")!;


### PR DESCRIPTION
## Summary
- prevent Codex `item/started` events with `item.type = agentMessage` from surfacing as fake `tool_use` events
- add a Codex regression transcript covering `item/started` → `item/agentMessage/delta` → `item/completed` → `turn/completed`
- extend assistant-only no-tool invariants across Claude Code, OpenCode, and ACP shared adapter coverage (Grok/Cursor path)

## Validation
- targeted provider tests: `pnpm --filter @sna-sdk/core exec node --import tsx --test test/acp-base.test.ts test/claude-tool-input-delta.test.ts test/opencode-history-injection.test.ts test/codex-item-normalization.test.ts`
- `pnpm --filter @sna-sdk/core build`
- `pnpm --filter @sna-sdk/core test` (388 pass)
- `git diff --check`