### PR TITLE
Fix Codex content lifecycle events and provider event contract

### DIFF
--- a/packages/core/src/core/providers/codex.ts
+++ b/packages/core/src/core/providers/codex.ts
@@ -1382,6 +1382,7 @@ class CodexProcess implements AgentProcess {
 
       case "agent_message":
       case "agentMessage":
+      case "reasoning":
         return null;
 
       case "userMessage":

--- a/packages/core/src/core/providers/codex.ts
+++ b/packages/core/src/core/providers/codex.ts
@@ -124,6 +124,60 @@ function codexConfigValue(value: unknown): string | null {
   return JSON.stringify(value);
 }
 
+type CodexItemKind =
+  | "assistant_text"
+  | "thinking"
+  | "user_echo"
+  | "command_execution"
+  | "file_change"
+  | "mcp_tool_call"
+  | "web_search"
+  | "image_generation"
+  | "todo_list"
+  | "error"
+  | "unknown";
+
+/**
+ * Codex `item.type` names are provider-native lifecycle labels. Classify them
+ * once into SNA's semantic categories so start/completed normalization cannot
+ * drift: content items are never tools, tool items get tool_use/tool_result,
+ * and genuinely unknown items keep the explicit fail-open behavior.
+ */
+function classifyCodexItemType(type: unknown): CodexItemKind {
+  switch (type) {
+    case "agent_message":
+    case "agentMessage":
+      return "assistant_text";
+    case "reasoning":
+      return "thinking";
+    case "user_message":
+    case "userMessage":
+      return "user_echo";
+    case "command_execution":
+    case "commandExecution":
+      return "command_execution";
+    case "file_change":
+    case "fileChange":
+      return "file_change";
+    case "mcp_tool_call":
+    case "mcpToolCall":
+      return "mcp_tool_call";
+    case "web_search":
+    case "webSearch":
+      return "web_search";
+    case "image_generation":
+    case "imageGeneration":
+      return "image_generation";
+    case "todo_list":
+    case "todoList":
+      return "todo_list";
+    case "error":
+      return "error";
+    default:
+      return "unknown";
+  }
+}
+
 /** @internal Exported for tests. Builds top-level Codex CLI args shared by app-server and exec. */
 export function buildCodexGlobalArgs(providerOptions?: Record<string, unknown>): string[] {
   const args: string[] = [];
@@ -1313,9 +1367,8 @@ class CodexProcess implements AgentProcess {
     // (rare) just don't get duration tracking.
     if (item.id) this._itemStartedAt.set(item.id, Date.now());
 
-    switch (item.type) {
+    switch (classifyCodexItemType(item.type)) {
       case "command_execution":
-      case "commandExecution":
         return {
           type: "tool_use",
           message: "shell",
@@ -1329,7 +1382,6 @@ class CodexProcess implements AgentProcess {
         };
 
       case "file_change":
-      case "fileChange":
         return {
           type: "tool_use",
           message: "file_change",
@@ -1343,7 +1395,6 @@ class CodexProcess implements AgentProcess {
         };
 
       case "mcp_tool_call":
-      case "mcpToolCall":
         return {
           type: "tool_use",
           message: `${item.server}:${item.tool}`,
@@ -1357,7 +1408,6 @@ class CodexProcess implements AgentProcess {
         };
 
       case "web_search":
-      case "webSearch":
         return {
           type: "tool_use",
           message: "web_search",
@@ -1366,7 +1416,6 @@ class CodexProcess implements AgentProcess {
         };
 
       case "image_generation":
-      case "imageGeneration":
         // OpenAI's hosted image_generation tool — `revised_prompt` and
         // `result` are empty at start; they get populated in item/completed.
         return {
@@ -1380,16 +1429,18 @@ class CodexProcess implements AgentProcess {
           timestamp: Date.now(),
         };
 
-      case "agent_message":
-      case "agentMessage":
-      case "reasoning":
+      case "assistant_text":
+      case "thinking":
         return null;
 
-      case "userMessage":
-      case "user_message":
+      case "user_echo":
         return null; // echo of user input — skip
 
-      default:
+      case "todo_list":
+        return null; // internal tracking
+
+      case "error":
+      case "unknown":
         // Fail-open: forward any item.type SNA doesn't have a specific
         // shape for as a generic tool_use. Without this, new Codex tool
         // types ship to consumers as silent invisibility — they happen
@@ -1417,16 +1468,15 @@ class CodexProcess implements AgentProcess {
     if (item.id) this._itemStartedAt.delete(item.id);
     const durationMs = startedAt !== undefined ? Date.now() - startedAt : undefined;
 
-    switch (item.type) {
-      case "agent_message":
-      case "agentMessage":
+    switch (classifyCodexItemType(item.type)) {
+      case "assistant_text":
         return {
           type: "assistant",
           message: item.text ?? "",
           timestamp: Date.now(),
         };
 
-      case "reasoning":
+      case "thinking":
         return {
           type: "thinking",
           message: item.text ?? "",
@@ -1434,7 +1484,6 @@ class CodexProcess implements AgentProcess {
         };
 
       case "command_execution":
-      case "commandExecution":
         return {
           type: "tool_result",
           message: item.aggregated_output ?? item.aggregatedOutput ?? "",
@@ -1450,7 +1499,6 @@ class CodexProcess implements AgentProcess {
         };
 
       case "file_change":
-      case "fileChange":
         return {
           type: "tool_result",
           message: `File changes ${item.status}`,
@@ -1466,7 +1514,6 @@ class CodexProcess implements AgentProcess {
         };
 
       case "mcp_tool_call":
-      case "mcpToolCall":
         return {
           type: "tool_result",
           message: item.result
@@ -1482,7 +1529,6 @@ class CodexProcess implements AgentProcess {
         };
 
       case "web_search":
-      case "webSearch":
         return {
           type: "tool_result",
           message: "Web search completed",
@@ -1491,7 +1537,6 @@ class CodexProcess implements AgentProcess {
         };
 
       case "image_generation":
-      case "imageGeneration":
         // saved_path is set by codex daemon after writing the PNG;
         // see codex-rs/core/src/stream_events_utils.rs:save_image_generation_result.
         return {
@@ -1509,8 +1554,10 @@ class CodexProcess implements AgentProcess {
           timestamp: Date.now(),
         };
 
+      case "user_echo":
+        return null;
+
       case "todo_list":
-      case "todoList":
         return null; // internal tracking
 
       case "error":
@@ -1520,7 +1567,7 @@ class CodexProcess implements AgentProcess {
           timestamp: Date.now(),
         };
 
-      default:
+      case "unknown":
         // Fail-open: forward any item.type SNA doesn't have a specific
         // shape for. Without this, new Codex tool types ship to consumers
         // as silent invisibility — the model invoked something but the

--- a/packages/core/src/core/providers/schemas.ts
+++ b/packages/core/src/core/providers/schemas.ts
@@ -30,6 +30,7 @@ export const AgentEventSchema = z.object({
     "assistant_delta",
     "assistant",
     "tool_use",
+    "tool_use_delta",
     "tool_result",
     "permission_needed",
     "milestone",

--- a/packages/core/src/core/providers/types.ts
+++ b/packages/core/src/core/providers/types.ts
@@ -3,6 +3,15 @@
  *
  * Providers translate their native event format (Claude Code stream-json,
  * Codex JSONL, etc.) into these common types.
+ *
+ * Adapter contract:
+ * - Assistant text is `assistant_delta` while streaming and `assistant` when
+ *   the block is final.
+ * - Reasoning/thinking is `thinking_delta` while streaming and `thinking` when
+ *   the block is final.
+ * - Native lifecycle "start" events for assistant text or thinking are not
+ *   user-visible events; they must never be surfaced as `tool_use`.
+ * - Only actual runtime tool invocations become `tool_use` / `tool_result`.
  */
 export interface AgentEvent {
   type:

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -186,6 +186,28 @@ function migrateDropSkillName(db: Database.Database) {
   }
 }
 
+/**
+ * Remove rows created by an older Codex item-start fail-open bug.
+ *
+ * Codex content items (`agentMessage`, `reasoning`) emit lifecycle starts just
+ * like tools do, but they are not tools. Before the explicit non-tool cases
+ * existed, those starts were persisted as assistant/tool_use rows and then
+ * replayed as fake function calls on resume/provider-switch.
+ */
+function migrateFakeCodexContentToolUses(db: Database.Database) {
+  const cols = db.prepare("PRAGMA table_info(chat_messages)").all() as { name: string }[];
+  if (cols.length === 0) return;
+  const names = new Set(cols.map((c) => c.name));
+  if (!names.has("actor") || !names.has("kind") || !names.has("meta")) return;
+
+  db.exec(`
+    DELETE FROM chat_messages
+    WHERE actor = 'assistant'
+      AND kind = 'tool_use'
+      AND json_extract(meta, '$.raw.type') IN ('agentMessage', 'agent_message', 'reasoning')
+  `);
+}
+
 function extToMime(ext: string): string {
   switch (ext.toLowerCase()) {
     case "png": return "image/png";
@@ -341,6 +363,8 @@ function initSchema(db: Database.Database) {
     CREATE INDEX IF NOT EXISTS idx_runtime_sessions_alive ON runtime_sessions(sna_session_id)
       WHERE retired_at IS NULL;
   `);
+
+  migrateFakeCodexContentToolUses(db);
 
   // Backfill must run after chat_sessions / runtime_sessions exist.
   migrateRuntimeSessions(db);

--- a/packages/core/test/codex-fake-content-tooluse-migration.test.ts
+++ b/packages/core/test/codex-fake-content-tooluse-migration.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getDb, resetDb } from "../src/db/schema.js";
+import { buildCanonicalFromDb } from "../src/history/canonical.js";
+import { canonicalToCodexResponseItems } from "../src/history/codex.js";
+
+describe("DB migration — fake Codex content tool_use cleanup", () => {
+  const origDbPath = process.env.SNA_DB_PATH;
+  let tmpDir: string | null = null;
+
+  afterEach(() => {
+    try { getDb().close(); } catch {}
+    resetDb();
+    if (origDbPath === undefined) delete process.env.SNA_DB_PATH;
+    else process.env.SNA_DB_PATH = origDbPath;
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = null;
+  });
+
+  it("removes previously persisted agentMessage/reasoning fake tool rows before canonical replay", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sna-codex-fake-tool-"));
+    process.env.SNA_DB_PATH = path.join(tmpDir, "sna.db");
+    resetDb();
+
+    const db = getDb();
+    db.prepare("INSERT INTO chat_sessions (id, label) VALUES (?, ?)").run("s1", "Test");
+    db.prepare(
+      "INSERT INTO chat_messages (session_id, actor, kind, content, meta) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "user", "text", "hello", null);
+    db.prepare(
+      "INSERT INTO chat_messages (session_id, actor, kind, content, meta) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "assistant", "tool_use", "agentMessage", JSON.stringify({
+      toolName: "agentMessage",
+      id: "msg_1",
+      raw: { type: "agentMessage", id: "msg_1" },
+    }));
+    db.prepare(
+      "INSERT INTO chat_messages (session_id, actor, kind, content, meta) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "assistant", "tool_use", "reasoning", JSON.stringify({
+      toolName: "reasoning",
+      id: "rs_1",
+      raw: { type: "reasoning", id: "rs_1" },
+    }));
+    db.prepare(
+      "INSERT INTO chat_messages (session_id, actor, kind, content, meta) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "assistant", "thinking", "real thinking", null);
+    db.prepare(
+      "INSERT INTO chat_messages (session_id, actor, kind, content, meta) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "assistant", "text", "real answer", null);
+    db.prepare(
+      "INSERT INTO chat_messages (session_id, actor, kind, content, meta) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "assistant", "tool_use", "future_widget", JSON.stringify({
+      toolName: "future_widget",
+      id: "fw_1",
+      raw: { type: "future_widget", id: "fw_1" },
+    }));
+    db.close();
+    resetDb();
+
+    const reopened = getDb();
+    const toolRows = reopened.prepare(
+      "SELECT content FROM chat_messages WHERE session_id = ? AND actor = 'assistant' AND kind = 'tool_use' ORDER BY id",
+    ).all("s1") as Array<{ content: string }>;
+    assert.deepEqual(toolRows.map((row) => row.content), ["future_widget"]);
+
+    const canonical = buildCanonicalFromDb("s1");
+    assert.deepEqual(
+      canonical
+        .filter((block) => block.actor === "assistant" && block.kind === "tool_use")
+        .map((block) => block.content),
+      ["future_widget"],
+    );
+
+    const codexItems = canonicalToCodexResponseItems(canonical, "s1");
+    assert.equal(
+      codexItems.some((item) => item.type === "function_call" && item.name === "reasoning"),
+      false,
+      "fake reasoning tool_use must not become a Codex function_call on resume",
+    );
+    assert.equal(
+      codexItems.some((item) => item.type === "function_call" && item.name === "agentMessage"),
+      false,
+      "fake agentMessage tool_use must not become a Codex function_call on resume",
+    );
+  });
+});

--- a/packages/core/test/codex-item-normalization.test.ts
+++ b/packages/core/test/codex-item-normalization.test.ts
@@ -122,6 +122,70 @@ describe("CodexProcess — item normalization", () => {
     assert.ok(events.some((e) => e.type === "complete"), "turn should still complete");
   });
 
+  it("does not treat reasoning starts as tool_use while preserving thinking deltas and completion", async () => {
+    process.env.CODEX_MOCK_TURN_NOTIFICATIONS = JSON.stringify([
+      {
+        jsonrpc: "2.0",
+        method: "item/started",
+        params: {
+          item: {
+            type: "reasoning",
+            id: "rs_1",
+            status: "in_progress",
+          },
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "item/reasoning/summaryTextDelta",
+        params: {
+          itemId: "rs_1",
+          delta: "Let me think",
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          item: {
+            type: "reasoning",
+            id: "rs_1",
+            status: "completed",
+            text: "Let me think",
+          },
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "thread/status/changed",
+        params: { status: "idle" },
+      },
+    ]);
+
+    const provider = new CodexProvider();
+    const proc = provider.spawn({ cwd: process.cwd(), prompt: "think" });
+    const events: AgentEvent[] = [];
+    proc.on("event", (e) => events.push(e));
+
+    await waitFor(() => events.some((e) => e.type === "complete"));
+    proc.kill();
+
+    assert.equal(
+      events.some((e) => e.type === "tool_use" && (e.data as any)?.toolName === "reasoning"),
+      false,
+      "reasoning item/started must not surface as a fake tool_use",
+    );
+    assert.equal(
+      events.some((e) => e.type === "tool_result" && (e.data as any)?.toolName === "reasoning"),
+      false,
+      "reasoning messages should not require a matching tool_result",
+    );
+
+    assert.equal(events.find((e) => e.type === "thinking_delta")?.message, "Let me think");
+    assert.equal(events.find((e) => e.type === "thinking")?.message, "Let me think");
+    assert.ok(events.some((e) => e.type === "complete"), "turn should still complete");
+  });
+
   it("forwards image_generation lifecycle as tool_use (start) + tool_result (savedPath + revisedPrompt + duration)", async () => {
     process.env.CODEX_MOCK_TURN_NOTIFICATIONS = JSON.stringify([
       {

--- a/packages/core/test/provider-event-schema.test.ts
+++ b/packages/core/test/provider-event-schema.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { AgentEventSchema } from "../src/core/providers/schemas.js";
+
+describe("AgentEvent provider contract schema", () => {
+  it("accepts every streamed assistant/tool event shape from AgentEvent", () => {
+    const events = [
+      { type: "assistant_delta", delta: "hello", index: 0, timestamp: Date.now() },
+      { type: "thinking_delta", message: "reasoning", timestamp: Date.now() },
+      {
+        type: "tool_use_delta",
+        delta: "{\"path\"",
+        index: 0,
+        data: { id: "toolu_1" },
+        timestamp: Date.now(),
+      },
+    ];
+
+    for (const event of events) {
+      const parsed = AgentEventSchema.safeParse(event);
+      assert.equal(parsed.success, true, `${event.type} must be part of the provider event contract`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent Codex `agentMessage` and `reasoning` item start notifications from surfacing as fake `tool_use` events
- Classify Codex native item types into semantic SNA categories before start/completed normalization
- Add a DB cleanup migration for previously persisted fake Codex content tool rows
- Tighten the provider event contract/schema, including `tool_use_delta`

## Tests
- `pnpm --filter @sna-sdk/core build && pnpm --filter @sna-sdk/core test`
- 391 tests passed, 0 failed